### PR TITLE
Add /testkline

### DIFF
--- a/help/opers/index
+++ b/help/opers/index
@@ -16,9 +16,9 @@ PONG            POST            PRIVMSG         PRIVS
 QUIT            REHASH          RESTART         RESV
 SCAN            SERVER          SET             SJOIN
 SNOMASK         SQUIT           STATS           SVINFO
-TESTGECOS       TESTLINE        TESTMASK        TIME
-TOPIC           TRACE           UHELP           UMODE
-UNDLINE         UNKLINE         UNREJECT        UNRESV
-UNXLINE         USER            USERHOST        USERS
-VERSION         WALLOPS         WHO             WHOIS
-WHOWAS          XLINE
+TESTGECOS       TESTKLINE       TESTLINE        TESTMASK
+TIME            TOPIC           TRACE           UHELP
+UMODE           UNDLINE         UNKLINE         UNREJECT
+UNRESV          UNXLINE         USER            USERHOST
+USERS           VERSION         WALLOPS         WHO
+WHOIS           WHOWAS          XLINE

--- a/help/opers/testkline
+++ b/help/opers/testkline
@@ -1,0 +1,7 @@
+TESTKLINE [user@]host
+
+Looks up given mask, looking for any matching K/D-lines.
+If username is not specified, it will look up "dummy@host".
+
+This command will not perform dns lookups on a host; for best
+results you must testkline a host and its IP form.

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -42,18 +42,23 @@
 static const char testline_desc[] = "Provides the ability to test I/K/D/X lines and RESVs";
 
 static void mo_testline(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
+static void mo_testkline(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 static void mo_testgecos(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 
 struct Message testline_msgtab = {
 	"TESTLINE", 0, 0, 0, 0,
 	{mg_unreg, mg_not_oper, mg_ignore, mg_ignore, mg_ignore, {mo_testline, 2}}
 };
+struct Message testkline_msgtab = {
+	"TESTKLINE", 0, 0, 0, 0,
+	{mg_unreg, mg_not_oper, mg_ignore, mg_ignore, mg_ignore, {mo_testkline, 2}}
+};
 struct Message testgecos_msgtab = {
 	"TESTGECOS", 0, 0, 0, 0,
 	{mg_unreg, mg_not_oper, mg_ignore, mg_ignore, mg_ignore, {mo_testgecos, 2}}
 };
 
-mapi_clist_av1 testline_clist[] = { &testline_msgtab, &testgecos_msgtab, NULL };
+mapi_clist_av1 testline_clist[] = { &testline_msgtab, &testkline_msgtab, &testgecos_msgtab, NULL };
 
 DECLARE_MODULE_AV2(testline, NULL, NULL, testline_clist, NULL, NULL, NULL, NULL, testline_desc);
 
@@ -229,6 +234,126 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 	}
 
 	/* nothing matches.. */
+	sendto_one(source_p, form_str(RPL_NOTESTLINE),
+			me.name, source_p->name, parv[1]);
+}
+
+
+static void
+mo_testkline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	struct ConfItem *aconf;
+	struct rb_sockaddr_storage ip;
+	char user_trunc[USERLEN + 1];
+	const char *username = NULL;
+	const char *host = NULL;
+	char *mask;
+	char *p;
+	int host_mask;
+	int type;
+	int duration;
+	char *puser, *phost, *reason, *operreason;
+	char reasonbuf[BUFSIZE];
+
+	if (!HasPrivilege(source_p, "oper:testline"))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			   me.name, source_p->name, "testline");
+		return;
+	}
+
+	mask = LOCAL_COPY(parv[1]);
+
+	if ((p = strchr(mask, '!')))
+	{
+		mask = p + 1;
+
+		if(EmptyString(mask))
+			return;
+	}
+
+	if ((p = strchr(mask, '@')))
+	{
+		*p++ = '\0';
+		username = mask;
+		host = p;
+
+		if(EmptyString(host))
+			return;
+	}
+	else
+	{
+		host = mask;
+	}
+
+	/* parses as an IP, check for a dline */
+	if ((type = parse_netmask(host, &ip, &host_mask)) != HM_HOST)
+	{
+		if(type == HM_IPV6)
+			aconf = find_dline((struct sockaddr *)&ip, AF_INET6);
+		else
+			aconf = find_dline((struct sockaddr *)&ip, AF_INET);
+
+		if(aconf && aconf->status & CONF_DLINE)
+		{
+			get_printable_kline(source_p, aconf, &phost, &reason, &puser, &operreason);
+			snprintf(reasonbuf, sizeof(reasonbuf), "%s%s%s", reason,
+				operreason ? "|" : "", operreason ? operreason : "");
+			sendto_one(source_p, form_str(RPL_TESTLINE),
+				me.name, source_p->name,
+				(aconf->flags & CONF_FLAGS_TEMPORARY) ? 'd' : 'D',
+				(aconf->flags & CONF_FLAGS_TEMPORARY) ?
+				 (long) ((aconf->hold - rb_current_time()) / 60) : 0L,
+				phost, reasonbuf);
+
+			return;
+		}
+		/* Otherwise, aconf is an exempt{} */
+		if (aconf == NULL && (duration = is_reject_ip((struct sockaddr *)&ip)))
+			sendto_one(source_p, form_str(RPL_TESTLINE),
+					me.name, source_p->name,
+					'!',
+					duration / 60L,
+					host, "Reject cache");
+		if (aconf == NULL && (duration = is_throttle_ip((struct sockaddr *)&ip)))
+			sendto_one(source_p, form_str(RPL_TESTLINE),
+					me.name, source_p->name,
+					'!',
+					duration / 60L,
+					host, "Throttled");
+	}
+
+	if (username != NULL)
+		rb_strlcpy(user_trunc, username, sizeof user_trunc);
+	else
+		rb_strlcpy(user_trunc, "dummy", sizeof user_trunc);
+
+	aconf = find_conf_by_address(host,
+		type != HM_HOST ? host : NULL,
+		NULL,
+		type != HM_HOST ? (struct sockaddr *)&ip : NULL,
+		CONF_KILL,
+		type == HM_IPV6 ? AF_INET6 : AF_INET,
+		user_trunc, NULL);
+
+	if (aconf != NULL && aconf->status & CONF_KILL)
+	{
+		static char buf[HOSTLEN+USERLEN+2];
+
+		get_printable_kline(source_p, aconf, &phost, &reason, &puser, &operreason);
+		snprintf(buf, sizeof(buf), "%s@%s",
+				puser, phost);
+		snprintf(reasonbuf, sizeof(reasonbuf), "%s%s%s", reason,
+			operreason ? "|" : "", operreason ? operreason : "");
+		sendto_one(source_p, form_str(RPL_TESTLINE),
+			me.name, source_p->name,
+			(aconf->flags & CONF_FLAGS_TEMPORARY) ? 'k' : 'K',
+			(aconf->flags & CONF_FLAGS_TEMPORARY) ?
+			 (long) ((aconf->hold - rb_current_time()) / 60) : 0L,
+			buf, reasonbuf);
+		return;
+	}
+
 	sendto_one(source_p, form_str(RPL_NOTESTLINE),
 			me.name, source_p->name, parv[1]);
 }

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -117,7 +117,10 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		mask = p;
 
 		if(EmptyString(mask))
+		{
+			sendto_one_notice(source_p, "Invalid syntax for TESTLINE");
 			return;
+		}
 	}
 
 	if((p = strchr(mask, '@')))
@@ -127,7 +130,10 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		host = p;
 
 		if(EmptyString(host))
+		{
+			sendto_one_notice(source_p, "Invalid syntax for TESTLINE");
 			return;
+		}
 	}
 	else
 		host = mask;
@@ -269,7 +275,10 @@ mo_testkline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *so
 		mask = p + 1;
 
 		if(EmptyString(mask))
+		{
+			sendto_one_notice(source_p, "Invalid syntax for TESTKLINE");
 			return;
+		}
 	}
 
 	if ((p = strchr(mask, '@')))
@@ -279,7 +288,10 @@ mo_testkline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *so
 		host = p;
 
 		if(EmptyString(host))
+		{
+			sendto_one_notice(source_p, "Invalid syntax for TESTKLINE");
 			return;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Like /testline, but doesn't report on I-lines or resvs or care if the former are missing.