### PR TITLE
wallops: require new oper:wallops right

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ bolded warnings in the full release notes below.
 - **Breaking:** /stats A output now follows the same format as other stats letters
 - **Breaking:** helpops now uses +h instead of +H
 - **Breaking:** sno\_whois and the spy\_ extensions have been removed
+- **Breaking:** Using /wallops now requires the oper:wallops privilege instead of oper:massnotice
 - Opers now have their privset (identified by name) on remote servers
 - Oper-only umodes are refreshed after rehash and /grant
 - Extension modules can be reloaded

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -244,7 +244,8 @@ privset "server_bot" {
 privset "global_op" {
 	extends = "local_op";
 	privs = oper:routing, oper:kline, oper:unkline, oper:xline,
-		oper:resv, oper:cmodes, oper:mass_notice, oper:remoteban;
+		oper:resv, oper:cmodes, oper:mass_notice, oper:wallops,
+		oper:remoteban;
 };
 
 privset "admin" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -456,7 +456,8 @@ privset "local_op" {
 	 *                       channels etc. see /quote help operspy
 	 * oper:hidden:          hides the oper from /stats p
 	 * oper:remoteban:       allows remote kline etc
-	 * oper:mass_notice:     allows sending wallops and mass notices
+	 * oper:mass_notice:     allows sending mass notices
+	 * oper:wallops:         allows sending wallops messages
 	 * oper:grant:           allows using the GRANT command
 	 * usermode:servnotice:  allows setting +s
 	 *
@@ -481,7 +482,8 @@ privset "server_bot" {
 privset "global_op" {
 	extends = "local_op";
 	privs = oper:routing, oper:kline, oper:unkline, oper:xline,
-		oper:resv, oper:cmodes, oper:mass_notice, oper:remoteban;
+		oper:resv, oper:cmodes, oper:mass_notice, oper:wallops,
+		oper:remoteban;
 };
 
 privset "admin" {

--- a/help/opers/wallops
+++ b/help/opers/wallops
@@ -5,4 +5,4 @@ who are umode +w (including non-opers).
 
 Server sent WALLOPS go to all opers who are umode +w.
 
-- Requires Oper Priv: oper:mass_notice
+- Requires Oper Priv: oper:wallops

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -157,7 +157,6 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperInvis(x)          (HasPrivilege((x), "oper:hidden"))
 #define IsOperRemoteBan(x)      (HasPrivilege((x), "oper:remoteban"))
 #define IsOperMassNotice(x)     (HasPrivilege((x), "oper:mass_notice"))
-#define IsOperWallOps(x)        (HasPrivilege((x), "oper:wallops"))
 #define IsOperGeneral(x)        (MayHavePrivilege((x), "oper:general"))
 
 #define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || HasPrivilege((source), "auspex:oper")))

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -157,6 +157,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperInvis(x)          (HasPrivilege((x), "oper:hidden"))
 #define IsOperRemoteBan(x)      (HasPrivilege((x), "oper:remoteban"))
 #define IsOperMassNotice(x)     (HasPrivilege((x), "oper:mass_notice"))
+#define IsOperWallOps(x)        (HasPrivilege((x), "oper:wallops"))
 #define IsOperGeneral(x)        (MayHavePrivilege((x), "oper:general"))
 
 #define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || HasPrivilege((source), "auspex:oper")))

--- a/modules/m_wallops.c
+++ b/modules/m_wallops.c
@@ -97,7 +97,7 @@ ms_wallops(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 {
 	const char *prefix = "";
 
-	if (MyClient(source_p) && !IsOperWallOps(source_p))
+	if (MyClient(source_p) && !HasPrivilege(source_p, "oper:wallops"))
 	{
 		sendto_one(source_p, form_str(ERR_NOPRIVS),
 			   me.name, source_p->name, "wallops");

--- a/modules/m_wallops.c
+++ b/modules/m_wallops.c
@@ -97,10 +97,10 @@ ms_wallops(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 {
 	const char *prefix = "";
 
-	if (MyClient(source_p) && !IsOperMassNotice(source_p))
+	if (MyClient(source_p) && !IsOperWallOps(source_p))
 	{
 		sendto_one(source_p, form_str(ERR_NOPRIVS),
-			   me.name, source_p->name, "mass_notice");
+			   me.name, source_p->name, "wallops");
 		return;
 	}
 


### PR DESCRIPTION
Split oper:wallops right from oper:mass_notice. Update documentation and
examples to grant oper:wallops everywhere oper:mass_notice was granted.

closes #103
