### PR TITLE
OpenSSL: Support configuration of TLSv1.3 ciphersuites

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -156,7 +156,7 @@ serverinfo {
 	ssl_dh_params = "etc/dh.pem";
 
 	/* ssl_cipher_list: A list of ciphers, dependent on your TLS backend */
-	#ssl_cipher_list = "EECDH+HIGH:EDH+HIGH:HIGH:!aNULL";
+	#ssl_cipher_list = "TLS_CHACHA20_POLY1305_SHA256:EECDH+HIGH:EDH+HIGH:HIGH:!aNULL";
 
 	/* ssld_count: number of ssld processes you want to start, if you
 	 * have a really busy server, using N-1 where N is the number of

--- a/librb/src/openssl_ratbox.h
+++ b/librb/src/openssl_ratbox.h
@@ -95,6 +95,10 @@
 #  endif
 #endif
 
+#if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+#  define LRB_HAVE_TLS13                1
+#endif
+
 
 
 /*
@@ -107,6 +111,11 @@
  */
 
 static const char rb_default_ciphers[] = ""
+#ifdef LRB_HAVE_TLS13
+	"TLS_AES_256_GCM_SHA384:"
+	"TLS_CHACHA20_POLY1305_SHA256:"
+	"TLS_AES_128_GCM_SHA256:"
+#endif
 	"aECDSA+kEECDH+CHACHA20:"
 	"aRSA+kEECDH+CHACHA20:"
 	"aRSA+kEDH+CHACHA20:"


### PR DESCRIPTION
The OpenSSL developers decided, during the OpenSSL 1.1.1 development phase, to use a different API and different set of lists for TLSv1.3 ciphersuites, than for every TLS version preceeding it.

This is stupid, but we have to work with it.

This commit also improves configuration fault resilience. The reason is that if you don't pass any valid old-style ciphersuites, OpenSSL will not negotiate an older protocol at all. However, when they implemented the new API, they decided that lack of any valid ciphersuites should result in using the defaults. This means that if you pass a completely invalid ciphersuite list (like "foo"), OR if you pass a TLSv1.2-only ciphersuite list, TLSv1.3 continues to work. This is not mirrored; passing a TLSv1.3-only ciphersuite list will break TLSv1.2 and below.

Therefore we work around this lack of mirroring by falling back to the default list for each protocol. This means that if `ssl_cipher_list` is complete garbage, the default will be used, and TLS setup will succeed for both protocols. This is logged, so that administrators can fix their configuration.

I prefer this approach over explicitly disabling the protocols if their respective ciphersuite lists are invalid, because it will result in unusable TLSv1.3 if people run newer solanum with their older charybdis/solanum configuration files that contain custom `ssl_cipher_list` definitions. Hindering TLSv1.3 adoption is not an option, in my opinion.

The downside of this is that it is no longer possible to disable a protocol family by not including any of its ciphersuites. This could be remedied by an `ssl_protocol_list` configuration directive if it is decided that this functionality is ultimately necessary.

This work is not required for either of the other TLS backends, because neither of those libraries yet support TLSv1.3, and in the event that they eventually do, I expect them to allow configuration of newer ciphersuites with the existing APIs. This can be revisited if it turns out not to be the case.
