### PR TITLE
helpops: change umode char to h

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -63,7 +63,7 @@
  * Server bans (+b $s:mask)                          -- extb_server
  * SSL bans (+b $z)                                  -- extb_ssl
  * User mode bans (+b $u:modes)                      -- extb_usermode
- * Helpops system (umode +H)                         -- helpops
+ * Helpops system (umode +h)                         -- helpops
  * HURT system                                       -- hurt
  * New host mangling (umode +x)                      -- ip_cloaking_4.0
  * Old host mangling (umode +h)                      -- ip_cloaking
@@ -472,7 +472,7 @@ privset "local_op" {
 	 * oper:override:        enables oper override via umode +p (from extensions/override)
 	 * oper:receive_immunity:
 	 *   confers the benefits of chmode +M (operpeace) (from extensions/chm_operpeace)
-	 * usermode:helpops      allows setting +H (from extensions/helpops)
+	 * usermode:helpops      allows setting +h (from extensions/helpops)
 	 */
 	privs = oper:general, oper:privs, oper:testline, oper:kill, oper:operwall, usermode:servnotice,
 		auspex:oper, auspex:hostname, auspex:umodes, auspex:cmodes;

--- a/extensions/helpops.c
+++ b/extensions/helpops.c
@@ -39,7 +39,7 @@ mapi_hfn_list_av1 helpops_hfnlist[] = {
 	{ NULL, NULL }
 };
 
-#define UMODECHAR_HELPOPS 'H'
+#define UMODECHAR_HELPOPS 'h'
 
 struct Message dehelper_msgtab = {
 	"DEHELPER", 0, 0, 0, 0,
@@ -91,6 +91,7 @@ static void
 do_dehelper(struct Client *source_p, struct Client *target_p)
 {
 	const char *fakeparv[4];
+	static const char minus_helpops[3] = {'-', UMODECHAR_HELPOPS, '\0'};
 
 	if(!(target_p->umodes & user_modes[UMODECHAR_HELPOPS]))
 		return;
@@ -100,7 +101,7 @@ do_dehelper(struct Client *source_p, struct Client *target_p)
 	sendto_one_notice(target_p, ":*** %s is using DEHELPER on you", source_p->name);
 
 	fakeparv[0] = fakeparv[1] = target_p->name;
-	fakeparv[2] = "-H";
+	fakeparv[2] = minus_helpops;
 	fakeparv[3] = NULL;
 	user_mode(target_p, target_p, 3, fakeparv);
 }
@@ -219,7 +220,7 @@ h_hdl_umode_changed(hook_data_umode_changed *hdata)
 {
 	struct Client *source_p = hdata->client;
 
-	/* didn't change +H umode, we don't need to do anything */
+	/* didn't change +h umode, we don't need to do anything */
 	bool changed = (hdata->oldumodes ^ source_p->umodes) & user_modes[UMODECHAR_HELPOPS];
 
 	if (source_p->umodes & user_modes[UMODECHAR_HELPOPS])
@@ -228,7 +229,7 @@ h_hdl_umode_changed(hook_data_umode_changed *hdata)
 		{
 			source_p->umodes &= ~user_modes[UMODECHAR_HELPOPS];
 			sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "usermode:helpops");
-			/* they didn't ask for +H so we must be removing it */
+			/* they didn't ask for +h so we must be removing it */
 			if (!changed)
 				helper_delete(source_p);
 			return;


### PR DESCRIPTION
So it's incompatible with IP cloaking modules that use +h. We can choose between them. Or maybe just throw the IP cloaking modules out...