### PR TITLE
A bunch of fixes

### DIFF
--- a/authd/providers/opm.c
+++ b/authd/providers/opm.c
@@ -25,6 +25,9 @@
 #include "authd.h"
 #include "notice.h"
 #include "provider.h"
+#ifdef HAVE_NETINET_TCP_H
+#include <netinet/tcp.h>
+#endif
 
 #define SELF_PID (opm_provider.id)
 

--- a/authd/reslib.c
+++ b/authd/reslib.c
@@ -1164,7 +1164,6 @@ irc_res_mkquery(
 	  return (-1);
 
 	cp += n;
-	buflen -= n;
 	IRC_NS_PUT16(type, cp);
 	IRC_NS_PUT16(class, cp);
 	hp->qdcount = htons(1);

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_STDBOOL
 
-AC_CHECK_HEADERS([crypt.h sys/resource.h sys/param.h errno.h sys/syslog.h stddef.h sys/wait.h wait.h sys/epoll.h sys/uio.h machine/endian.h])
+AC_CHECK_HEADERS([crypt.h sys/resource.h sys/param.h errno.h sys/syslog.h stddef.h sys/wait.h wait.h sys/epoll.h sys/uio.h machine/endian.h netinet/tcp.h])
 
 dnl Stuff that the memory manager (imalloc) depends on
 dnl ==================================================

--- a/extensions/filter.c
+++ b/extensions/filter.c
@@ -341,7 +341,7 @@ unsigned match_message(const char *prefix,
                        const char *target,
                        const char *msg)
 {
-	unsigned state = 0;
+	unsigned context = 0;
 	if (!filter_enable)
 		return 0;
 	if (!filter_db)
@@ -370,10 +370,10 @@ unsigned match_message(const char *prefix,
 	         target ? " " : "",
 	         target ? target : "",
 	         msg);
-	hs_error_t r = hs_scan(filter_db, check_buffer, strlen(check_buffer), 0, filter_scratch, match_callback, &state);
+	hs_error_t r = hs_scan(filter_db, check_buffer, strlen(check_buffer), 0, filter_scratch, match_callback, &context);
 	if (r != HS_SUCCESS && r != HS_SCAN_TERMINATED)
 		return 0;
-	return state;
+	return context;
 }
 
 void

--- a/extensions/hurt.c
+++ b/extensions/hurt.c
@@ -203,7 +203,7 @@ mo_hurt(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	if (!expire)
 		expire_time = HURT_DEFAULT_EXPIRE;
-	if (expire && (expire_time = valid_temp_time(expire)) < 1) {
+	else if ((expire_time = valid_temp_time(expire)) < 1) {
 		sendto_one_notice(source_p, ":Permanent HURTs are not supported");
 		return;
 	}

--- a/extensions/ip_cloaking.c
+++ b/extensions/ip_cloaking.c
@@ -77,7 +77,7 @@ static void
 do_host_cloak_ip(const char *inbuf, char *outbuf)
 {
 	/* None of the characters in this table can be valid in an IP */
-	char chartable[] = "ghijklmnopqrstuvwxyz";
+	const char chartable[] = "ghijklmnopqrstuvwxyz";
 	char *tptr;
 	uint32_t accum = fnv_hash((const unsigned char*) inbuf, 32);
 	int sepcount = 0;
@@ -127,7 +127,7 @@ do_host_cloak_ip(const char *inbuf, char *outbuf)
 static void
 do_host_cloak_host(const char *inbuf, char *outbuf)
 {
-	char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
+	const char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
 	char *tptr;
 	uint32_t accum = fnv_hash((const unsigned char*) inbuf, 32);
 

--- a/extensions/ip_cloaking_3.0.c
+++ b/extensions/ip_cloaking_3.0.c
@@ -136,7 +136,7 @@ do_host_cloak_ip(const char *inbuf, char *outbuf)
 static void
 do_host_cloak_host(const char *inbuf, char *outbuf)
 {
-	char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
+	const char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
 	char *tptr;
 	unsigned int accum = get_string_weighted_entropy(inbuf);
 

--- a/extensions/ip_cloaking_4.0.c
+++ b/extensions/ip_cloaking_4.0.c
@@ -77,7 +77,7 @@ static void
 do_host_cloak_ip(const char *inbuf, char *outbuf)
 {
 	/* None of the characters in this table can be valid in an IP */
-	char chartable[] = "ghijklmnopqrstuvwxyz";
+	const char chartable[] = "ghijklmnopqrstuvwxyz";
 	char *tptr;
 	uint32_t accum = fnv_hash((const unsigned char*) inbuf, 32);
 	int sepcount = 0;
@@ -127,7 +127,7 @@ do_host_cloak_ip(const char *inbuf, char *outbuf)
 static void
 do_host_cloak_host(const char *inbuf, char *outbuf)
 {
-	char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
+	const char b26_alphabet[] = "abcdefghijklmnopqrstuvwxyz";
 	char *tptr;
 	uint32_t accum = fnv_hash((const unsigned char*) inbuf, 32);
 

--- a/include/hash.h
+++ b/include/hash.h
@@ -73,17 +73,17 @@ extern uint32_t fnv_hash_upper_len(const unsigned char *s, int bits, int len);
 extern void init_hash(void);
 
 extern void add_to_client_hash(const char *name, struct Client *client);
-extern void del_from_client_hash(const char *name, struct Client *client);
+extern void del_from_client_hash(const char *name, const struct Client *client);
 extern struct Client *find_client(const char *name);
 extern struct Client *find_named_client(const char *name);
 extern struct Client *find_server(struct Client *source_p, const char *name);
 
 extern void add_to_id_hash(const char *, struct Client *);
-extern void del_from_id_hash(const char *name, struct Client *client);
+extern void del_from_id_hash(const char *name, const struct Client *client);
 extern struct Client *find_id(const char *name);
 
 extern struct Channel *get_or_create_channel(struct Client *client_p, const char *chname, bool *isnew);
-extern void del_from_channel_hash(const char *name, struct Channel *chan);
+extern void del_from_channel_hash(const char *name, const struct Channel *chan);
 extern struct Channel *find_channel(const char *name);
 
 extern void add_to_hostname_hash(const char *, struct Client *);
@@ -91,7 +91,7 @@ extern void del_from_hostname_hash(const char *, struct Client *);
 extern rb_dlink_node *find_hostname(const char *);
 
 extern void add_to_resv_hash(const char *name, struct ConfItem *aconf);
-extern void del_from_resv_hash(const char *name, struct ConfItem *aconf);
+extern void del_from_resv_hash(const char *name, const struct ConfItem *aconf);
 extern struct ConfItem *hash_find_resv(const char *name);
 extern void clear_resv_hash(void);
 

--- a/include/send.h
+++ b/include/send.h
@@ -70,7 +70,7 @@ extern void sendto_common_channels_local(struct Client *, int cap, int negcap, c
 extern void sendto_common_channels_local_butone(struct Client *, int cap, int negcap, const char *, ...) AFP(4, 5);
 
 
-extern void sendto_match_butone(struct Client *, struct Client *,
+extern void sendto_match_butone(const struct Client *, struct Client *,
 				const char *, int, const char *, ...) AFP(5, 6);
 extern void sendto_match_servs(struct Client *source_p, const char *mask,
 				int capab, int, const char *, ...) AFP(5, 6);

--- a/ircd/authproc.c
+++ b/ircd/authproc.c
@@ -422,7 +422,7 @@ check_authd(void)
 static inline uint32_t
 generate_cid(void)
 {
-	if(++cid == 0)
+	if(cid++ == UINT32_MAX)
 		cid = 1;
 
 	return cid;

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -793,7 +793,6 @@ can_send(struct Channel *chptr, struct Client *source_p, struct membership *mspt
 	hook_data_channel_approval moduledata;
 
 	moduledata.approved = CAN_SEND_NONOP;
-	moduledata.dir = MODE_QUERY;
 
 	if(IsServer(source_p) || IsService(source_p))
 		return CAN_SEND_OPV;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -373,7 +373,7 @@ pretty_mask(const char *idmask)
 	static char mask_buf[BUFSIZE];
 	int old_mask_pos;
 	const char *nick, *user, *host, *forward = NULL;
-	char *t, *at, *ex;
+	char *t, *at, *ex = NULL;
 	int nl, ul, hl, fl;
 	char *mask;
 	size_t masklen;
@@ -405,7 +405,6 @@ pretty_mask(const char *idmask)
 		return mask_buf + old_mask_pos;
 	}
 
-	at = ex = NULL;
 	if((t = memchr(mask, '@', masklen)) != NULL)
 	{
 		at = t;
@@ -1336,10 +1335,10 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 	int parn = 1;
 	int errors = 0;
 	int alevel;
-	const char *ml = parv[0];
+	const char *ml;
 	char c;
 	struct Client *fakesource_p;
-	int flags_list[3] = { ALL_MEMBERS, ONLY_CHANOPS, ONLY_OPERS };
+	const int flags_list[3] = { ALL_MEMBERS, ONLY_CHANOPS, ONLY_OPERS };
 	int mode_limit = 0;
 	int mode_limit_simple = 0;
 

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1248,7 +1248,7 @@ recurse_remove_clients(struct Client *source_p, const char *comment)
 ** and its SQUITs have been sent except for the upstream one  -orabidoo
  */
 static void
-remove_dependents(struct Client *client_p,
+remove_dependents(const struct Client *client_p,
 		  struct Client *source_p,
 		  struct Client *from, const char *comment, const char *comment1)
 {

--- a/ircd/hash.c
+++ b/ircd/hash.c
@@ -202,7 +202,7 @@ add_to_resv_hash(const char *name, struct ConfItem *aconf)
  * removes an id from the id hash table
  */
 void
-del_from_id_hash(const char *id, struct Client *client_p)
+del_from_id_hash(const char *id, const struct Client *client_p)
 {
 	s_assert(id != NULL);
 	s_assert(client_p != NULL);
@@ -217,7 +217,7 @@ del_from_id_hash(const char *id, struct Client *client_p)
  * removes a client/server from the client hash table
  */
 void
-del_from_client_hash(const char *name, struct Client *client_p)
+del_from_client_hash(const char *name, const struct Client *client_p)
 {
 	/* no s_asserts, this can happen when removing a client that
 	 * is unregistered.
@@ -233,7 +233,7 @@ del_from_client_hash(const char *name, struct Client *client_p)
  * removes a channel from the channel hash table
  */
 void
-del_from_channel_hash(const char *name, struct Channel *chptr)
+del_from_channel_hash(const char *name, const struct Channel *chptr)
 {
 	s_assert(name != NULL);
 	s_assert(chptr != NULL);
@@ -274,7 +274,7 @@ del_from_hostname_hash(const char *hostname, struct Client *client_p)
  * removes a resv entry from the resv hash table
  */
 void
-del_from_resv_hash(const char *name, struct ConfItem *aconf)
+del_from_resv_hash(const char *name, const struct ConfItem *aconf)
 {
 	s_assert(name != NULL);
 	s_assert(aconf != NULL);

--- a/ircd/msgbuf.c
+++ b/ircd/msgbuf.c
@@ -427,9 +427,9 @@ void
 msgbuf_cache_initf(struct MsgBuf_cache *cache, const struct MsgBuf *msgbuf, const rb_strf_t *message, const char *format, ...)
 {
 	va_list va;
-	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 
 	va_start(va, format);
+	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 	msgbuf_cache_init(cache, msgbuf, &strings);
 	va_end(va);
 }

--- a/ircd/packet.c
+++ b/ircd/packet.c
@@ -43,7 +43,7 @@ static void client_dopacket(struct Client *client_p, char *buffer, size_t length
 static void
 parse_client_queued(struct Client *client_p)
 {
-	int dolen = 0;
+	int dolen;
 	int allow_read;
 
 	if(IsAnyDead(client_p))
@@ -238,7 +238,7 @@ void
 read_packet(rb_fde_t * F, void *data)
 {
 	struct Client *client_p = data;
-	int length = 0;
+	int length;
 	int binary = 0;
 
 	while(1)

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -426,6 +426,9 @@ do_numeric(int numeric, struct Client *client_p, struct Client *source_p, int pa
 {
 	struct Client *target_p;
 	struct Channel *chptr;
+	char *t = buffer;	/* Current position within the buffer */
+	int i;
+	int tl;			/* current length of presently being built string in t */
 
 	if(parc < 2 || !IsServer(source_p))
 		return;
@@ -441,18 +444,12 @@ do_numeric(int numeric, struct Client *client_p, struct Client *source_p, int pa
 	 * assumptions--bets are off, if these are changed --msa)
 	 * Note: if buffer is non-empty, it will begin with SPACE.
 	 */
-	if(parc > 1)
+	for (i = 2; i < (parc - 1); i++)
 	{
-		char *t = buffer;	/* Current position within the buffer */
-		int i;
-		int tl;		/* current length of presently being built string in t */
-		for (i = 2; i < (parc - 1); i++)
-		{
-			tl = sprintf(t, " %s", parv[i]);
-			t += tl;
-		}
-		sprintf(t, " :%s", parv[parc - 1]);
+		tl = sprintf(t, " %s", parv[i]);
+		t += tl;
 	}
+	sprintf(t, " :%s", parv[parc - 1]);
 
 	if((target_p = find_client(parv[1])) != NULL)
 	{

--- a/ircd/privilege.c
+++ b/ircd/privilege.c
@@ -142,7 +142,7 @@ privilegeset_add_privilegeset(struct PrivilegeSet *dst, const struct PrivilegeSe
 
 	if (dst->priv_storage == NULL)
 	{
-		dst->stored_size = dst->allocated_size = 0;
+		dst->allocated_size = 0;
 		cur_size = 0;
 		alloc_size = 256;
 	}
@@ -330,8 +330,7 @@ privilegeset_diff(const struct PrivilegeSet *old, const struct PrivilegeSet *new
 	static struct PrivilegeSet *set_unchanged = NULL,
 	                           *set_added = NULL,
 	                           *set_removed = NULL;
-	static size_t n_privs = 0;
-	size_t new_size = n_privs ? n_privs : 32;
+	size_t new_size = 32;
 	size_t i = 0, j = 0;
 
 	if (set_unchanged == NULL)
@@ -349,12 +348,9 @@ privilegeset_diff(const struct PrivilegeSet *old, const struct PrivilegeSet *new
 	while (new_size < MAX(old->size, new->size) + 1)
 		new_size *= 2;
 
-	if (new_size > n_privs)
-	{
-		set_unchanged->privs = rb_realloc(set_unchanged->privs, sizeof *set_unchanged->privs * new_size);
-		set_added->privs = rb_realloc(set_added->privs, sizeof *set_added->privs * new_size);
-		set_removed->privs = rb_realloc(set_removed->privs, sizeof *set_removed->privs * new_size);
-	}
+	set_unchanged->privs = rb_realloc(set_unchanged->privs, sizeof *set_unchanged->privs * new_size);
+	set_added->privs = rb_realloc(set_added->privs, sizeof *set_added->privs * new_size);
+	set_removed->privs = rb_realloc(set_removed->privs, sizeof *set_removed->privs * new_size);
 
 	const char **res_unchanged = set_unchanged->privs;
 	const char **res_added = set_added->privs;

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -351,7 +351,7 @@ register_local_user(struct Client *client_p, struct Client *source_p)
 	char tmpstr2[BUFSIZE];
 	char ipaddr[HOSTIPLEN];
 	char myusername[USERLEN+1];
-	int status, umodes;
+	int umodes;
 
 	s_assert(NULL != source_p);
 	s_assert(MyConnect(source_p));
@@ -410,7 +410,7 @@ register_local_user(struct Client *client_p, struct Client *source_p)
 	else
 		rb_strlcpy(myusername, source_p->username, sizeof myusername);
 
-	if((status = check_client(client_p, source_p, myusername)) < 0)
+	if(check_client(client_p, source_p, myusername) < 0)
 		return (CLIENT_EXITED);
 
 	/* Apply nick override */

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -232,9 +232,9 @@ static void
 linebuf_put_tagsf(buf_head_t *linebuf, const struct MsgBuf *msgbuf, const struct Client *target_p, const rb_strf_t *message, const char *format, ...)
 {
 	va_list va;
-	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 
 	va_start(va, format);
+	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 	linebuf_put_tags(linebuf, msgbuf, target_p, &strings);
 	va_end(va);
 }
@@ -250,9 +250,9 @@ static void
 linebuf_put_msgf(buf_head_t *linebuf, const rb_strf_t *message, const char *format, ...)
 {
 	va_list va;
-	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 
 	va_start(va, format);
+	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
 	linebuf_put_msg(linebuf, &strings);
 	va_end(va);
 }
@@ -289,7 +289,6 @@ sendto_one(struct Client *target_p, const char *pattern, ...)
 	va_list args;
 	struct MsgBuf msgbuf;
 	buf_head_t linebuf;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	/* send remote if to->from non NULL */
 	if(target_p->from != NULL)
@@ -302,6 +301,7 @@ sendto_one(struct Client *target_p, const char *pattern, ...)
 
 	build_msgbuf_tags(&msgbuf, &me);
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_tags(&linebuf, &msgbuf, target_p, &strings);
 	va_end(args);
 
@@ -324,7 +324,6 @@ sendto_one_prefix(struct Client *target_p, struct Client *source_p,
 	va_list args;
 	struct MsgBuf msgbuf;
 	buf_head_t linebuf;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	if(IsIOError(dest_p))
 		return;
@@ -339,6 +338,7 @@ sendto_one_prefix(struct Client *target_p, struct Client *source_p,
 
 	rb_linebuf_newbuf(&linebuf);
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_tagsf(&linebuf, &msgbuf, target_p, &strings,
 		":%s %s %s ", get_id(source_p, target_p),
 		command, get_id(target_p, target_p));
@@ -361,7 +361,6 @@ sendto_one_notice(struct Client *target_p, const char *pattern, ...)
 	va_list args;
 	struct MsgBuf msgbuf;
 	buf_head_t linebuf;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	char *to;
 
 	if(IsIOError(dest_p))
@@ -377,6 +376,7 @@ sendto_one_notice(struct Client *target_p, const char *pattern, ...)
 
 	rb_linebuf_newbuf(&linebuf);
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_tagsf(&linebuf, &msgbuf, target_p, &strings,
 		":%s NOTICE %s ", get_id(&me, target_p),
 		*(to = get_id(target_p, target_p)) != '\0' ? to : "*");
@@ -400,7 +400,6 @@ sendto_one_numeric(struct Client *target_p, int numeric, const char *pattern, ..
 	va_list args;
 	struct MsgBuf msgbuf;
 	buf_head_t linebuf;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	char *to;
 
 	if(IsIOError(dest_p))
@@ -416,6 +415,7 @@ sendto_one_numeric(struct Client *target_p, int numeric, const char *pattern, ..
 
 	rb_linebuf_newbuf(&linebuf);
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_tagsf(&linebuf, &msgbuf, target_p, &strings,
 		":%s %03d %s ", get_id(&me, target_p), numeric,
 		*(to = get_id(target_p, target_p)) != '\0' ? to : "*");
@@ -451,7 +451,6 @@ sendto_server(struct Client *one, struct Channel *chptr, unsigned long caps,
 	rb_dlink_node *ptr;
 	rb_dlink_node *next_ptr;
 	buf_head_t linebuf;
-	rb_strf_t strings = { .format = format, .format_args = &args, .next = NULL };
 
 	/* noone to send to.. */
 	if(rb_dlink_list_length(&serv_list) == 0)
@@ -462,6 +461,7 @@ sendto_server(struct Client *one, struct Channel *chptr, unsigned long caps,
 
 	rb_linebuf_newbuf(&linebuf);
 	va_start(args, format);
+	rb_strf_t strings = { .format = format, .format_args = &args, .next = NULL };
 	linebuf_put_msg(&linebuf, &strings);
 	va_end(args);
 
@@ -753,7 +753,7 @@ sendto_channel_local(struct Client *source_p, int type, struct Channel *chptr, c
  * Shared implementation of sendto_channel_local_with_capability and sendto_channel_local_with_capability_butone
  */
 static void
-_sendto_channel_local_with_capability_butone(struct Client *source_p, struct Client *one, int type,
+_sendto_channel_local_with_capability_butone(struct Client *source_p, const struct Client *one, int type,
 	int caps, int negcaps, struct Channel *chptr, const char *pattern, va_list * args)
 {
 	struct membership *msptr;
@@ -841,11 +841,11 @@ sendto_channel_local_butone(struct Client *one, int type, struct Channel *chptr,
 	rb_dlink_node *ptr;
 	rb_dlink_node *next_ptr;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, one);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, &strings);
 	va_end(args);
 
@@ -896,11 +896,11 @@ sendto_common_channels_local(struct Client *user, int cap, int negcap, const cha
 	struct membership *mscptr;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, user);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, &strings);
 	va_end(args);
 
@@ -963,11 +963,11 @@ sendto_common_channels_local_butone(struct Client *user, int cap, int negcap, co
 	struct membership *mscptr;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, user);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, &strings);
 	va_end(args);
 
@@ -1006,7 +1006,7 @@ sendto_common_channels_local_butone(struct Client *user, int cap, int negcap, co
  * side effects - message is sent to matching clients
  */
 void
-sendto_match_butone(struct Client *one, struct Client *source_p,
+sendto_match_butone(const struct Client *one, struct Client *source_p,
 		    const char *mask, int what, const char *pattern, ...)
 {
 	static char buf[BUFSIZE];
@@ -1142,11 +1142,11 @@ sendto_local_clients_with_capability(int cap, const char *pattern, ...)
 	struct Client *target_p;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, &me);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, &strings);
 	va_end(args);
 
@@ -1178,11 +1178,11 @@ sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *patt
 	rb_dlink_node *next_ptr;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, source_p);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, &strings);
 	va_end(args);
 
@@ -1358,11 +1358,11 @@ sendto_realops_snomask_from(int flags, int level, struct Client *source_p,
 	va_list args;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, &me);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	msgbuf_cache_initf(&msgbuf_cache, &msgbuf, &strings,
 		       ":%s NOTICE * :*** Notice -- ", source_p->name);
 	va_end(args);
@@ -1404,11 +1404,11 @@ sendto_wallops_flags(int flags, struct Client *source_p, const char *pattern, ..
 	va_list args;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, source_p);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	if (IsPerson(source_p)) {
 		msgbuf_cache_initf(&msgbuf_cache, &msgbuf, &strings,
 			       ":%s!%s@%s WALLOPS :", source_p->name,
@@ -1443,13 +1443,13 @@ kill_client(struct Client *target_p, struct Client *diedie, const char *pattern,
 	va_list args;
 	buf_head_t linebuf;
 	struct MsgBuf msgbuf;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	build_msgbuf_tags(&msgbuf, &me);
 
 	rb_linebuf_newbuf(&linebuf);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_tagsf(&linebuf, &msgbuf, target_p, &strings,
 		":%s KILL %s :", get_id(&me, target_p), get_id(diedie, target_p));
 	va_end(args);
@@ -1479,11 +1479,11 @@ kill_client_serv_butone(struct Client *one, struct Client *target_p, const char 
 	rb_dlink_node *ptr;
 	rb_dlink_node *next_ptr;
 	buf_head_t rb_linebuf_id;
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 
 	rb_linebuf_newbuf(&rb_linebuf_id);
 
 	va_start(args, pattern);
+	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
 	linebuf_put_msgf(&rb_linebuf_id, &strings, ":%s KILL %s :%s",
 		       use_id(&me), use_id(target_p), buf);
 	va_end(args);

--- a/librb/include/rb_balloc.h
+++ b/librb/include/rb_balloc.h
@@ -37,7 +37,7 @@ typedef void rb_bh_usage_cb (size_t bused, size_t bfree, size_t bmemusage, size_
 			     const char *desc, void *data);
 
 
-int rb_bh_free(rb_bh *, void *);
+int rb_bh_free(const rb_bh *, void *);
 void *rb_bh_alloc(rb_bh *);
 
 rb_bh *rb_bh_create(size_t elemsize, int elemsperblock, const char *desc);

--- a/librb/include/rb_dictionary.h
+++ b/librb/include/rb_dictionary.h
@@ -120,7 +120,7 @@ extern void rb_dictionary_foreach_start(rb_dictionary *dtree,
  * rb_dictionary_foreach_cur() returns the current element of the iteration,
  * or NULL if there are no more elements.
  */
-extern void *rb_dictionary_foreach_cur(rb_dictionary *dtree,
+extern void *rb_dictionary_foreach_cur(const rb_dictionary *dtree,
 	rb_dictionary_iter *state);
 
 /*

--- a/librb/include/rb_radixtree.h
+++ b/librb/include/rb_radixtree.h
@@ -120,12 +120,12 @@ extern void rb_radixtree_foreach_start_from(rb_radixtree *dtree, rb_radixtree_it
  * rb_radixtree_foreach_cur() returns the current element of the iteration,
  * or NULL if there are no more elements.
  */
-extern void *rb_radixtree_foreach_cur(rb_radixtree *dtree, rb_radixtree_iteration_state *state);
+extern void *rb_radixtree_foreach_cur(const rb_radixtree *dtree, rb_radixtree_iteration_state *state);
 
 /*
  * rb_radixtree_foreach_next() moves to the next element.
  */
-extern void rb_radixtree_foreach_next(rb_radixtree *dtree, rb_radixtree_iteration_state *state);
+extern void rb_radixtree_foreach_next(const rb_radixtree *dtree, rb_radixtree_iteration_state *state);
 
 /*
  * rb_radixtree_add() adds a key->value entry to the patricia tree.

--- a/librb/src/arc4random.c
+++ b/librb/src/arc4random.c
@@ -69,7 +69,7 @@ arc4_init(struct arc4_stream *as)
 }
 
 static inline void
-arc4_addrandom(struct arc4_stream *as, uint8_t *dat, int datlen)
+arc4_addrandom(struct arc4_stream *as, const uint8_t *dat, int datlen)
 {
 	int n;
 	uint8_t si;

--- a/librb/src/balloc.c
+++ b/librb/src/balloc.c
@@ -191,7 +191,7 @@ rb_bh_alloc(rb_bh *bh)
 /*    0 if successful, 1 if element not contained within rb_bh.           */
 /* ************************************************************************ */
 int
-rb_bh_free(rb_bh *bh, void *ptr)
+rb_bh_free(const rb_bh *bh, void *ptr)
 {
 	lrb_assert(bh != NULL);
 	lrb_assert(ptr != NULL);

--- a/librb/src/commio.c
+++ b/librb/src/commio.c
@@ -217,7 +217,6 @@ rb_set_nb(rb_fde_t *F)
 		return 0;
 #else
 	nonb = 1;
-	res = 0;
 	if(ioctl(fd, FIONBIO, (char *)&nonb) == -1)
 		return 0;
 #endif
@@ -2290,7 +2289,7 @@ rb_recv_fd_buf(rb_fde_t *F, void *data, size_t datasize, rb_fde_t **xF, int nfds
 	struct cmsghdr *cmsg;
 	struct iovec iov[1];
 	struct stat st;
-	uint8_t stype = RB_FD_UNKNOWN;
+	uint8_t stype;
 	const char *desc;
 	int fd, len, x, rfds;
 

--- a/librb/src/crypt.c
+++ b/librb/src/crypt.c
@@ -52,7 +52,7 @@ rb_crypt(const char *key, const char *salt)
 			return rb_sha512_crypt(key, salt);
 		default:
 			return NULL;
-		};
+		}
 	}
 	else
 		return rb_des_crypt(key, salt);

--- a/librb/src/dictionary.c
+++ b/librb/src/dictionary.c
@@ -205,7 +205,7 @@ rb_dictionary_retune(rb_dictionary *dict, const void *key)
 			if (node->left == NULL)
 				break;
 
-			if ((ret = dict->compare_cb(key, node->left->key)) < 0)
+			if (dict->compare_cb(key, node->left->key) < 0)
 			{
 				tn = node->left;
 				node->left = tn->right;
@@ -225,7 +225,7 @@ rb_dictionary_retune(rb_dictionary *dict, const void *key)
 			if (node->right == NULL)
 				break;
 
-			if ((ret = dict->compare_cb(key, node->right->key)) > 0)
+			if (dict->compare_cb(key, node->right->key) > 0)
 			{
 				tn = node->right;
 				node->right = tn->left;
@@ -586,7 +586,7 @@ void rb_dictionary_foreach_start(rb_dictionary *dtree,
  * Side Effects:
  *     - none
  */
-void *rb_dictionary_foreach_cur(rb_dictionary *dtree __attribute__((unused)),
+void *rb_dictionary_foreach_cur(const rb_dictionary *dtree __attribute__((unused)),
 	rb_dictionary_iter *state)
 {
 	lrb_assert(dtree != NULL);
@@ -817,7 +817,7 @@ void rb_dictionary_stats(rb_dictionary *dict, void (*cb)(const char *line, void 
 	{
 		maxdepth = 0;
 		sum = stats_recurse(dict->root, 0, &maxdepth);
-		snprintf(str, sizeof str, "%-30s %-15s %-10u %-10d %-10d %-10d", dict->id, "DICT", dict->count, sum, sum / dict->count, maxdepth);
+		snprintf(str, sizeof str, "%-30s %-15s %-10u %-10d %-10u %-10d", dict->id, "DICT", dict->count, sum, sum / dict->count, maxdepth);
 	}
 	else
 	{

--- a/librb/src/event.c
+++ b/librb/src/event.c
@@ -61,7 +61,7 @@ static time_t event_time_min = -1;
  * Side Effects: None
  */
 static struct ev_entry *
-rb_event_find(EVH * func, void *arg)
+rb_event_find(EVH * func, const void *arg)
 {
 	rb_dlink_node *ptr;
 	struct ev_entry *ev;

--- a/librb/src/helper.c
+++ b/librb/src/helper.c
@@ -27,7 +27,6 @@
 
 struct _rb_helper
 {
-	char *path;
 	buf_head_t sendq;
 	buf_head_t recvq;
 	rb_fde_t *ifd;
@@ -208,9 +207,9 @@ void
 rb_helper_write_queue(rb_helper *helper, const char *format, ...)
 {
 	va_list ap;
-	rb_strf_t strings = { .format = format, .format_args = &ap, .next = NULL };
 
 	va_start(ap, format);
+	rb_strf_t strings = { .format = format, .format_args = &ap, .next = NULL };
 	rb_linebuf_put(&helper->sendq, &strings);
 	va_end(ap);
 }
@@ -226,9 +225,9 @@ void
 rb_helper_write(rb_helper *helper, const char *format, ...)
 {
 	va_list ap;
-	rb_strf_t strings = { .format = format, .format_args = &ap, .next = NULL };
 
 	va_start(ap, format);
+	rb_strf_t strings = { .format = format, .format_args = &ap, .next = NULL };
 	rb_linebuf_put(&helper->sendq, &strings);
 	va_end(ap);
 

--- a/librb/src/patricia.c
+++ b/librb/src/patricia.c
@@ -152,7 +152,6 @@ ascii2prefix(int family, const char *string)
 	char *cp;
 	struct in_addr sinaddr;
 	struct in6_addr sinaddr6;
-	int result;
 	char save[MAXLINE];
 
 	if(string == NULL)
@@ -193,13 +192,13 @@ ascii2prefix(int family, const char *string)
 
 	if(family == AF_INET)
 	{
-		if((result = rb_inet_pton(AF_INET, string, &sinaddr)) <= 0)
+		if(rb_inet_pton(AF_INET, string, &sinaddr) <= 0)
 			return (NULL);
 		return (New_Prefix(AF_INET, &sinaddr, bitlen));
 	}
 	else if(family == AF_INET6)
 	{
-		if((result = rb_inet_pton(AF_INET6, string, &sinaddr6)) <= 0)
+		if(rb_inet_pton(AF_INET6, string, &sinaddr6) <= 0)
 			return (NULL);
 		return (New_Prefix(AF_INET6, &sinaddr6, bitlen));
 	}

--- a/librb/src/ports.c
+++ b/librb/src/ports.c
@@ -122,7 +122,7 @@ rb_setselect_ports(rb_fde_t *F, unsigned int type, PF * handler, void *client_da
 int
 rb_select_ports(long delay)
 {
-	int i, fd = -1;
+	int i;
 	unsigned int nget = 1;
 	struct timespec poll_time;
 	struct timespec *p = NULL;
@@ -146,7 +146,6 @@ rb_select_ports(long delay)
 	{
 		if(pelst[i].portev_source == PORT_SOURCE_FD)
 		{
-			fd = pelst[i].portev_object;
 			PF *hdl = NULL;
 			rb_fde_t *F = pelst[i].portev_user;
 			if((pelst[i].portev_events & (POLLIN | POLLHUP | POLLERR)) && (hdl = F->read_handler))
@@ -172,7 +171,7 @@ int
 rb_ports_supports_event(void)
 {
 	return 1;
-};
+}
 
 void
 rb_ports_init_event(void)

--- a/librb/src/radixtree.c
+++ b/librb/src/radixtree.c
@@ -442,7 +442,7 @@ rb_radixtree_foreach_start(rb_radixtree *dtree, rb_radixtree_iteration_state *st
  *     - none
  */
 void *
-rb_radixtree_foreach_cur(rb_radixtree *dtree, rb_radixtree_iteration_state *state)
+rb_radixtree_foreach_cur(const rb_radixtree *dtree, rb_radixtree_iteration_state *state)
 {
 	if (dtree == NULL)
 		return NULL;
@@ -470,7 +470,7 @@ rb_radixtree_foreach_cur(rb_radixtree *dtree, rb_radixtree_iteration_state *stat
  *     - the static iterator, &state, is advanced to a new DTree node.
  */
 void
-rb_radixtree_foreach_next(rb_radixtree *dtree, rb_radixtree_iteration_state *state)
+rb_radixtree_foreach_next(const rb_radixtree *dtree, rb_radixtree_iteration_state *state)
 {
 	rb_radixtree_leaf *leaf;
 
@@ -1077,7 +1077,7 @@ rb_radixtree_stats(rb_radixtree *dict, void (*cb)(const char *line, void *privda
 	if (dict->count > 0)
 	{
 		sum = stats_recurse(dict->root, 0, &maxdepth);
-		snprintf(str, sizeof str, "%-30s %-15s %-10u %-10d %-10d %-10d", dict->id, "RADIX", dict->count, sum, sum / dict->count, maxdepth);
+		snprintf(str, sizeof str, "%-30s %-15s %-10u %-10d %-10u %-10d", dict->id, "RADIX", dict->count, sum, sum / dict->count, maxdepth);
 	}
 	else
 	{

--- a/librb/src/tools.c
+++ b/librb/src/tools.c
@@ -438,10 +438,10 @@ int rb_fsnprint(char *buf, size_t len, const rb_strf_t *strings)
 int rb_fsnprintf(char *buf, size_t len, const rb_strf_t *strings, const char *format, ...)
 {
 	va_list args;
-	rb_strf_t prepend_string = { .format = format, .format_args = &args, .next = strings };
 	int ret;
 
 	va_start(args, format);
+	rb_strf_t prepend_string = { .format = format, .format_args = &args, .next = strings };
 	ret = rb_fsnprint(buf, len, &prepend_string);
 	va_end(args);
 

--- a/librb/src/unix.c
+++ b/librb/src/unix.c
@@ -162,7 +162,7 @@ rb_path_to_self(void)
 {
 	static char path_buf[4096];
 #if defined(HAVE_GETEXECNAME)
-	char *s = getexecname();
+	const char *s = getexecname();
 	if (s == NULL)
 		return NULL;
 	realpath(s, path_buf);

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -119,7 +119,7 @@ static bool flood_attack_client(enum message_type msgtype, struct Client *source
 static struct entity targets[512];
 static int ntargets = 0;
 
-static bool duplicate_ptr(void *);
+static bool duplicate_ptr(const void *);
 
 static void msg_channel(enum message_type msgtype,
 			struct Client *client_p,
@@ -483,7 +483,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
  * side effects	- NONE
  */
 static bool
-duplicate_ptr(void *ptr)
+duplicate_ptr(const void *ptr)
 {
 	int i;
 	for(i = 0; i < ntargets; i++)
@@ -774,7 +774,7 @@ static void
 msg_client(enum message_type msgtype,
 	   struct Client *source_p, struct Client *target_p, const char *text)
 {
-	int do_floodcount = 0;
+	int do_floodcount;
 	hook_data_privmsg_user hdata;
 
 	if(MyClient(source_p))

--- a/modules/m_kline.c
+++ b/modules/m_kline.c
@@ -110,10 +110,9 @@ is_temporary_kline(struct ConfItem *aconf)
 static void
 mo_kline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char **parv)
 {
-	char def[] = "No Reason";
 	char user[USERLEN + 2];
 	char host_buf[HOSTLEN + 3], *host = host_buf + 1;
-	char *reason = def;
+	char *reason;
 	char *oper_reason;
 	const char *target_server = NULL;
 	struct ConfItem *aconf;

--- a/modules/m_map.c
+++ b/modules/m_map.c
@@ -153,30 +153,30 @@ dump_map(struct Client *client_p, struct Client *root_p, char *pbuf)
 static void
 flattened_map(struct Client *client_p)
 {
-	char buf[BUFSIZE];
+	char lbuf[BUFSIZE];
 	rb_dlink_node *ptr;
 	struct Client *target_p;
 	int i, len;
 	unsigned long cnt = 0;
 
 	/* First display me as the root */
-	rb_strlcpy(buf, me.name, BUFSIZE);
-	len = strlen(buf);
-	buf[len] = ' ';
+	rb_strlcpy(lbuf, me.name, BUFSIZE);
+	len = strlen(lbuf);
+	lbuf[len] = ' ';
 
 	if(len < USER_COL)
 	{
 		for (i = len + 1; i < USER_COL; i++)
 		{
-			buf[i] = '-';
+			lbuf[i] = '-';
 		}
 	}
 
-	snprintf(buf + USER_COL, BUFSIZE - USER_COL,
+	snprintf(lbuf + USER_COL, BUFSIZE - USER_COL,
 		" | Users: %5lu (%4.1f%%)", rb_dlink_list_length(&me.serv->users),
 		100 * (float) rb_dlink_list_length(&me.serv->users) / (float) Count.total);
 
-	sendto_one_numeric(client_p, RPL_MAP, form_str(RPL_MAP), buf);
+	sendto_one_numeric(client_p, RPL_MAP, form_str(RPL_MAP), lbuf);
 
 	/* Next, we run through every other server and list them */
 	RB_DLINK_FOREACH(ptr, global_serv_list.head)
@@ -194,26 +194,26 @@ flattened_map(struct Client *client_p)
 			continue;
 
 		if (cnt == rb_dlink_list_length(&global_serv_list))
-			rb_strlcpy(buf, " `- ", BUFSIZE);
+			rb_strlcpy(lbuf, " `- ", BUFSIZE);
 		else
-			rb_strlcpy(buf, " |- ", BUFSIZE);
+			rb_strlcpy(lbuf, " |- ", BUFSIZE);
 
-		rb_strlcat(buf, target_p->name, BUFSIZE);
-		len = strlen(buf);
-		buf[len] = ' ';
+		rb_strlcat(lbuf, target_p->name, BUFSIZE);
+		len = strlen(lbuf);
+		lbuf[len] = ' ';
 
 		if(len < USER_COL)
 		{
 			for (i = len + 1; i < USER_COL; i++)
 			{
-				buf[i] = '-';
+				lbuf[i] = '-';
 			}
 		}
 
-		snprintf(buf + USER_COL, BUFSIZE - USER_COL,
+		snprintf(lbuf + USER_COL, BUFSIZE - USER_COL,
 			" | Users: %5lu (%4.1f%%)", rb_dlink_list_length(&target_p->serv->users),
 			100 * (float) rb_dlink_list_length(&target_p->serv->users) / (float) Count.total);
 
-		sendto_one_numeric(client_p, RPL_MAP, form_str(RPL_MAP), buf);
+		sendto_one_numeric(client_p, RPL_MAP, form_str(RPL_MAP), lbuf);
 	}
 }

--- a/modules/m_operspy.c
+++ b/modules/m_operspy.c
@@ -67,7 +67,7 @@ ms_operspy(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 {
 	static char buffer[BUFSIZE];
 	char *ptr;
-	int cur_len = 0;
+	int cur_len;
 	int len, i;
 
 	if(parc < 4)

--- a/modules/m_set.c
+++ b/modules/m_set.c
@@ -289,7 +289,7 @@ quote_adminstring(struct Client *source_p, const char *arg, int newval)
 static void
 quote_spamnum(struct Client *source_p, const char *arg, int newval)
 {
-	if(newval > 0)
+	if(newval >= 0)
 	{
 		if(newval == 0)
 		{

--- a/modules/m_whowas.c
+++ b/modules/m_whowas.c
@@ -116,7 +116,7 @@ m_whowas(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	RB_DLINK_FOREACH(ptr, whowas_list->head)
 	{
 		struct Whowas *temp = ptr->data;
-		if(cur > 0 && rb_linebuf_len(&client_p->localClient->buf_sendq) > sendq_limit)
+		if(rb_linebuf_len(&client_p->localClient->buf_sendq) > sendq_limit)
 		{
 			sendto_one(source_p, form_str(ERR_TOOMANYMATCHES),
 				   me.name, source_p->name, "WHOWAS");

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -361,7 +361,7 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
 {
 	char inbuf[READBUF_SIZE];
 	conn_t *conn = data;
-	int length = 0;
+	int length;
 	if(conn == NULL)
 		return;
 
@@ -405,7 +405,7 @@ conn_plain_read_shutdown_cb(rb_fde_t *fd, void *data)
 {
 	char inbuf[READBUF_SIZE];
 	conn_t *conn = data;
-	int length = 0;
+	int length;
 
 	if(conn == NULL)
 		return;

--- a/tools/mkfingerprint.c
+++ b/tools/mkfingerprint.c
@@ -24,7 +24,7 @@
 #include "rb_lib.h"
 #include "certfp.h"
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	uint8_t certfp[RB_SSL_CERTFP_LEN+1] = { 0 };
 	const char *method_str;

--- a/wsockd/wsockd.c
+++ b/wsockd/wsockd.c
@@ -110,11 +110,6 @@ typedef struct {
 
 typedef struct {
 	ws_frame_hdr_t header;
-	uint8_t payload_data[WEBSOCKET_MAX_UNEXTENDED_PAYLOAD_DATA_LENGTH];
-} ws_frame_payload_t;
-
-typedef struct {
-	ws_frame_hdr_t header;
 } ws_frame_t;
 
 typedef struct {
@@ -483,7 +478,7 @@ cleanup_bad_message(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
 }
 
 static void
-ws_frame_unmask(char *msg, int length, uint8_t maskval[WEBSOCKET_MASK_LENGTH])
+ws_frame_unmask(char *msg, int length, const uint8_t maskval[WEBSOCKET_MASK_LENGTH])
 {
 	int i;
 
@@ -674,7 +669,7 @@ conn_mod_read_cb(rb_fde_t *fd, void *data)
 	memset(inbuf, 0, sizeof inbuf);
 
 	conn_t *conn = data;
-	int length = 0;
+	int length;
 	if (conn == NULL)
 		return;
 
@@ -766,7 +761,7 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
 	memset(inbuf, 0, sizeof inbuf);
 
 	conn_t *conn = data;
-	int length = 0;
+	int length;
 	if(conn == NULL)
 		return;
 
@@ -812,7 +807,7 @@ conn_plain_read_shutdown_cb(rb_fde_t *fd, void *data)
 {
 	char inbuf[READBUF_SIZE];
 	conn_t *conn = data;
-	int length = 0;
+	int length;
 
 	if(conn == NULL)
 		return;


### PR DESCRIPTION
- NetBSD needs netinet/tcp.h for TCP_NODELAY
- Remove some trailing ;s that cause a few warnings
- getexecname returns const
- Clean up a bunch of cppcheck warnings. I have a feeling that the va_start
  warnings are benign, but might as well clean them up
- There's a bunch of cppcheck warnings about being able to reduce the scope
  of variables, however I didn't include those in this.