### PR TITLE
Allow for default umodes to change at runtime

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -234,6 +234,9 @@ struct LocalUser
 	/* nicknames theyre monitoring */
 	rb_dlink_list monitor_list;
 
+	/* collects umodes explicitly changed by this user */
+	unsigned int changed_umodes;
+
 	/*
 	 * Anti-flood stuff. We track how many messages were parsed and how
 	 * many we were allowed in the current second, and apply a simple decay

--- a/include/s_user.h
+++ b/include/s_user.h
@@ -38,6 +38,7 @@ extern bool valid_username(const char *username);
 extern int user_mode(struct Client *, struct Client *, int, const char **);
 extern void send_umode(struct Client *, struct Client *, int, char *);
 extern void send_umode_out(struct Client *, struct Client *, int);
+extern void change_default_umodes(struct Client *);
 extern void show_lusers(struct Client *source_p);
 extern int register_local_user(struct Client *, struct Client *);
 
@@ -55,6 +56,6 @@ struct PrivilegeSet;
 extern void report_priv_change(struct Client *, struct PrivilegeSet *, struct PrivilegeSet *);
 extern void oper_up(struct Client *, struct oper_conf *);
 
-#endif
-
 extern bool has_common_channel(struct Client *source_p, struct Client *target_p);
+
+#endif

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -653,6 +653,7 @@ bool
 rehash(bool sig)
 {
 	rb_dlink_node *n;
+	int old_umodes;
 
 	hook_data_rehash hdata = { sig };
 
@@ -663,6 +664,10 @@ rehash(bool sig)
 	rehash_authd();
 
 	privilegeset_prepare_rehash();
+
+	/* capture current set of default umodes; if this changes we'll apply the
+	 * change to all local clients */
+	old_umodes = ConfigFileEntry.default_umodes;
 
 	/* don't close listeners until we know we can go ahead with the rehash */
 	read_conf_files(false);
@@ -682,6 +687,15 @@ rehash(bool sig)
 	}
 
 	privilegeset_cleanup_rehash();
+
+	if (old_umodes != ConfigFileEntry.default_umodes)
+		RB_DLINK_FOREACH(n, lclient_list.head)
+		{
+			struct Client *client = n->data;
+			if (!IsPerson(client))
+				continue;
+			change_default_umodes(client);
+		}
 
 	call_hook(h_rehash, &hdata);
 	return false;


### PR DESCRIPTION
When default umodes are changed in ircd.conf, these changes will now be
applied to all local clients upon receiving a /rehash. We track which
umodes a user has explicitly (un)set and avoid modifying those umodes
when changing the defaults -- only umodes that a user didn't explicitly
touch are subject to change on rehash.