### PR TITLE
iter lists backwards when sending BMASK

### DIFF
--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -551,7 +551,7 @@ burst_modes_TS6(struct Client *client_p, struct Channel *chptr,
 				    me.id, (long) chptr->channelts, chptr->chname, flag);
 	t = buf + mlen;
 
-	RB_DLINK_FOREACH(ptr, list->head)
+	RB_DLINK_FOREACH_PREV(ptr, list->tail)
 	{
 		banptr = ptr->data;
 


### PR DESCRIPTION
as per #46 - netjoined servers end up with reversed ban lists.

this is due to `add_id()` doing left appends, which means local queries of ban lists do newest-to-oldest, but once we send the list newest-to-oldest to a server we're bursting, they do left appends newest-to-oldest, making the their list oldest-to-newest.