### PR TITLE
Restructure channel mode handling, make it interact consistently with override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ ircd/version.c.last
 ssld/ssld
 wsockd/wsockd
 tests/core
+tests/chmode1
 tests/hostmask1
 tests/match1
 tests/msgbuf_parse1

--- a/extensions/chm_operonly_compat.c
+++ b/extensions/chm_operonly_compat.c
@@ -15,41 +15,33 @@ static const char chm_operonly_compat[] =
 static int _modinit(void);
 static void _moddeinit(void);
 static void chm_operonly(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type);
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 
 DECLARE_MODULE_AV2(chm_operonly_compat, _modinit, _moddeinit, NULL, NULL, NULL, NULL, NULL, chm_operonly_compat);
 
 static int
 _modinit(void)
 {
-	chmode_table['O'].set_func = chm_operonly;
-	chmode_table['O'].mode_type = 0;
-
+	chmode_table['O'] = (struct ChannelMode){chm_operonly, 0, 0};
 	return 0;
 }
 
 static void
 _moddeinit(void)
 {
-	chmode_table['O'].set_func = chm_nosuch;
-	chmode_table['O'].mode_type = 0;
+	chmode_table['O'] = (struct ChannelMode){chm_nosuch, 0, 0};
 }
 
 static void
 chm_operonly(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type)
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type)
 {
-	int newparn = 0;
-	const char *newparv[] = { "$o" };
-
 	if (MyClient(source_p)) {
-		chm_simple(source_p, chptr, alevel, parc, parn, parv,
+		chm_simple(source_p, chptr, alevel, NULL,
 				errors, dir, 'i', MODE_INVITEONLY);
-		chm_ban(source_p, chptr, alevel, 1, &newparn, newparv,
+		chm_ban(source_p, chptr, alevel, "$o",
 				errors, dir, 'I', CHFL_INVEX);
 	} else
-		chm_nosuch(source_p, chptr, alevel, parc, parn, parv,
+		chm_nosuch(source_p, chptr, alevel, NULL,
 				errors, dir, c, mode_type);
 }

--- a/extensions/chm_quietunreg_compat.c
+++ b/extensions/chm_quietunreg_compat.c
@@ -16,39 +16,31 @@ static const char chm_quietunreg_compat_desc[] =
 static int _modinit(void);
 static void _moddeinit(void);
 static void chm_quietunreg(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type);
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 
 DECLARE_MODULE_AV2(chm_quietunreg_compat, _modinit, _moddeinit, NULL, NULL, NULL, NULL, NULL, chm_quietunreg_compat_desc);
 
 static int
 _modinit(void)
 {
-	chmode_table['R'].set_func = chm_quietunreg;
-	chmode_table['R'].mode_type = 0;
-
+	chmode_table['R'] = (struct ChannelMode){ chm_quietunreg, 0, 0 };
 	return 0;
 }
 
 static void
 _moddeinit(void)
 {
-	chmode_table['R'].set_func = chm_nosuch;
-	chmode_table['R'].mode_type = 0;
+	chmode_table['R'] = (struct ChannelMode){ chm_nosuch, 0, 0 };
 }
 
 static void
 chm_quietunreg(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type)
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type)
 {
-	int newparn = 0;
-	const char *newparv[] = { "$~a" };
-
 	if (MyClient(source_p))
-		chm_ban(source_p, chptr, alevel, 1, &newparn, newparv,
+		chm_ban(source_p, chptr, alevel, "$~a",
 				errors, dir, 'q', CHFL_QUIET);
 	else
-		chm_nosuch(source_p, chptr, alevel, parc, parn, parv,
+		chm_nosuch(source_p, chptr, alevel, NULL,
 				errors, dir, c, mode_type);
 }

--- a/extensions/chm_sslonly_compat.c
+++ b/extensions/chm_sslonly_compat.c
@@ -15,39 +15,31 @@ static const char chm_sslonly_compat_desc[] =
 static int _modinit(void);
 static void _moddeinit(void);
 static void chm_sslonly(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type);
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 
 DECLARE_MODULE_AV2(chm_sslonly_compat, _modinit, _moddeinit, NULL, NULL, NULL, NULL, NULL, chm_sslonly_compat_desc);
 
 static int
 _modinit(void)
 {
-	chmode_table['S'].set_func = chm_sslonly;
-	chmode_table['S'].mode_type = 0;
-
+	chmode_table['S'] = (struct ChannelMode){ chm_sslonly, 0, 0 };
 	return 0;
 }
 
 static void
 _moddeinit(void)
 {
-	chmode_table['S'].set_func = chm_nosuch;
-	chmode_table['S'].mode_type = 0;
+	chmode_table['S'] = (struct ChannelMode){ chm_nosuch, 0, 0 };
 }
 
 static void
 chm_sslonly(struct Client *source_p, struct Channel *chptr,
-	int alevel, int parc, int *parn,
-	const char **parv, int *errors, int dir, char c, long mode_type)
+	int alevel, const char *arg, int *errors, int dir, char c, long mode_type)
 {
-	int newparn = 0;
-	const char *newparv[] = { "$~z" };
-
 	if (MyClient(source_p))
-		chm_ban(source_p, chptr, alevel, 1, &newparn, newparv,
+		chm_ban(source_p, chptr, alevel, "$~z",
 				errors, dir, 'b', CHFL_BAN);
 	else
-		chm_nosuch(source_p, chptr, alevel, parc, parn, parv,
+		chm_nosuch(source_p, chptr, alevel, NULL,
 				errors, dir, c, mode_type);
 }

--- a/include/channel.h
+++ b/include/channel.h
@@ -122,13 +122,23 @@ struct ChModeChange
 };
 
 typedef void (*ChannelModeFunc)(struct Client *source_p, struct Channel *chptr,
-		int alevel, int parc, int *parn,
-		const char **parv, int *errors, int dir, char c, long mode_type);
+		int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
+
+enum chm_flags
+{
+	CHM_CAN_QUERY  = 1 << 0,
+	CHM_OPS_QUERY  = 1 << 1,
+	CHM_ARG_SET    = 1 << 2,
+	CHM_ARG_DEL    = 1 << 3,
+	CHM_ARGS       = CHM_ARG_SET | CHM_ARG_DEL,
+	CHM_QUERYABLE  = CHM_ARGS | CHM_CAN_QUERY,
+};
 
 struct ChannelMode
 {
 	ChannelModeFunc set_func;
 	long mode_type;
+	enum chm_flags flags;
 };
 
 typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,

--- a/include/channel.h
+++ b/include/channel.h
@@ -191,6 +191,7 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_QUERY     0
 #define MODE_ADD       1
 #define MODE_DEL       -1
+#define MODE_OP_QUERY  2
 
 #define SecretChannel(x)        ((x) && ((x)->mode.mode & MODE_SECRET))
 #define HiddenChannel(x)        ((x) && ((x)->mode.mode & MODE_PRIVATE))

--- a/include/chmode.h
+++ b/include/chmode.h
@@ -35,41 +35,29 @@
 extern int chmode_flags[256];
 
 extern void chm_nosuch(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_orphaned(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_simple(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_ban(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_hidden(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_staff(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_forward(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_throttle(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_key(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_limit(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_op(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 extern void chm_voice(struct Client *source_p, struct Channel *chptr,
-	   int alevel, int parc, int *parn,
-	   const char **parv, int *errors, int dir, char c, long mode_type);
+	   int alevel, const char *arg, int *errors, int dir, char c, long mode_type);
 
 extern unsigned int cflag_add(char c, ChannelModeFunc function);
 extern void cflag_orphan(char c);

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -1457,6 +1457,8 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 
 			if (effective_dir != MODE_QUERY && access_dir == MODE_QUERY)
 				access_dir = effective_dir;
+			if (effective_dir == MODE_QUERY && cm->flags & CHM_OPS_QUERY)
+				access_dir = MODE_OP_QUERY;
 
 			ms->cm = cm;
 			ms->dir = effective_dir;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -86,13 +86,13 @@ construct_cflags_strings(void)
 
 	for(i = 0; i < 256; i++)
 	{
-		if( !(chmode_table[i].set_func == chm_ban) &&
-			!(chmode_table[i].set_func == chm_forward) &&
-			!(chmode_table[i].set_func == chm_throttle) &&
-                        !(chmode_table[i].set_func == chm_key) &&
-                        !(chmode_table[i].set_func == chm_limit) &&
-                        !(chmode_table[i].set_func == chm_op) &&
-                        !(chmode_table[i].set_func == chm_voice))
+		if (chmode_table[i].set_func != chm_ban &&
+				chmode_table[i].set_func != chm_forward &&
+				chmode_table[i].set_func != chm_throttle &&
+				chmode_table[i].set_func != chm_key &&
+				chmode_table[i].set_func != chm_limit &&
+				chmode_table[i].set_func != chm_op &&
+				chmode_table[i].set_func != chm_voice)
 		{
 			chmode_flags[i] = chmode_table[i].mode_type;
 		}
@@ -116,7 +116,9 @@ construct_cflags_strings(void)
 		}
 
 		/* Should we leave orphaned check here? -- dwr */
-		if(!(chmode_table[i].set_func == chm_nosuch) && !(chmode_table[i].set_func == chm_orphaned))
+		if (chmode_table[i].set_func != NULL &&
+				chmode_table[i].set_func != chm_nosuch &&
+				chmode_table[i].set_func != chm_orphaned)
 		{
 		    *ptr2++ = (char) i;
 		}
@@ -153,11 +155,12 @@ cflag_add(char c_, ChannelModeFunc function)
 {
 	int c = (unsigned char)c_;
 
-	if (chmode_table[c].set_func != chm_nosuch &&
+	if (chmode_table[c].set_func != NULL &&
+			chmode_table[c].set_func != chm_nosuch &&
 			chmode_table[c].set_func != chm_orphaned)
 		return 0;
 
-	if (chmode_table[c].set_func == chm_nosuch)
+	if (chmode_table[c].set_func == NULL || chmode_table[c].set_func == chm_nosuch)
 		chmode_table[c].mode_type = find_cflag_slot();
 	if (chmode_table[c].mode_type == 0)
 		return 0;
@@ -1385,272 +1388,29 @@ chm_key(struct Client *source_p, struct Channel *chptr,
 /* *INDENT-OFF* */
 struct ChannelMode chmode_table[256] =
 {
-  {chm_nosuch,  0 },			/* 0x00 */
-  {chm_nosuch,  0 },			/* 0x01 */
-  {chm_nosuch,  0 },			/* 0x02 */
-  {chm_nosuch,  0 },			/* 0x03 */
-  {chm_nosuch,  0 },			/* 0x04 */
-  {chm_nosuch,  0 },			/* 0x05 */
-  {chm_nosuch,  0 },			/* 0x06 */
-  {chm_nosuch,  0 },			/* 0x07 */
-  {chm_nosuch,  0 },			/* 0x08 */
-  {chm_nosuch,  0 },			/* 0x09 */
-  {chm_nosuch,  0 },			/* 0x0a */
-  {chm_nosuch,  0 },			/* 0x0b */
-  {chm_nosuch,  0 },			/* 0x0c */
-  {chm_nosuch,  0 },			/* 0x0d */
-  {chm_nosuch,  0 },			/* 0x0e */
-  {chm_nosuch,  0 },			/* 0x0f */
-  {chm_nosuch,  0 },			/* 0x10 */
-  {chm_nosuch,  0 },			/* 0x11 */
-  {chm_nosuch,  0 },			/* 0x12 */
-  {chm_nosuch,  0 },			/* 0x13 */
-  {chm_nosuch,  0 },			/* 0x14 */
-  {chm_nosuch,  0 },			/* 0x15 */
-  {chm_nosuch,  0 },			/* 0x16 */
-  {chm_nosuch,  0 },			/* 0x17 */
-  {chm_nosuch,  0 },			/* 0x18 */
-  {chm_nosuch,  0 },			/* 0x19 */
-  {chm_nosuch,  0 },			/* 0x1a */
-  {chm_nosuch,  0 },			/* 0x1b */
-  {chm_nosuch,  0 },			/* 0x1c */
-  {chm_nosuch,  0 },			/* 0x1d */
-  {chm_nosuch,  0 },			/* 0x1e */
-  {chm_nosuch,  0 },			/* 0x1f */
-  {chm_nosuch,  0 },			/* 0x20 */
-  {chm_nosuch,  0 },			/* 0x21 */
-  {chm_nosuch,  0 },			/* 0x22 */
-  {chm_nosuch,  0 },			/* 0x23 */
-  {chm_nosuch,  0 },			/* 0x24 */
-  {chm_nosuch,  0 },			/* 0x25 */
-  {chm_nosuch,  0 },			/* 0x26 */
-  {chm_nosuch,  0 },			/* 0x27 */
-  {chm_nosuch,  0 },			/* 0x28 */
-  {chm_nosuch,  0 },			/* 0x29 */
-  {chm_nosuch,  0 },			/* 0x2a */
-  {chm_nosuch,  0 },			/* 0x2b */
-  {chm_nosuch,  0 },			/* 0x2c */
-  {chm_nosuch,  0 },			/* 0x2d */
-  {chm_nosuch,  0 },			/* 0x2e */
-  {chm_nosuch,  0 },			/* 0x2f */
-  {chm_nosuch,  0 },			/* 0x30 */
-  {chm_nosuch,  0 },			/* 0x31 */
-  {chm_nosuch,  0 },			/* 0x32 */
-  {chm_nosuch,  0 },			/* 0x33 */
-  {chm_nosuch,  0 },			/* 0x34 */
-  {chm_nosuch,  0 },			/* 0x35 */
-  {chm_nosuch,  0 },			/* 0x36 */
-  {chm_nosuch,  0 },			/* 0x37 */
-  {chm_nosuch,  0 },			/* 0x38 */
-  {chm_nosuch,  0 },			/* 0x39 */
-  {chm_nosuch,  0 },			/* 0x3a */
-  {chm_nosuch,  0 },			/* 0x3b */
-  {chm_nosuch,  0 },			/* 0x3c */
-  {chm_nosuch,  0 },			/* 0x3d */
-  {chm_nosuch,  0 },			/* 0x3e */
-  {chm_nosuch,  0 },			/* 0x3f */
-
-  {chm_nosuch,	0 },			/* @ */
-  {chm_nosuch,	0 },			/* A */
-  {chm_nosuch,	0 },			/* B */
-  {chm_nosuch,  0 },			/* C */
-  {chm_nosuch,	0 },			/* D */
-  {chm_nosuch,	0 },			/* E */
-  {chm_simple,	MODE_FREETARGET },	/* F */
-  {chm_nosuch,	0 },			/* G */
-  {chm_nosuch,	0 },			/* H */
-  {chm_ban,	CHFL_INVEX },           /* I */
-  {chm_nosuch,	0 },			/* J */
-  {chm_nosuch,	0 },			/* K */
-  {chm_staff,	MODE_EXLIMIT },		/* L */
-  {chm_nosuch,	0 },			/* M */
-  {chm_nosuch,	0 },			/* N */
-  {chm_nosuch,	0 },			/* O */
-  {chm_staff,	MODE_PERMANENT },	/* P */
-  {chm_simple,	MODE_DISFORWARD },	/* Q */
-  {chm_nosuch,	0 },			/* R */
-  {chm_nosuch,	0 },			/* S */
-  {chm_nosuch,	0 },			/* T */
-  {chm_nosuch,	0 },			/* U */
-  {chm_nosuch,	0 },			/* V */
-  {chm_nosuch,	0 },			/* W */
-  {chm_nosuch,	0 },			/* X */
-  {chm_nosuch,	0 },			/* Y */
-  {chm_nosuch,	0 },			/* Z */
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },
-  {chm_nosuch,	0 },			/* a */
-  {chm_ban,	CHFL_BAN },		/* b */
-  {chm_nosuch,	0 },			/* c */
-  {chm_nosuch,	0 },			/* d */
-  {chm_ban,	CHFL_EXCEPTION },	/* e */
-  {chm_forward,	0 },			/* f */
-  {chm_simple,	MODE_FREEINVITE },	/* g */
-  {chm_nosuch,	0 },			/* h */
-  {chm_simple,	MODE_INVITEONLY },	/* i */
-  {chm_throttle, 0 },			/* j */
-  {chm_key,	0 },			/* k */
-  {chm_limit,	0 },			/* l */
-  {chm_simple,	MODE_MODERATED },	/* m */
-  {chm_simple,	MODE_NOPRIVMSGS },	/* n */
-  {chm_op,	0 },			/* o */
-  {chm_simple,	MODE_PRIVATE },		/* p */
-  {chm_ban,	CHFL_QUIET },		/* q */
-  {chm_simple,  MODE_REGONLY },		/* r */
-  {chm_simple,	MODE_SECRET },		/* s */
-  {chm_simple,	MODE_TOPICLIMIT },	/* t */
-  {chm_nosuch,	0 },			/* u */
-  {chm_voice,	0 },			/* v */
-  {chm_nosuch,	0 },			/* w */
-  {chm_nosuch,	0 },			/* x */
-  {chm_nosuch,	0 },			/* y */
-  {chm_simple,	MODE_OPMODERATE },	/* z */
-
-  {chm_nosuch,  0 },			/* 0x7b */
-  {chm_nosuch,  0 },			/* 0x7c */
-  {chm_nosuch,  0 },			/* 0x7d */
-  {chm_nosuch,  0 },			/* 0x7e */
-  {chm_nosuch,  0 },			/* 0x7f */
-
-  {chm_nosuch,  0 },			/* 0x80 */
-  {chm_nosuch,  0 },			/* 0x81 */
-  {chm_nosuch,  0 },			/* 0x82 */
-  {chm_nosuch,  0 },			/* 0x83 */
-  {chm_nosuch,  0 },			/* 0x84 */
-  {chm_nosuch,  0 },			/* 0x85 */
-  {chm_nosuch,  0 },			/* 0x86 */
-  {chm_nosuch,  0 },			/* 0x87 */
-  {chm_nosuch,  0 },			/* 0x88 */
-  {chm_nosuch,  0 },			/* 0x89 */
-  {chm_nosuch,  0 },			/* 0x8a */
-  {chm_nosuch,  0 },			/* 0x8b */
-  {chm_nosuch,  0 },			/* 0x8c */
-  {chm_nosuch,  0 },			/* 0x8d */
-  {chm_nosuch,  0 },			/* 0x8e */
-  {chm_nosuch,  0 },			/* 0x8f */
-
-  {chm_nosuch,  0 },			/* 0x90 */
-  {chm_nosuch,  0 },			/* 0x91 */
-  {chm_nosuch,  0 },			/* 0x92 */
-  {chm_nosuch,  0 },			/* 0x93 */
-  {chm_nosuch,  0 },			/* 0x94 */
-  {chm_nosuch,  0 },			/* 0x95 */
-  {chm_nosuch,  0 },			/* 0x96 */
-  {chm_nosuch,  0 },			/* 0x97 */
-  {chm_nosuch,  0 },			/* 0x98 */
-  {chm_nosuch,  0 },			/* 0x99 */
-  {chm_nosuch,  0 },			/* 0x9a */
-  {chm_nosuch,  0 },			/* 0x9b */
-  {chm_nosuch,  0 },			/* 0x9c */
-  {chm_nosuch,  0 },			/* 0x9d */
-  {chm_nosuch,  0 },			/* 0x9e */
-  {chm_nosuch,  0 },			/* 0x9f */
-
-  {chm_nosuch,  0 },			/* 0xa0 */
-  {chm_nosuch,  0 },			/* 0xa1 */
-  {chm_nosuch,  0 },			/* 0xa2 */
-  {chm_nosuch,  0 },			/* 0xa3 */
-  {chm_nosuch,  0 },			/* 0xa4 */
-  {chm_nosuch,  0 },			/* 0xa5 */
-  {chm_nosuch,  0 },			/* 0xa6 */
-  {chm_nosuch,  0 },			/* 0xa7 */
-  {chm_nosuch,  0 },			/* 0xa8 */
-  {chm_nosuch,  0 },			/* 0xa9 */
-  {chm_nosuch,  0 },			/* 0xaa */
-  {chm_nosuch,  0 },			/* 0xab */
-  {chm_nosuch,  0 },			/* 0xac */
-  {chm_nosuch,  0 },			/* 0xad */
-  {chm_nosuch,  0 },			/* 0xae */
-  {chm_nosuch,  0 },			/* 0xaf */
-
-  {chm_nosuch,  0 },			/* 0xb0 */
-  {chm_nosuch,  0 },			/* 0xb1 */
-  {chm_nosuch,  0 },			/* 0xb2 */
-  {chm_nosuch,  0 },			/* 0xb3 */
-  {chm_nosuch,  0 },			/* 0xb4 */
-  {chm_nosuch,  0 },			/* 0xb5 */
-  {chm_nosuch,  0 },			/* 0xb6 */
-  {chm_nosuch,  0 },			/* 0xb7 */
-  {chm_nosuch,  0 },			/* 0xb8 */
-  {chm_nosuch,  0 },			/* 0xb9 */
-  {chm_nosuch,  0 },			/* 0xba */
-  {chm_nosuch,  0 },			/* 0xbb */
-  {chm_nosuch,  0 },			/* 0xbc */
-  {chm_nosuch,  0 },			/* 0xbd */
-  {chm_nosuch,  0 },			/* 0xbe */
-  {chm_nosuch,  0 },			/* 0xbf */
-
-  {chm_nosuch,  0 },			/* 0xc0 */
-  {chm_nosuch,  0 },			/* 0xc1 */
-  {chm_nosuch,  0 },			/* 0xc2 */
-  {chm_nosuch,  0 },			/* 0xc3 */
-  {chm_nosuch,  0 },			/* 0xc4 */
-  {chm_nosuch,  0 },			/* 0xc5 */
-  {chm_nosuch,  0 },			/* 0xc6 */
-  {chm_nosuch,  0 },			/* 0xc7 */
-  {chm_nosuch,  0 },			/* 0xc8 */
-  {chm_nosuch,  0 },			/* 0xc9 */
-  {chm_nosuch,  0 },			/* 0xca */
-  {chm_nosuch,  0 },			/* 0xcb */
-  {chm_nosuch,  0 },			/* 0xcc */
-  {chm_nosuch,  0 },			/* 0xcd */
-  {chm_nosuch,  0 },			/* 0xce */
-  {chm_nosuch,  0 },			/* 0xcf */
-
-  {chm_nosuch,  0 },			/* 0xd0 */
-  {chm_nosuch,  0 },			/* 0xd1 */
-  {chm_nosuch,  0 },			/* 0xd2 */
-  {chm_nosuch,  0 },			/* 0xd3 */
-  {chm_nosuch,  0 },			/* 0xd4 */
-  {chm_nosuch,  0 },			/* 0xd5 */
-  {chm_nosuch,  0 },			/* 0xd6 */
-  {chm_nosuch,  0 },			/* 0xd7 */
-  {chm_nosuch,  0 },			/* 0xd8 */
-  {chm_nosuch,  0 },			/* 0xd9 */
-  {chm_nosuch,  0 },			/* 0xda */
-  {chm_nosuch,  0 },			/* 0xdb */
-  {chm_nosuch,  0 },			/* 0xdc */
-  {chm_nosuch,  0 },			/* 0xdd */
-  {chm_nosuch,  0 },			/* 0xde */
-  {chm_nosuch,  0 },			/* 0xdf */
-
-  {chm_nosuch,  0 },			/* 0xe0 */
-  {chm_nosuch,  0 },			/* 0xe1 */
-  {chm_nosuch,  0 },			/* 0xe2 */
-  {chm_nosuch,  0 },			/* 0xe3 */
-  {chm_nosuch,  0 },			/* 0xe4 */
-  {chm_nosuch,  0 },			/* 0xe5 */
-  {chm_nosuch,  0 },			/* 0xe6 */
-  {chm_nosuch,  0 },			/* 0xe7 */
-  {chm_nosuch,  0 },			/* 0xe8 */
-  {chm_nosuch,  0 },			/* 0xe9 */
-  {chm_nosuch,  0 },			/* 0xea */
-  {chm_nosuch,  0 },			/* 0xeb */
-  {chm_nosuch,  0 },			/* 0xec */
-  {chm_nosuch,  0 },			/* 0xed */
-  {chm_nosuch,  0 },			/* 0xee */
-  {chm_nosuch,  0 },			/* 0xef */
-
-  {chm_nosuch,  0 },			/* 0xf0 */
-  {chm_nosuch,  0 },			/* 0xf1 */
-  {chm_nosuch,  0 },			/* 0xf2 */
-  {chm_nosuch,  0 },			/* 0xf3 */
-  {chm_nosuch,  0 },			/* 0xf4 */
-  {chm_nosuch,  0 },			/* 0xf5 */
-  {chm_nosuch,  0 },			/* 0xf6 */
-  {chm_nosuch,  0 },			/* 0xf7 */
-  {chm_nosuch,  0 },			/* 0xf8 */
-  {chm_nosuch,  0 },			/* 0xf9 */
-  {chm_nosuch,  0 },			/* 0xfa */
-  {chm_nosuch,  0 },			/* 0xfb */
-  {chm_nosuch,  0 },			/* 0xfc */
-  {chm_nosuch,  0 },			/* 0xfd */
-  {chm_nosuch,  0 },			/* 0xfe */
-  {chm_nosuch,  0 },			/* 0xff */
+  ['F'] = {chm_simple,    MODE_FREETARGET },
+  ['I'] = {chm_ban,       CHFL_INVEX },
+  ['L'] = {chm_staff,     MODE_EXLIMIT },
+  ['P'] = {chm_staff,     MODE_PERMANENT },
+  ['Q'] = {chm_simple,    MODE_DISFORWARD },
+  ['b'] = {chm_ban,       CHFL_BAN },
+  ['e'] = {chm_ban,       CHFL_EXCEPTION },
+  ['f'] = {chm_forward,   0 },
+  ['g'] = {chm_simple,    MODE_FREEINVITE },
+  ['i'] = {chm_simple,    MODE_INVITEONLY },
+  ['j'] = {chm_throttle,  0 },
+  ['k'] = {chm_key,       0 },
+  ['l'] = {chm_limit,     0 },
+  ['m'] = {chm_simple,    MODE_MODERATED },
+  ['n'] = {chm_simple,    MODE_NOPRIVMSGS },
+  ['o'] = {chm_op,        0 },
+  ['p'] = {chm_simple,    MODE_PRIVATE },
+  ['q'] = {chm_ban,       CHFL_QUIET },
+  ['r'] = {chm_simple,    MODE_REGONLY },
+  ['s'] = {chm_simple,    MODE_SECRET },
+  ['t'] = {chm_simple,    MODE_TOPICLIMIT },
+  ['v'] = {chm_voice,     0 },
+  ['z'] = {chm_simple,    MODE_OPMODERATE },
 };
 
 /* *INDENT-ON* */
@@ -1701,6 +1461,7 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 	{
 		switch (c)
 		{
+		ChannelModeFunc set_func;
 		case '+':
 			dir = MODE_ADD;
 			if (!reauthorized)
@@ -1721,7 +1482,10 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 			dir = MODE_QUERY;
 			break;
 		default:
-			chmode_table[(unsigned char) c].set_func(fakesource_p, chptr, alevel,
+			set_func = chmode_table[(unsigned char) c].set_func;
+			if (set_func == NULL)
+				set_func = chm_nosuch;
+			set_func(fakesource_p, chptr, alevel,
 				       parc, &parn, parv,
 				       &errors, dir, c,
 				       chmode_table[(unsigned char) c].mode_type);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,5 @@
 check_PROGRAMS = runtests \
+	chmode1 \
 	match1 \
 	msgbuf_parse1 \
 	msgbuf_unparse1 \
@@ -24,6 +25,7 @@ check_LIBRARIES = tap/libtap.a
 tap_libtap_a_SOURCES = tap/basic.c tap/basic.h \
 	tap/float.c tap/float.h tap/macros.h
 
+chmode1_SOURCES = chmode1.c ircd_util.c client_util.c
 match1_SOURCES = match1.c
 msgbuf_parse1_SOURCES = msgbuf_parse1.c
 msgbuf_unparse1_SOURCES = msgbuf_unparse1.c

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -1,3 +1,4 @@
+chmode1
 match1
 msgbuf_parse1
 msgbuf_unparse1

--- a/tests/chmode1.c
+++ b/tests/chmode1.c
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2020 Ed Kellett
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include <stdinc.h>
+#include <channel.h>
+#include <hook.h>
+
+#include "client_util.h"
+#include "ircd_util.h"
+#include "tap/basic.h"
+
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+
+static struct Channel *channel;
+static struct Client *client;
+
+static hook_data_channel_approval chmode_hdata;
+
+static void
+chmode_access_hook(void *data_)
+{
+	hook_data_channel_approval *data = data_;
+	chmode_hdata = *data;
+}
+
+void
+test_chmode_parse(void)
+{
+	add_hook_prio("get_channel_access", chmode_access_hook, HOOK_MONITOR);
+
+	set_channel_mode(client, client, channel, NULL, 2, (const char *[]){"o", "foo"});
+	is_string("+o foo", chmode_hdata.modestr, MSG);
+
+	set_channel_mode(client, client, channel, NULL, 3, (const char *[]){"o", "foo", "bar"});
+	is_string("+o foo", chmode_hdata.modestr, MSG);
+
+	chmode_hdata.modestr = NULL;
+	set_channel_mode(client, client, channel, NULL, 3, (const char *[]){"+-=+++--+", "foo", "bar"});
+	is_bool(true, chmode_hdata.modestr == NULL, MSG);
+
+	set_channel_mode(client, client, channel, NULL, 1, (const char *[]){"b"});
+	is_string("=b", chmode_hdata.modestr, MSG);
+
+	set_channel_mode(client, client, channel, NULL, 2, (const char *[]){"bb", "foo"});
+	is_string("+b=b foo", chmode_hdata.modestr, MSG);
+
+	set_channel_mode(client, client, channel, NULL, 1, (const char *[]){"iqiqiqiq"});
+	is_string("+i=q+i=q+i=q+i=q", chmode_hdata.modestr, MSG);
+
+	remove_hook("get_channel_access", chmode_access_hook);
+}
+
+static void
+chmode_init(void)
+{
+	channel = make_channel();
+	client = make_local_person();
+}
+
+int
+main(int argc, char *argv[])
+{
+	plan_lazy();
+
+	ircd_util_init(__FILE__);
+	client_util_init();
+
+	chmode_init();
+
+	test_chmode_parse();
+
+	client_util_free();
+	ircd_util_free();
+
+	return 0;
+}

--- a/tests/chmode1.conf
+++ b/tests/chmode1.conf
@@ -1,0 +1,29 @@
+serverinfo {
+	sid = "0AA";
+	name = "me.test";
+	description = "Test server";
+	network_name = "Test network";
+};
+
+connect "remote.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote2.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote3.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+privset "admin" {
+	privs = oper:admin;
+};
+


### PR DESCRIPTION
The previous behaviour did one access check for a query, and then another one if you tried to set something, with the result that you couldn't see +eI lists with `MODE #foo e`, but you could by prefixing with a +: `MODE #foo +e`. Also you'd send an override snote for a query you could have done without override.

Most of this change is just making things more consistent; currently I've also got an override change in here to prevent using it to view +eI lists at all, but there's an argument to be had about how you should do that.

As a bonus, doing the parsing properly means we can restore the behaviour of `MODE #foo b x!y@z` (which once banned x!y@z, then didn't because override reauthorization hack).

I've been fairly conservative about rejecting invalid mode commands we can now detect before we start trying to effect them; see XXXs in the diff. There's a fair bit more we could do in that vein if we want to; I don't see any reason we couldn't process mode limits at parse time, for example.