### PR TITLE
authd/providers/opm.c: include <netinet/tcp.h>

### DIFF
--- a/authd/providers/opm.c
+++ b/authd/providers/opm.c
@@ -26,6 +26,8 @@
 #include "notice.h"
 #include "provider.h"
 
+#include <netinet/tcp.h> // TCP_NODELAY
+
 #define SELF_PID (opm_provider.id)
 
 #define OPM_READSIZE 128


### PR DESCRIPTION
This header defines the TCP_NODELAY flag, which this compilation unit uses.

Other C libraries implicitly include this header from some other header we are using (I have not investigated which), but musl's system headers do not, which breaks building on musl.

Reported-by: 0x5c <dev@0x5c.io>