### PR TITLE
Add description parameter to auth blocks

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -344,6 +344,11 @@ listen {
 
 /* auth {}: allow users to connect to the ircd (OLD I:) */
 auth {
+	/* desc: descriptive text to help recognize this auth block in
+	 * stats i output.
+	 */
+	desc = "example oper";
+
 	/* user: the user@host allowed to connect.  Multiple IPv4/IPv6 user
 	 * lines are permitted per auth block.  This is matched against the
 	 * hostname and IP address (using :: shortening for IPv6 and

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -344,10 +344,10 @@ listen {
 
 /* auth {}: allow users to connect to the ircd (OLD I:) */
 auth {
-	/* desc: descriptive text to help recognize this auth block in
+	/* description: descriptive text to help recognize this auth block in
 	 * stats i output.
 	 */
-	desc = "example oper";
+	description = "example oper";
 
 	/* user: the user@host allowed to connect.  Multiple IPv4/IPv6 user
 	 * lines are permitted per auth block.  This is matched against the

--- a/include/messages.h
+++ b/include/messages.h
@@ -49,7 +49,7 @@
 #define NUMERIC_STR_209      "Class %s %d"
 #define NUMERIC_STR_212      "%s %u %lu :%u"
 #define NUMERIC_STR_213      "C %s %s %s %d %s %s"
-#define NUMERIC_STR_215      "I %s %s %s@%s %d %s"
+#define NUMERIC_STR_215      "I %s %s %s@%s %d %s :%s"
 #define NUMERIC_STR_216      "%c %s * %s :%s%s%s"
 #define NUMERIC_STR_217      "%c %d %s :%s"
 #define NUMERIC_STR_218      "Y %s %d %d %d %u %d.%d %d.%d %u"

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -65,6 +65,7 @@ struct ConfItem
 	char *passwd;		/* doubles as kline reason *ugh* */
 	char *spasswd;		/* Password to send. */
 	char *user;		/* user part of user@host */
+	char *desc;             /* description */
 	int port;
 	time_t hold;		/* Hold action until this time (calendar time) */
 	time_t created;		/* Creation time (for klines etc) */
@@ -384,7 +385,7 @@ extern int detach_conf(struct Client *);
 extern struct ConfItem *find_tkline(const char *, const char *, struct sockaddr *);
 extern char *show_iline_prefix(struct Client *, struct ConfItem *, char *);
 extern void get_printable_conf(struct ConfItem *,
-			       char **, char **, const char **, char **, int *, char **);
+			       char **, char **, const char **, char **, int *, char **, char **);
 extern char *get_user_ban_reason(struct ConfItem *aconf);
 extern void get_printable_kline(struct Client *, struct ConfItem *,
 				char **, char **, char **, char **);

--- a/ircd/hostmask.c
+++ b/ircd/hostmask.c
@@ -723,7 +723,7 @@ show_iline_prefix(struct Client *sptr, struct ConfItem *aconf, char *name)
 void
 report_auth(struct Client *client_p)
 {
-	char *name, *host, *user, *classname;
+	char *name, *host, *user, *classname, *desc;
 	const char *pass;
 	struct AddressRec *arec;
 	struct ConfItem *aconf;
@@ -739,7 +739,7 @@ report_auth(struct Client *client_p)
 					continue;
 
 				get_printable_conf(aconf, &name, &host, &pass, &user, &port,
-						   &classname);
+						   &classname, &desc);
 
 				if(!EmptyString(aconf->spasswd))
 					pass = aconf->spasswd;
@@ -748,7 +748,7 @@ report_auth(struct Client *client_p)
 						   form_str(RPL_STATSILINE),
 						   name, pass, show_iline_prefix(client_p, aconf, user),
 						   show_ip_conf(aconf, client_p) ? host : "255.255.255.255",
-						   port, classname);
+						   port, classname, desc);
 			}
 }
 

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -1037,6 +1037,9 @@ conf_end_auth(struct TopConf *tc)
 		if(yy_aconf->className)
 			yy_tmp->className = rb_strdup(yy_aconf->className);
 
+		if(yy_aconf->desc)
+			yy_tmp->desc = rb_strdup(yy_aconf->desc);
+
 		yy_tmp->flags = yy_aconf->flags;
 		yy_tmp->port = yy_aconf->port;
 
@@ -1170,6 +1173,13 @@ conf_set_auth_spoof(void *data)
 	rb_free(yy_aconf->info.name);
 	yy_aconf->info.name = rb_strdup(data);
 	yy_aconf->flags |= CONF_FLAGS_SPOOF_IP;
+}
+
+static void
+conf_set_auth_desc(void *data)
+{
+	rb_free(yy_aconf->desc);
+	yy_aconf->desc = rb_strdup(data);
 }
 
 static void
