### PR TITLE
msgbuf: use only relevant caps for the cache key

### DIFF
--- a/ircd/msgbuf.c
+++ b/ircd/msgbuf.c
@@ -443,6 +443,8 @@ msgbuf_cache_get(struct MsgBuf_cache *cache, unsigned int caps)
 	struct MsgBuf_cache_entry *tail = NULL;
 	int n = 0;
 
+	caps &= cache->overall_capmask;
+
 	while (entry != NULL) {
 		if (entry->caps == caps) {
 			/* Cache hit */


### PR DESCRIPTION
Given cache->overall_capmask was already computed, but not used, I haved a feeling that this was always planned but the original implementers forgot about it. Without this change, messages to large channels with diverse clients consistently cause _many_ cache evictions; with it they never do.

Reviewers: the `caps` parameter we're modifying eventually makes its way to `msgbuf_unparse_tags`, where it's &ed with `msgbuf->tags[foo].capmask`, the same field whose | makes up overall_capmask. Given that, I think any bits in caps that aren't in overall_capmask will never be used anyway.