### PR TITLE
Remove ERR_NOSUCHNICK from LIST reply

### DIFF
--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -436,18 +436,10 @@ static void safelist_channel_named(struct Client *source_p, const char *name, in
 	if ((p = strchr(name, ',')))
 		*p = '\0';
 
-	if (*name == '\0')
-	{
-		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), name);
-		sendto_one(source_p, form_str(RPL_LISTEND), me.name, source_p->name);
-		return;
-	}
-
 	chptr = find_channel(name);
 
 	if (chptr == NULL)
 	{
-		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), name);
 		sendto_one(source_p, form_str(RPL_LISTEND), me.name, source_p->name);
 		return;
 	}


### PR DESCRIPTION
1. The first block was unreachable according to @dwfreed
2. In the second block, sending ERR_NOSUCHNICK can be unexpected by clients,
   as no other IRCd does that and https://modern.ircdocs.horse/#list-message
   does not list it.
   Additionally, it leaks information on the existence of secret channels.