### PR TITLE
Remove the CLIENTVER 005 token.

### DIFF
--- a/ircd/supported.c
+++ b/ircd/supported.c
@@ -326,7 +326,6 @@ init_isupport(void)
 	add_isupport("DEAF", isupport_umode, "D");
 	add_isupport("TARGMAX", isupport_targmax, NULL);
 	add_isupport("EXTBAN", isupport_extban, NULL);
-	add_isupport("CLIENTVER", isupport_string, "3.0");
 }
 
 void


### PR DESCRIPTION
This was introduced in commit bde6442c47 but the rationale for it is pretty shaky. 

No other non-Charybdis-derived servers send it and the features the original commit claims it can be used to detect all have
their own methods of detection. 

The concept of "core capabilities" and versioned releases was also dropped by IRCv3 many years ago in favour of living specifications.