### PR TITLE
Fix a corner case of superset matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ ircd/version.c.last
 ssld/ssld
 wsockd/wsockd
 tests/core
+tests/hostmask1
+tests/match1
 tests/msgbuf_parse1
 tests/msgbuf_unparse1
 tests/rb_dictionary1

--- a/ircd/match.c
+++ b/ircd/match.c
@@ -144,12 +144,16 @@ int mask_match(const char *mask_, const char *name)
 	static char mask[BUFSIZE];
 	const char *m = mask, *n = name;
 	const char *m_tmp = mask, *n_tmp = name;
+	size_t len;
 	int star_p;
 
 	s_assert(mask_ != NULL);
 	s_assert(name != NULL);
 
-	rb_strlcpy(mask, mask_, sizeof mask);
+	len = rb_strlcpy(mask, mask_, sizeof mask);
+	s_assert(len < sizeof mask);
+	(void) len; /* for NDEBUG */
+
 	match_arrange_stars(mask);
 
 	for (;;)

--- a/ircd/match.c
+++ b/ircd/match.c
@@ -104,6 +104,7 @@ int match(const char *mask, const char *name)
 	}
 }
 
+/* Reorder runs of [?*] in mask to the form  ``**...??...'' */
 void
 match_arrange_stars(char *mask)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,5 @@
 check_PROGRAMS = runtests \
+	match1 \
 	msgbuf_parse1 \
 	msgbuf_unparse1 \
 	hostmask1 \
@@ -23,6 +24,7 @@ check_LIBRARIES = tap/libtap.a
 tap_libtap_a_SOURCES = tap/basic.c tap/basic.h \
 	tap/float.c tap/float.h tap/macros.h
 
+match1_SOURCES = match1.c
 msgbuf_parse1_SOURCES = msgbuf_parse1.c
 msgbuf_unparse1_SOURCES = msgbuf_unparse1.c
 hostmask1_SOURCES = hostmask1.c

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -1,3 +1,4 @@
+match1
 msgbuf_parse1
 msgbuf_unparse1
 hostmask1

--- a/tests/match1.c
+++ b/tests/match1.c
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2020 Ed Kellett
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "tap/basic.h"
+
+#include "stdinc.h"
+#include "client.h"
+#include "match.h"
+
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+
+struct Client me;
+
+static void test_match(void)
+{
+	is_int(0, match("*foo*", "bar"), MSG);
+	is_int(1, match("*foo*", "foo"), MSG);
+
+	is_int(1, match("*foo*", "xfofoo"), MSG);
+}
+
+static void test_mask_match(void)
+{
+	is_int(0, mask_match("*foo*", "bar"), MSG);
+	is_int(1, mask_match("*foo*", "foo"), MSG);
+
+	is_int(1, mask_match("*foo*", "xfofoo"), MSG);
+
+	is_int(1, mask_match("*", "*foo*"), MSG);
+	is_int(0, mask_match("*foo*", "*"), MSG);
+	is_int(1, mask_match("*", "*"), MSG);
+	is_int(0, mask_match("?", "*"), MSG);
+	is_int(1, mask_match("*?", "*?"), MSG);
+	is_int(1, mask_match("?*", "*?"), MSG);
+	is_int(1, mask_match("*?*?*?*", "*?????*"), MSG);
+	is_int(0, mask_match("*??*??*??*", "*?????*"), MSG);
+
+	is_int(1, mask_match("?*", "*a"), MSG);
+	is_int(1, mask_match("???*", "*a*a*a"), MSG);
+	is_int(0, mask_match("???*", "*a*a*"), MSG);
+
+	is_int(0, mask_match("??", "a"), MSG);
+	is_int(1, mask_match("??", "aa"), MSG);
+	is_int(0, mask_match("??", "aaa"), MSG);
+}
+
+int main(int argc, char *argv[])
+{
+	plan_lazy();
+
+	test_match();
+	test_mask_match();
+
+	return 0;
+}

--- a/tests/match1.c
+++ b/tests/match1.c
@@ -30,6 +30,8 @@
 
 struct Client me;
 
+void match_arrange_stars(char *);
+
 static void test_match(void)
 {
 	is_int(0, match("*foo*", "bar"), MSG);
@@ -40,6 +42,7 @@ static void test_match(void)
 
 static void test_mask_match(void)
 {
+
 	is_int(0, mask_match("*foo*", "bar"), MSG);
 	is_int(1, mask_match("*foo*", "foo"), MSG);
 
@@ -63,12 +66,32 @@ static void test_mask_match(void)
 	is_int(0, mask_match("??", "aaa"), MSG);
 }
 
+static void test_arrange_stars(void)
+{
+	{
+		char rearrange[] = "quick brown fox";
+		match_arrange_stars(rearrange);
+		is_string("quick brown fox", rearrange, MSG);
+	}
+	{
+		char rearrange[] = "?*?*?*";
+		match_arrange_stars(rearrange);
+		is_string("***???", rearrange, MSG);
+	}
+	{
+		char rearrange[] = "?*? *?*";
+		match_arrange_stars(rearrange);
+		is_string("*?? **?", rearrange, MSG);
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	plan_lazy();
 
 	test_match();
 	test_mask_match();
+	test_arrange_stars();
 
 	return 0;
 }


### PR DESCRIPTION
The algorithm we're using gets stuck if it has a ? and can only see a * to feed to it, even if it could skip over that * and consume a character following it. Remedy this by rearranging the input so * always precedes ? in runs of wildcards, so when we're matching ? we know we can skip things.