### PR TITLE
Port m_invex_regonly from ircd-seven

### DIFF
--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -68,6 +68,7 @@ extension_LTLIBRARIES =		\
   drain.la			\
   identify_msg.la		\
   cap_realhost.la		\
+  m_invex_regonly.la		\
   example_module.la
 
 if HAVE_HYPERSCAN

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -68,7 +68,7 @@ extension_LTLIBRARIES =		\
   drain.la			\
   identify_msg.la		\
   cap_realhost.la		\
-  m_invex_regonly.la		\
+  invex_regonly.la		\
   example_module.la
 
 if HAVE_HYPERSCAN

--- a/extensions/invex_regonly.c
+++ b/extensions/invex_regonly.c
@@ -26,12 +26,12 @@ h_can_join(hook_data_channel *data)
 	struct matchset ms;
 	rb_dlink_node *ptr;
 	
-	matchset_for_client(source_p, &ms);
-
 	if(data->approved != ERR_NEEDREGGEDNICK)
 		return;
 	if(!ConfigChannel.use_invex)
 		return;
+
+	matchset_for_client(source_p, &ms);
 
 	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
 	{
@@ -43,4 +43,3 @@ h_can_join(hook_data_channel *data)
 	if(ptr != NULL)
 		data->approved=0;
 }
-

