### PR TITLE
remove trailing space from umode help file

### DIFF
--- a/help/users/umode
+++ b/help/users/umode
@@ -11,7 +11,7 @@ User modes: (? designates that the umode is provided by an extension
        ? +h     - Has a cloaked host. May be +x depending on cloaking module
          +g     - Deny users not on your /ACCEPT list from messaging you and
                   inviting you to channels.
-       ? +u     - Receive messages that are filtered server side based 
+       ? +u     - Receive messages that are filtered server side based
                   on content.
          +w     - Can see oper wallops.
        ? +C     - Prevents you from receiving CTCPs other than ACTION.


### PR DESCRIPTION
currently, this space breaks rendering in at least one client:

Quassel issue: https://bugs.quassel-irc.org/issues/1733