### PR TITLE
m_cap: send multiline cap lists to everyone

### DIFF
--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -198,11 +198,6 @@ clicap_generate(struct Client *source_p, const char *subcmd, int flags)
 					data != NULL ? data : "") < 0
 					&& buf_list[0] != '\0') {
 
-				if (!(source_p->flags & FLAGS_CLICAP_DATA)) {
-					/* the client doesn't support multiple lines */
-					break;
-				}
-
 				/* doesn't fit in the buffer, output what we have */
 				sendto_one(source_p, "%s%s%s", buf_prefix, str_cont, buf_list);
 


### PR DESCRIPTION
IRCv3 doesn't spec this for non-302 CAP LS, but as far as I can tell this is just a mistake. The original cap implementation always did it.