### PR TITLE
Normalize generation for reproducible builds

### DIFF
--- a/ircd/version.c.SH
+++ b/ircd/version.c.SH
@@ -26,6 +26,7 @@ else \
          { print $1 " "  $2 " " $3 " " $7 " at " $4 " " $5 " " $6 }}'`
 else
     creation="$EXTERNAL_BUILD_TIMESTAMP"
+    generation=1
 fi
 
 $spitshell >version.c <<!SUB!THIS!


### PR DESCRIPTION
While working on reproducible builds for openSUSE, I found that
our `solanum` package varied even when building in clean VMs
with as little non-determinism as possible.
This was because of variations in the `generation` value in version.c

```diff
+++ solanum-0~ch560/ircd/version.c.last
@@ -25,7 +25,7 @@
 #include "serno.h"
 #include "stdinc.h"

-const char *generation = "6";
+const char *generation = "5";
 const char *creation = "1653004800";
 const char *ircd_version = PATCHLEVEL;
 const char *serno = SERNO;
```