### PR TITLE
chmode: end the grace period more intelligently

### DIFF
--- a/modules/core/m_mode.c
+++ b/modules/core/m_mode.c
@@ -138,13 +138,6 @@ m_mode(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	{
 		msptr = find_channel_membership(chptr, source_p);
 
-		/* Finish the flood grace period... */
-		if(MyClient(source_p) && !IsFloodDone(source_p))
-		{
-			if(!((parc == 3) && (parv[2][0] == 'b' || parv[2][0] == 'q') && (parv[2][1] == '\0')))
-				flood_endgrace(source_p);
-		}
-
 		set_channel_mode(client_p, source_p, chptr, msptr, parc - n, parv + n);
 	}
 }


### PR DESCRIPTION
We were ending the flood grace period for any channel mode command other than `MODE #foo [bq]` by means of a hardcoded check. I've moved that to after we parse the mode string, so we can correctly identify all requests to change modes and end the grace period on exactly those.

It would have been entirely possible to move the check even further down and flood_endgrace on only mode commands that *actually* change modes, but I don't like the idea of making it sensitive to external conditions.