### PR TITLE
authd: substitute * if rewritten user is empty

### DIFF
--- a/authd/providers/ident.c
+++ b/authd/providers/ident.c
@@ -159,6 +159,12 @@ read_ident_reply(rb_fde_t *F, void *data)
 			message = REPORT_INVALID;
 	}
 
+	if (*auth->username == '\0')
+	{
+		auth->username[0] = '*';
+		auth->username[1] = '\0';
+	}
+
 	if(s == NULL)
 		client_fail(auth, message);
 	else


### PR DESCRIPTION
We remove characters like ^ and ~ from the ident string after checking
if it's valid. If it consisted entirely of those, we'd try to send an
empty string to ircd, which would break the protocol, so don't let that
happen.