### PR TITLE
Add ability to mark webirc users and forbid marked users

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -394,6 +394,9 @@ auth {
 	 * extend_chans               | allow this user to join more channels than normal
 	 * kline_spoof_ip             | if this block has a spoof host, klines match only
 	 *                            | the spoof and not the underlying IP
+	 * set_mark                   | no-op by default; used by webirc to mark this user
+	 *                            | before resolving their actual auth block
+	 * forbid_mark                | reject connections from marked users
 	 */
 	flags = kline_exempt, exceed_limit;
 

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -31,6 +31,8 @@
  * Possible flags:
  *   encrypted - password is encrypted (recommended)
  *   kline_exempt - klines on the cgiirc ip are ignored
+ *   set_mark - mark clients connecting via this block, interacts with
+ *     forbid_mark when resolving the auth block for the spoofed ip
  * dlines are checked on the cgiirc ip (of course).
  * k/d/x lines, auth blocks, user limits, etc are checked using the
  * real host/ip.
@@ -142,6 +144,15 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	source_p->localClient->ip = addr;
 	source_p->username[0] = '\0';
 	ClearGotId(source_p);
+
+	/* set_mark and forbid_mark in an auth block both set CONF_FLAG_FORBIDMARK;
+	 * the distinction is purely visual for the sake of human readability,
+	 * hence checking IsConfForbidMark here.
+	 */
+	if (IsConfForbidMark(aconf))
+	{
+		SetMark(source_p);
+	}
 
 	if (parc >= 6)
 	{

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -110,6 +110,7 @@ struct ConfItem
 #define CONF_FLAGS_EXEMPTJUPE		0x00020000	/* exempt from resv generating warnings */
 #define CONF_FLAGS_NEED_SASL		0x00040000
 #define CONF_FLAGS_EXTEND_CHANS		0x00080000
+#define CONF_FLAGS_FORBIDMARK		0x00100000
 #define CONF_FLAGS_ENCRYPTED		0x00200000
 #define CONF_FLAGS_EXEMPTDNSBL		0x04000000
 #define CONF_FLAGS_EXEMPTPROXY		0x08000000
@@ -132,6 +133,7 @@ struct ConfItem
 #define IsConfExemptResv(x)	((x)->flags & CONF_FLAGS_EXEMPTRESV)
 #define IsConfDoSpoofIp(x)      ((x)->flags & CONF_FLAGS_SPOOF_IP)
 #define IsConfSpoofNotice(x)    ((x)->flags & CONF_FLAGS_SPOOF_NOTICE)
+#define IsConfForbidMark(x)     ((x)->flags & CONF_FLAGS_FORBIDMARK)
 #define IsConfEncrypted(x)      ((x)->flags & CONF_FLAGS_ENCRYPTED)
 #define IsNeedSasl(x)		((x)->flags & CONF_FLAGS_NEED_SASL)
 #define IsConfExemptDNSBL(x)	((x)->flags & CONF_FLAGS_EXEMPTDNSBL)

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -351,6 +351,8 @@ static struct mode_table auth_table[] = {
 	{"extend_chans",	CONF_FLAGS_EXTEND_CHANS		},
 	{"allow_sctp",		CONF_FLAGS_ALLOW_SCTP		},
 	{"kline_spoof_ip",	CONF_FLAGS_KLINE_SPOOF		},
+	{"set_mark",		CONF_FLAGS_FORBIDMARK		},
+	{"forbid_mark",		CONF_FLAGS_FORBIDMARK		},
 	{NULL, 0}
 };
 

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -325,6 +325,14 @@ verify_access(struct Client *client_p, const char *username)
 			return (NOT_AUTHORISED);
 		}
 
+		if(IsMarked(client_p))
+		{
+			if(IsConfForbidMark(aconf))
+				return NOT_AUTHORISED;
+
+			ClearMark(client_p);
+		}
+
 		/* Thanks for spoof idea amm */
 		if(IsConfDoSpoofIp(aconf))
 		{


### PR DESCRIPTION
Marked connections (via set_mark in the webirc auth block) will be
checked against the forbid_mark flag in the final auth block after
resolving the user's spoofed IP. This allows for additional levels of
security from webirc operators so that they are unable to spoof their
way into privileged auth blocks -- an auth block with forbid_mark will
reject any connections from marked users.

The mark is not automatic because some webirc servers may be fully
trusted to allow privileged users to connect (such as a webchat hosted
by the network itself).