### PR TITLE
ircd/packet.c: make function definition consistent with declaration

### DIFF
--- a/ircd/packet.c
+++ b/ircd/packet.c
@@ -322,7 +322,7 @@ read_packet(rb_fde_t * F, void *data)
  *      with client_p of "local" variation, which contains all the
  *      necessary fields (buffer etc..)
  */
-void
+static void
 client_dopacket(struct Client *client_p, char *buffer, size_t length)
 {
 	s_assert(client_p != NULL);


### PR DESCRIPTION
This function has a static forward-declaration, and is not used outside this compilation unit. However, the definition was non-static. Fix this.