### PR TITLE
Allow temporary K-lines to extend shorter ones

### DIFF
--- a/include/hostmask.h
+++ b/include/hostmask.h
@@ -46,6 +46,8 @@ struct ConfItem *find_conf_by_address(const char *host, const char *sockhost,
 				      int, int, const char *, const char *);
 struct ConfItem *find_exact_conf_by_address(const char *address, int type,
 					    const char *username);
+struct ConfItem *find_exact_conf_by_address_filtered(const char *address, int type,
+		const char *username, bool (*filter)(struct ConfItem *));
 void add_conf_by_address(const char *, int, const char *, const char *, struct ConfItem *);
 void delete_one_address_conf(const char *, struct ConfItem *);
 void clear_out_address_conf(enum aconf_category);

--- a/ircd/hostmask.c
+++ b/ircd/hostmask.c
@@ -478,13 +478,8 @@ find_dline(struct sockaddr *addr, int aftype)
 	return NULL;
 }
 
-/* void find_exact_conf_by_address(const char*, int, const char *)
- * Input:
- * Output: ConfItem if found
- * Side-effects: None
- */
 struct ConfItem *
-find_exact_conf_by_address(const char *address, int type, const char *username)
+find_exact_conf_by_address_filtered(const char *address, int type, const char *username, bool (*filter)(struct ConfItem *))
 {
 	int masktype, bits;
 	unsigned long hv;
@@ -514,6 +509,9 @@ find_exact_conf_by_address(const char *address, int type, const char *username)
 				arec->masktype == masktype &&
 				(arec->username == NULL || username == NULL ? arec->username == username : !irccmp(arec->username, username)))
 		{
+			if (filter && !filter(arec->aconf))
+				continue;
+
 			if (masktype == HM_HOST)
 			{
 				if (!irccmp(arec->Mask.hostname, address))
@@ -528,6 +526,17 @@ find_exact_conf_by_address(const char *address, int type, const char *username)
 		}
 	}
 	return NULL;
+}
+
+/* void find_exact_conf_by_address(const char*, int, const char *)
+ * Input:
+ * Output: ConfItem if found
+ * Side-effects: None
+ */
+struct ConfItem *
+find_exact_conf_by_address(const char *address, int type, const char *username)
+{
+	return find_exact_conf_by_address_filtered(address, type, username, NULL);
 }
 
 /* void add_conf_by_address(const char*, int, const char *,

--- a/modules/m_kline.c
+++ b/modules/m_kline.c
@@ -734,21 +734,21 @@ already_placed_kline(struct Client *source_p, const char *luser, const char *lho
 				aconf = NULL;
 		}
 	}
-	if(aconf != NULL)
-	{
-		/* setting a tkline, or existing one is perm */
-		if(tkline || ((aconf->flags & CONF_FLAGS_TEMPORARY) == 0))
-		{
-			reason = aconf->passwd ? aconf->passwd : "<No Reason>";
 
-			sendto_one_notice(source_p,
-					  ":[%s@%s] already K-Lined by [%s@%s] - %s",
-					  luser, lhost, aconf->user, aconf->host, reason);
-			return true;
-		}
-	}
+	if (aconf == NULL)
+		return false;
 
-	return false;
+	/* allow klines to be duplicated by longer ones */
+	if ((aconf->flags & CONF_FLAGS_TEMPORARY) &&
+			(tkline == 0 || tkline > aconf->hold - rb_current_time()))
+		return false;
+
+	reason = aconf->passwd ? aconf->passwd : "<No Reason>";
+
+	sendto_one_notice(source_p,
+			  ":[%s@%s] already K-Lined by [%s@%s] - %s",
+			  luser, lhost, aconf->user, aconf->host, reason);
+	return true;
 }
 
 /* remove_permkline_match()

--- a/modules/m_kline.c
+++ b/modules/m_kline.c
@@ -424,19 +424,22 @@ mo_unkline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 		return;
 	}
 
-	if(aconf->lifetime)
+	do
 	{
-		if(propagated)
-			remove_prop_kline(source_p, aconf);
-		else
-			sendto_one_notice(source_p, ":Cannot remove global K-Line %s@%s on specific servers", user, host);
-		return;
-	}
+		if (aconf->lifetime)
+		{
+			if (propagated)
+				remove_prop_kline(source_p, aconf);
+			else
+				sendto_one_notice(source_p, ":Cannot remove global K-Line %s@%s on specific servers", user, host);
+			continue;
+		}
 
-	if(remove_temp_kline(source_p, aconf))
-		return;
+		if(remove_temp_kline(source_p, aconf))
+			continue;
 
-	remove_permkline_match(source_p, aconf);
+		remove_permkline_match(source_p, aconf);
+	} while (aconf = find_exact_conf_by_address(host, CONF_KILL, user), aconf != NULL);
 }
 
 /* ms_unkline()
@@ -482,16 +485,20 @@ handle_remote_unkline(struct Client *source_p, const char *user, const char *hos
 		sendto_one_notice(source_p, ":No K-Line for %s@%s", user, host);
 		return;
 	}
-	if(aconf->lifetime)
+
+	do
 	{
-		sendto_one_notice(source_p, ":Cannot remove global K-Line %s@%s on specific servers", user, host);
-		return;
-	}
+		if(aconf->lifetime)
+		{
+			sendto_one_notice(source_p, ":Cannot remove global K-Line %s@%s on specific servers", user, host);
+			continue;
+		}
 
-	if(remove_temp_kline(source_p, aconf))
-		return;
+		if(remove_temp_kline(source_p, aconf))
+			continue;
 
-	remove_permkline_match(source_p, aconf);
+		remove_permkline_match(source_p, aconf);
+	} while (aconf = find_exact_conf_by_address(host, CONF_KILL, user), aconf != NULL);
 }
 
 /* apply_kline()


### PR DESCRIPTION
I've also made /kline delete any matching temporary non-propagated K-lines (as effectively happened for propagated ones already) since otherwise this would make it very easy to add duplicates, and made /unkline able to delete multiple matches—while I don't know that there's any way to add unlimited duplicate K-lines, one can add two (a propagated K-line and a longer local K-line, for instance).

The propagated K-line logic already handles extensions adequately; `replace_old_ban` will ensure they win out over the extendee. You just couldn't tell /kline to do them until now.