### PR TITLE
Remove ambiguity in descriptions +u

### DIFF
--- a/help/opers/cmode
+++ b/help/opers/cmode
@@ -20,8 +20,8 @@ NO PARAMETERS:
               messages is stripped.
      +g     - Free invite.  Everyone may invite users.  Significantly
               weakens +i control.
-  ?  +u     - Unfiltered. Receive messages that are filtered server side based 
-              on content
+  ?  +u     - Unfiltered. Receive messages that would otherwise be filtered
+              server side based on content.
      +z     - Op moderated.  Messages blocked by +m, +b and +q are instead
               sent to ops.
      +L     - Large ban list.  Increase maximum number of +beIq entries.

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -16,8 +16,8 @@ User modes: (* designates that the umode is oper only)
        * +a     - Is marked as a server admin in whois.
        * +l     - Can see oper locops (local wallops).
        * +s     - Can see server notices (see /quote help snomask).
-       ? +u     - Receive messages that are filtered server side based
-                  on content
+       ? +u     - Receive messages that would otherwise be filtered server side
+                  based on content.
        * +z     - Can see operwalls.
        ? +C     - Prevents you from receiving CTCPs other than ACTION.
          +D     - Deaf - ignores all channel messages.

--- a/help/users/umode
+++ b/help/users/umode
@@ -11,8 +11,8 @@ User modes: (? designates that the umode is provided by an extension
        ? +h     - Has a cloaked host. May be +x depending on cloaking module
          +g     - Deny users not on your /ACCEPT list from messaging you and
                   inviting you to channels.
-       ? +u     - Receive messages that are filtered server side based
-                  on content.
+       ? +u     - Receive messages that would otherwise be filtered server side
+                  based on content.
          +w     - Can see oper wallops.
        ? +C     - Prevents you from receiving CTCPs other than ACTION.
          +D     - Deaf - ignores all channel messages.


### PR DESCRIPTION
The old descriptions might be interpreted as meaning that +u enables
server-side filtering.