### PR TITLE
don't subject remote users to chm_nonotice

### DIFF
--- a/extensions/chm_nonotice.c
+++ b/extensions/chm_nonotice.c
@@ -52,8 +52,11 @@ chm_nonotice_process(void *data_)
 {
 	hook_data_privmsg_channel *data = data_;
 
-	/* don't waste CPU if message is already blocked */
-	if (data->approved || data->msgtype != MESSAGE_TYPE_NOTICE)
+	/*
+	 * don't waste CPU if message is already blocked, only block notices,
+	 * only check messages sourced from local clients (so we don't block services notices)
+	 */
+	if (data->approved || data->msgtype != MESSAGE_TYPE_NOTICE || !MyClient(data->source_p))
 		return;
 
 	/* block all notices except CTCPs; use chm_noctcp to block CTCPs. */


### PR DESCRIPTION
chanserv currently cannot notice `VERBOSE` channels that are `+T` and it feels needless to check this on every single server of the network