--- a/extensions/invex_regonly.c
+++ b/extensions/invex_regonly.c
@@ -35,10 +35,10 @@ h_can_join(hook_data_channel *data)
 
 	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
 	{
-	invex = ptr->data;
-	if (matches_mask(&ms, invex->banstr) ||
-			match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
-				break;
+		invex = ptr->data;
+		if (matches_mask(&ms, invex->banstr) ||
+				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
+			break;
 	}
 	if(ptr != NULL)
 		data->approved=0;

--- a/extensions/invex_regonly.c
+++ b/extensions/invex_regonly.c
@@ -38,8 +38,9 @@ h_can_join(hook_data_channel *data)
 		invex = ptr->data;
 		if (matches_mask(&ms, invex->banstr) ||
 				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
+		{
+			data->approved = 0;
 			break;
+		}
 	}
-	if(ptr != NULL)
-		data->approved=0;
 }

--- a/extensions/invex_regonly.c
+++ b/extensions/invex_regonly.c
@@ -1,5 +1,5 @@
 /*
- * m_invex_regonly.c Allow invite exemptions to bypass registered-only (+r)
+ * invex_regonly.c Allow invite exemptions to bypass registered-only (+r)
  */
 #include "stdinc.h"
 #include "modules.h"

--- a/extensions/m_invex_regonly.c
+++ b/extensions/m_invex_regonly.c
@@ -1,0 +1,72 @@
+/*
+ * m_invex_regonly.c Allow invite exemptions to bypass registered-only (+r)
+ */
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "channel.h"
+#include "s_conf.h"
+#include "numeric.h"
+
+static void h_can_join(hook_data_channel *);
+
+mapi_hfn_list_av1 invex_regonly_hfnlist[] = {
+	{ "can_join", (hookfn) h_can_join },
+	{ NULL, NULL }
+};
+
+DECLARE_MODULE_AV1(invex_regonly, NULL, NULL, NULL, NULL, invex_regonly_hfnlist, "$Revision$");
+
+static void
+h_can_join(hook_data_channel *data)
+{
+	struct Client *source_p = data->client;
+	struct Channel *chptr = data->chptr;
+	struct Ban *invex = NULL;
+	rb_dlink_node *ptr;
+	char src_host[NICKLEN + USERLEN + HOSTLEN + 6];
+	char src_iphost[NICKLEN + USERLEN + HOSTLEN + 6];
+	char src_althost[NICKLEN + USERLEN + HOSTLEN + 6];
+
+	int use_althost = 0;
+
+
+	if(data->approved == ERR_NEEDREGGEDNICK) {
+		if(!ConfigChannel.use_invex)
+				return;
+
+		sprintf(src_host, "%s!%s@%s", source_p->name, source_p->username, source_p->host);
+		sprintf(src_iphost, "%s!%s@%s", source_p->name, source_p->username, source_p->sockhost);
+		if(source_p->localClient->mangledhost != NULL)
+		{
+			/* if host mangling mode enabled, also check their real host */
+			if(!strcmp(source_p->host, source_p->localClient->mangledhost))
+			{
+				sprintf(src_althost, "%s!%s@%s", source_p->name, source_p->username, source_p->orighost);
+				use_althost = 1;
+			}
+			/* if host mangling mode not enabled and no other spoof,
+		  	* also check the mangled form of their host */
+			else if (!IsDynSpoof(source_p))
+			{
+				sprintf(src_althost, "%s!%s@%s", source_p->name, source_p->username, source_p->localClient->mangledhost);
+				use_althost = 1;
+			}
+		}
+
+		RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
+		{
+			invex = ptr->data;
+			if(match(invex->banstr, src_host)
+			   || match(invex->banstr, src_iphost)
+			   || match_cidr(invex->banstr, src_iphost)
+			   || match_extban(invex->banstr, source_p, chptr, CHFL_INVEX)
+			   || (use_althost && match(invex->banstr, src_althost)))
+				break;
+		}
+		if(ptr != NULL)
+			data->approved=0;
+	}
+
+}
+

--- a/extensions/m_invex_regonly.c
+++ b/extensions/m_invex_regonly.c
@@ -23,49 +23,24 @@ h_can_join(hook_data_channel *data)
 	struct Client *source_p = data->client;
 	struct Channel *chptr = data->chptr;
 	struct Ban *invex = NULL;
+	struct matchset ms;
 	rb_dlink_node *ptr;
-	char src_host[NICKLEN + USERLEN + HOSTLEN + 6];
-	char src_iphost[NICKLEN + USERLEN + HOSTLEN + 6];
-	char src_althost[NICKLEN + USERLEN + HOSTLEN + 6];
-
-	int use_althost = 0;
-
+	
+	matchset_for_client(source_p, &ms);
 
 	if(data->approved == ERR_NEEDREGGEDNICK) {
 		if(!ConfigChannel.use_invex)
 				return;
 
-		sprintf(src_host, "%s!%s@%s", source_p->name, source_p->username, source_p->host);
-		sprintf(src_iphost, "%s!%s@%s", source_p->name, source_p->username, source_p->sockhost);
-		if(source_p->localClient->mangledhost != NULL)
-		{
-			/* if host mangling mode enabled, also check their real host */
-			if(!strcmp(source_p->host, source_p->localClient->mangledhost))
-			{
-				sprintf(src_althost, "%s!%s@%s", source_p->name, source_p->username, source_p->orighost);
-				use_althost = 1;
-			}
-			/* if host mangling mode not enabled and no other spoof,
-		  	* also check the mangled form of their host */
-			else if (!IsDynSpoof(source_p))
-			{
-				sprintf(src_althost, "%s!%s@%s", source_p->name, source_p->username, source_p->localClient->mangledhost);
-				use_althost = 1;
-			}
-		}
-
-		RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
-		{
-			invex = ptr->data;
-			if(match(invex->banstr, src_host)
-			   || match(invex->banstr, src_iphost)
-			   || match_cidr(invex->banstr, src_iphost)
-			   || match_extban(invex->banstr, source_p, chptr, CHFL_INVEX)
-			   || (use_althost && match(invex->banstr, src_althost)))
-				break;
-		}
-		if(ptr != NULL)
-			data->approved=0;
+	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
+	{
+		invex = ptr->data;
+		if (matches_mask(&ms, invex->banstr) ||
+				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
+					break;
+	}
+	if(ptr != NULL)
+		data->approved=0;
 	}
 
 }

--- a/extensions/m_invex_regonly.c
+++ b/extensions/m_invex_regonly.c
@@ -28,19 +28,19 @@ h_can_join(hook_data_channel *data)
 	
 	matchset_for_client(source_p, &ms);
 
-	if(data->approved == ERR_NEEDREGGEDNICK) {
-		if(!ConfigChannel.use_invex)
-				return;
+	if(data->approved != ERR_NEEDREGGEDNICK)
+		return;
+	if(!ConfigChannel.use_invex)
+		return;
 
-		RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
-		{
-		invex = ptr->data;
-		if (matches_mask(&ms, invex->banstr) ||
-				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
-					break;
-		}
-		if(ptr != NULL)
-			data->approved=0;
+	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
+	{
+	invex = ptr->data;
+	if (matches_mask(&ms, invex->banstr) ||
+			match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
+				break;
 	}
+	if(ptr != NULL)
+		data->approved=0;
 }
 

--- a/extensions/m_invex_regonly.c
+++ b/extensions/m_invex_regonly.c
@@ -32,16 +32,15 @@ h_can_join(hook_data_channel *data)
 		if(!ConfigChannel.use_invex)
 				return;
 
-	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
-	{
+		RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
+		{
 		invex = ptr->data;
 		if (matches_mask(&ms, invex->banstr) ||
 				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
 					break;
+		}
+		if(ptr != NULL)
+			data->approved=0;
 	}
-	if(ptr != NULL)
-		data->approved=0;
-	}
-
 }
 


### PR DESCRIPTION
This module allows +I to be used to bypass +r (registered only) as well as +i (invite only).