### PR TITLE
change "forcing message" override from CAN_SEND_NONOP to CAN_SEND_OPV

### DIFF
--- a/extensions/override.c
+++ b/extensions/override.c
@@ -217,12 +217,12 @@ hack_can_send(void *vdata)
 	if (data->dir == MODE_QUERY)
 		return;
 
-	if (data->approved == CAN_SEND_NONOP || data->approved == CAN_SEND_OPV)
+	if (data->approved == CAN_SEND_OPV)
 		return;
 
 	if (data->client->umodes & user_modes['p'])
 	{
-		data->approved = CAN_SEND_NONOP;
+		data->approved = CAN_SEND_OPV;
 
 		if (MyClient(data->client))
 		{


### PR DESCRIPTION
per
https://github.com/solanum-ircd/solanum/blob/a92275551218402bf4969a7fe613cab27416c4ef/modules/core/m_message.c#L550-L551
we want to avoid the `flood_attack_channel` call, and I can't see `CAN_SEND_OPV` being used anywhere else for anything more serious than this

closes #108