### PR TITLE
Illumos fixes

### DIFF
--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -756,8 +756,8 @@ solanum_main(int argc, char * const argv[])
 		check_splitmode_ev = rb_event_add("check_splitmode", check_splitmode, NULL, 5);
 
 	if(server_state_foreground)
-		inotice("now running in foreground mode from %s as pid %d ...",
-		        ConfigFileEntry.dpath, getpid());
+		inotice("now running in foreground mode from %s as pid %ld ...",
+		        ConfigFileEntry.dpath, (long)getpid());
 
 	rb_lib_loop(0);
 

--- a/librb/src/unix.c
+++ b/librb/src/unix.c
@@ -162,7 +162,7 @@ rb_path_to_self(void)
 {
 	static char path_buf[4096];
 #if defined(HAVE_GETEXECNAME)
-	char *s = getexecname();
+	const char *s = getexecname();
 	if (s == NULL)
 		return NULL;
 	realpath(s, path_buf);

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -908,8 +908,8 @@ stats_ssld_foreach(void *data, pid_t pid, int cli_count, enum ssld_status status
 	struct Client *source_p = data;
 
 	sendto_one_numeric(source_p, RPL_STATSDEBUG,
-			"S :%u %c %u :%s",
-			pid,
+			"S :%ld %c %u :%s",
+			(long)pid,
 			status == SSLD_DEAD ? 'D' : (status == SSLD_SHUTDOWN ? 'S' : 'A'),
 			cli_count,
 			version);


### PR DESCRIPTION
- getexecname(3) returns const char *
- pid_t is long