### PR TITLE
m_stats: when viewing self using /STATS l|L, show real hostname or IP

### DIFF
--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -1654,7 +1654,7 @@ stats_l_client(struct Client *source_p, struct Client *target_p,
 	else
 	{
 		sendto_one_numeric(source_p, RPL_STATSLINKINFO, Lformat,
-				   show_ip(source_p, target_p) ?
+				   (show_ip(source_p, target_p) || source_p == target_p) ?
 				    (IsUpper(statchar) ?
 				     get_client_name(target_p, SHOW_IP) :
 				     get_client_name(target_p, HIDE_IP)) :


### PR DESCRIPTION
Closes #191.

It probably makes sense to show you your own IP and/or hostname when using /STATS l or /STATS L. You can't see other people anyway, and this brings the behaviour in line with /WHOIS (namely the line that shows you your real IP).