@@ -2640,6 +2650,7 @@ static struct ConfEntry conf_auth_table[] =
 	{ "redirport",	CF_INT,     conf_set_auth_redir_port,	0, NULL },
 	{ "flags",	CF_STRING | CF_FLIST, conf_set_auth_flags,	0, NULL },
 	{ "umodes",     CF_QSTRING, conf_set_auth_umodes,	0, NULL},
+	{ "description",CF_QSTRING, conf_set_auth_desc,         0, NULL},
 	{ "\0",	0, NULL, 0, NULL }
 };
 

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -154,6 +154,7 @@ free_conf(struct ConfItem *aconf)
 	rb_free(aconf->className);
 	rb_free(aconf->user);
 	rb_free(aconf->host);
+	rb_free(aconf->desc);
 
 	if(IsConfBan(aconf))
 		operhash_delete(aconf->info.oper);
@@ -1346,7 +1347,8 @@ get_oper_name(struct Client *client_p)
  */
 void
 get_printable_conf(struct ConfItem *aconf, char **name, char **host,
-		   const char **pass, char **user, int *port, char **classname)
+		   const char **pass, char **user, int *port,
+		   char **classname, char **desc)
 {
 	static char null[] = "<NULL>";
 	static char zero[] = "default";
@@ -1356,6 +1358,7 @@ get_printable_conf(struct ConfItem *aconf, char **name, char **host,
 	*pass = EmptyString(aconf->passwd) ? null : aconf->passwd;
 	*user = EmptyString(aconf->user) ? null : aconf->user;
 	*classname = EmptyString(aconf->className) ? zero : aconf->className;
+	*desc = CheckEmpty(aconf->desc);
 	*port = (int) aconf->port;
 }
 

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -453,7 +453,7 @@ stats_deny (struct Client *source_p)
 static void
 stats_exempt(struct Client *source_p)
 {
-	char *name, *host, *user, *classname;
+	char *name, *host, *user, *classname, *desc;
 	const char *pass;
 	struct AddressRec *arec;
 	struct ConfItem *aconf;
@@ -474,7 +474,7 @@ stats_exempt(struct Client *source_p)
 			{
 				aconf = arec->aconf;
 				get_printable_conf (aconf, &name, &host, &pass,
-						    &user, &port, &classname);
+						    &user, &port, &classname, &desc);
 
 				sendto_one_numeric(source_p, RPL_STATSDLINE,
 						   form_str(RPL_STATSDLINE),
@@ -533,7 +533,7 @@ stats_auth (struct Client *source_p)
 	else if((ConfigFileEntry.stats_i_oper_only == 1) && !IsOperGeneral (source_p))
 	{
 		struct ConfItem *aconf;
-		char *name, *host, *user, *classname;
+		char *name, *host, *user, *classname, *desc;
 		const char *pass = "*";
 		int port;
 
@@ -550,13 +550,13 @@ stats_auth (struct Client *source_p)
 		if(aconf == NULL)
 			return;
 
-		get_printable_conf (aconf, &name, &host, &pass, &user, &port, &classname);
+		get_printable_conf (aconf, &name, &host, &pass, &user, &port, &classname, &desc);
 		if(!EmptyString(aconf->spasswd))
 			pass = aconf->spasswd;
 
 		sendto_one_numeric(source_p, RPL_STATSILINE, form_str(RPL_STATSILINE),
 				   name, pass, show_iline_prefix(source_p, aconf, user),
-				   host, port, classname);
+				   host, port, classname, desc);
 	}
 
 	/* Theyre opered, or allowed to see all auth blocks */

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -34,7 +34,6 @@
 #include "msg.h"
 #include "hash.h"
 #include "hostmask.h"
-#include "match.h"
 #include "numeric.h"
 #include "s_conf.h"
 #include "s_newconf.h"

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -235,7 +235,8 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		sendto_one_numeric(source_p, RPL_STATSILINE, form_str(RPL_STATSILINE),
 				aconf->info.name, EmptyString(aconf->spasswd) ? "<NULL>" : aconf->spasswd,
 				show_iline_prefix(source_p, aconf, aconf->user),
-				aconf->host, aconf->port, aconf->className);
+				aconf->host, aconf->port, aconf->className,
+				EmptyString(aconf->desc) ? "" : aconf->desc);
 		return;
 	}
 

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -34,6 +34,7 @@
 #include "msg.h"
 #include "hash.h"
 #include "hostmask.h"
+#include "match.h"
 #include "numeric.h"
 #include "s_conf.h"
 #include "s_newconf.h"
@@ -236,7 +237,7 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 				aconf->info.name, EmptyString(aconf->spasswd) ? "<NULL>" : aconf->spasswd,
 				show_iline_prefix(source_p, aconf, aconf->user),
 				aconf->host, aconf->port, aconf->className,
-				EmptyString(aconf->desc) ? "" : aconf->desc);
+				CheckEmpty(aconf->desc));
 		return;
 	}
 


### PR DESCRIPTION
This would make it easy to see _why_ we have so many I lines and to group them back together to a single auth block both with manual queries and also for consumption by automated tooling.