### PR TITLE
MODE +k: Return ERR_INVALIDMODEPARAM instead of stripping invalid chars or truncating

### DIFF
--- a/include/messages.h
+++ b/include/messages.h
@@ -203,6 +203,7 @@
 #define NUMERIC_STR_670      ":STARTTLS successful, proceed with TLS handshake"
 #define NUMERIC_STR_671      "%s :%s"
 #define NUMERIC_STR_691      ":%s"
+#define NUMERIC_STR_696      ":%s 696 %s %s %c %s :%s"
 #define NUMERIC_STR_702      ":%s 702 %s %s 0x%lx %s%s :[Version %s] [Description: %s]"
 #define NUMERIC_STR_703      ":%s 703 %s :End of /MODLIST."
 #define NUMERIC_STR_704      ":%s 704 %s %s :%s"

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -317,6 +317,8 @@
 
 #define ERR_STARTTLS         691 /* ircv3.atheme.org tls-3.2 */
 
+#define ERR_INVALIDMODEPARAM 696 /* InspIRCd, Ergo */
+
 #define RPL_MODLIST          702
 #define RPL_ENDOFMODLIST     703
 

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -1234,9 +1234,10 @@ chm_key(struct Client *source_p, struct Channel *chptr,
 	{
 		key = LOCAL_COPY(arg);
 
-		if(MyClient(source_p))
+		if(MyClient(source_p)) {
 			if (!check_key(key))
 				sendto_one(source_p, form_str(ERR_INVALIDMODEPARAM), me.name, source_p->name, chptr->chname, 'k', "*", "Invalid key mode parameter, invalid character(s).");
+		}
 		else
 			fix_key_remote(key);
 


### PR DESCRIPTION
This is more user-friendly (prevents setting a different key than
what the other requested) and makes the behavior consistent with
InspIRCd and Ergo (and hopefully others soon).

https://github.com/ircdocs/modern-irc/pull/111