### PR TITLE
Combine stats A output parameters

### DIFF
--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -288,7 +288,7 @@ stats_dns_servers (struct Client *source_p)
 
 	RB_DLINK_FOREACH(n, nameservers.head)
 	{
-		sendto_one_numeric(source_p, RPL_STATSDEBUG, "A %s", (char *)n->data);
+		sendto_one_numeric(source_p, RPL_STATSDEBUG, "A :%s", (char *)n->data);
 	}
 }
 


### PR DESCRIPTION
Every other use of RPL_STATSDEBUG follows the format: `<letter> :<text>`

This case appeared to slip through because it's two-word argument is encoded
in a single `->data` buffer.