### PR TITLE
Actually run tests with assertions enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ cache:
 
 script:
   - bash autogen.sh
-  - "if [ ${TRAVIS_OS_NAME} != 'osx' ]; then CFLAGS=\"-Werror -Wno-unused-value -Wno-unused-parameter\" ./configure --with-shared-sqlite --with-assert=hard --enable-warnings; fi"
+  - "if [ ${TRAVIS_OS_NAME} != 'osx' ]; then CFLAGS=\"-Werror -Wno-unused-value -Wno-unused-parameter\" ./configure --with-shared-sqlite --enable-assert=hard --enable-warnings; fi"
   - "if [ ${TRAVIS_OS_NAME} = 'osx' ]; then ./configure --with-shared-sqlite; fi"
   - make -j4
   - "if [ ${TRAVIS_OS_NAME} != 'osx' ]; then make check; fi"

--- a/include/client.h
+++ b/include/client.h
@@ -438,6 +438,7 @@ struct ListClient
 #define LFLAGS_CORK		0x00000004
 #define LFLAGS_SCTP		0x00000008
 #define LFLAGS_SECURE		0x00000010	/* for marking SSL clients as secure before registration */
+#define LFLAGS_FAKE		0x00000020
 
 /* umodes, settable flags */
 /* lots of this moved to snomask -- jilles */

--- a/include/client.h
+++ b/include/client.h
@@ -438,6 +438,7 @@ struct ListClient
 #define LFLAGS_CORK		0x00000004
 #define LFLAGS_SCTP		0x00000008
 #define LFLAGS_SECURE		0x00000010	/* for marking SSL clients as secure before registration */
+/* LFLAGS_FAKE: client may not have the usually expected machinery plugged in; don't assert on it. For tests only. */
 #define LFLAGS_FAKE		0x00000020
 
 /* umodes, settable flags */

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -82,8 +82,9 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 	struct Message *mptr;
 	struct MsgBuf msgbuf;
 
-	s_assert(MyConnect(client_p));
-	s_assert(client_p->localClient->F != NULL);
+	s_assert(MyConnect(client_p) &&
+			(client_p->localClient->F != NULL ||
+				client_p->localClient->localflags & LFLAGS_FAKE));
 	if(IsAnyDead(client_p))
 		return;
 

--- a/tests/client_util.c
+++ b/tests/client_util.c
@@ -59,6 +59,7 @@ struct Client *make_local_unknown(void)
 	rb_dlinkAdd(client, &client->lnode, &client->servptr->serv->users);
 	client->localClient->listener = &fake_listener;
 	client->preClient->auth.accepted = true;
+	client->localClient->localflags |= LFLAGS_FAKE;
 
 	return client;
 }
@@ -123,6 +124,7 @@ struct Client *make_remote_server_full(struct Client *uplink, const char *name, 
 
 	client = make_client(NULL);
 	client->servptr = uplink;
+	client->localClient->localflags |= LFLAGS_FAKE;
 
 	attach_server_conf(client, find_server_conf(name));
 


### PR DESCRIPTION
There's one that fails, which I'm remedying by adding a local client flag to shut it up. If it happens more often we might think about a generic mechanism for tests to silence/expect assertions.