### PR TITLE
fix typo in `sasl_only_client_message`

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -579,7 +579,7 @@ general {
 	kline_with_reason = yes;
 	hide_tkdline_duration = no;
 	kline_reason = "K-Lined";
-	sasl_only_client_message = "You need to identify via SASL to use to use this server.";
+	sasl_only_client_message = "You need to identify via SASL to use this server.";
 	identd_only_client_message = "You need to install identd to use this server.";
 	sctp_forbidden_client_message = "You are not allowed to use SCTP on this server.";
 	ssltls_only_client_message = "You need to use SSL/TLS to use this server.";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -1160,7 +1160,7 @@ general {
 	/* SASL access only client message: give users a message that
 	 * informs them
 	 */
-	sasl_only_client_message = "You need to identify via SASL to use to use this server.";
+	sasl_only_client_message = "You need to identify via SASL to use this server.";
 
 	/* Identd access only client message: give users a message that
 	 * informs them

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -524,7 +524,7 @@ register_local_user(struct Client *client_p, struct Client *source_p)
 		const char *sasl_only_client_message = ConfigFileEntry.sasl_only_client_message;
 
 		if (sasl_only_client_message == NULL)
-			sasl_only_client_message = "You need to identify via SASL to use to use this server.";
+			sasl_only_client_message = "You need to identify via SASL to use this server.";
 
 		ServerStats.is_ref++;
 		sendto_one_notice(source_p, ":*** Notice -- %s", sasl_only_client_message);


### PR DESCRIPTION
```
:copper.libera.chat NOTICE l :*** Notice -- You need to identify via SASL to use to use this server.
ERROR :Closing Link: ranger.zpld.me (You need to identify via SASL to use to use this server.)
```