### PR TITLE
Force close listener sockets during rehash

### DIFF
--- a/ircd/listener.c
+++ b/ircd/listener.c
@@ -480,6 +480,7 @@ close_listeners()
 		listener_next = listener->next;
 		close_listener(listener);
 	}
+	rb_select(1);
 }
 
 /*


### PR DESCRIPTION
On both Solaris 11.4 and also Illumos-based distributions (eg, OmniOSce), rehashing the ircd.conf using either /rehash or kill -HUP causes the daemon to not be able to rebind to the listener sockets, and then new inbound connections just hang.

This seems to be caused by the fact that rb_close() just shuts down the sockets, but they don't end up being close()ed before it attempts to re-bind().  This bug seems to have been in charybdis also.

This patch forces the cleanup by calling rb_select() at the end of close_listeners().  rb_select() calls free_fds(), which probably closes the listener sockets.  The bind()s then work.

This is kind of a dirty hack.  A cleaner fix would be to probably rename free_fds() to rb_free_fds() and then export that symbol and call that directly instead of rb_select().  (ab)using rb_select() seems to be less disruptive, however.

If you'd prefer to free_fds() change, however, I can do that instead.