### PR TITLE
add sqlite3 to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ These are known issues and workarounds for various platforms.
 # building
 
 ```bash
+sudo apt install build-essential pkg-config libsqlite3-dev # or equivalent for your distribution
 ./autogen.sh
 ./configure --prefix=/path/to/installation
 make


### PR DESCRIPTION
Quite often people new to Solanum run into trouble in the configure step: the error message if they are lacking either the pkg-config or libsqlite3 packages are identical and discovering the pkg-config dependency is not trivial:

checking for SQLITE... no
configure: error: sqlite3 is required

I can't promise this apt install line is complete, but I know that I've suggested the pkg-config and libsqlite3-dev packages many times in the #solanum channel and they've been very helpful.