### PR TITLE
modules/m_sasl.c: use IsSecure() instead of IsSSL()

### DIFF
--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -202,7 +202,7 @@ m_authenticate(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *
 		sendto_one(saslserv_p, ":%s ENCAP %s SASL %s %s H %s %s %c",
 					me.id, saslserv_p->servptr->name, source_p->id, saslserv_p->id,
 					source_p->host, source_p->sockhost,
-					IsSSL(source_p) ? 'S' : 'P');
+					IsSecure(source_p) ? 'S' : 'P');
 
 		if (source_p->certfp != NULL)
 			sendto_one(saslserv_p, ":%s ENCAP %s SASL %s %s S %s %s",


### PR DESCRIPTION
Further to our implementation of the concept of "secure origins", we can indicate to services that the client is connected securely, rather than just that the client is using TLS. For example, connections from the local host (from the IRCd's perspective) can be considered secure against eavesdropping.

Allow this to factor into services' decision on whether to allow an SASL negotiation or not. Atheme currently assumes this means the client is using TLS, but I have changed that in atheme/atheme@412d50103c1d8c2a