### PR TITLE
m_message: global snote when massnotice is used

### DIFF
--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -957,6 +957,14 @@ handle_special(enum message_type msgtype, struct Client *client_p,
 			return;
 		}
 
+		if(MyClient(source_p))
+		{
+			sendto_realops_snomask(SNO_GENERAL, L_ALL | L_NETWIDE, "%s sent mass-%s to %s: %s",
+					get_oper_name(source_p),
+					msgtype == MESSAGE_TYPE_PRIVMSG ? "privmsg" : "notice",
+					nick, text);
+		}
+
 		sendto_match_butone(IsServer(client_p) ? client_p : NULL, source_p,
 				    nick + 1,
 				    (*nick == '#') ? MATCH_HOST : MATCH_SERVER,


### PR DESCRIPTION
We're doing this as a globally propagated snote from the source server rather than something local because overriding message propagation is more complicated than just using snote propagation as-is.