### PR TITLE
Remove unneeded ugly hack for 32-bit Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ These are known issues and workarounds for various platforms.
    fix this you must: `sysctl net.inet6.ip6.v6only=0`
 
  * **Solaris**: you may have to set your `PATH` to include `/usr/gnu/bin` and `/usr/gnu/sbin` before `/usr/bin`
-   and `/usr/sbin`. Solaris's default tools don't seem to play nicely with the configure script.
+   and `/usr/sbin`. Solaris's default tools don't seem to play nicely with the configure script. When running
+   as a 32-bit binary, it should be started as:
+
+   ```bash
+   ulimit -n 4095 ; LD_PRELOAD_32=/usr/lib/extendedFILE.so.1 ./solanum
+   ```
 
 # building
 


### PR DESCRIPTION
- The official Sun/Oracle solution is to use the extendedFILE(5)
  mechanism, which works around the limitation.
  https://docs.oracle.com/cd/E18752_01/html/816-5175/extendedfile-5.html
- Add a quick HOWTO to the README.md