### PR TITLE
Send RPL_ENDOFTRACE on local /etrace

### DIFF
--- a/modules/m_etrace.c
+++ b/modules/m_etrace.c
@@ -123,7 +123,10 @@ mo_etrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 						target_p->servptr->name,
 						get_id(target_p, target_p));
 				else
+				{
 					do_single_etrace(source_p, target_p);
+					sendto_one_numeric(source_p, RPL_ENDOFTRACE, form_str(RPL_ENDOFTRACE), target_p->name);
+				}
 			}
 			else
 				sendto_one_numeric(source_p, ERR_NOSUCHNICK,


### PR DESCRIPTION
When running `/etrace <nick>` against a local user, the "end of trace" numeric is not sent to the client. This numeric is sent in all other circumstances (such as when running `/etrace <nick>` against a remote user), so send it when executing locally as well for consistency.