### PR TITLE
Snprintf sizeof

### DIFF
--- a/authd/res.c
+++ b/authd/res.c
@@ -514,7 +514,7 @@ static void do_query_number(struct DNSQuery *query, const struct rb_sockaddr_sto
 		request->name = (char *)rb_malloc(IRCD_RES_HOSTLEN + 1);
 	}
 
-	build_rdns(request->queryname, IRCD_RES_HOSTLEN + 1, addr, NULL);
+	build_rdns(request->queryname, sizeof request->queryname, addr, NULL);
 
 	request->type = T_PTR;
 	query_name(request);

--- a/extensions/extb_extgecos.c
+++ b/extensions/extb_extgecos.c
@@ -41,7 +41,7 @@ static int eb_extended(const char *data, struct Client *client_p,
 	if (data == NULL)
 		return EXTBAN_INVALID;
 
-	snprintf(buf, BUFSIZE, "%s!%s@%s#%s",
+	snprintf(buf, sizeof buf, "%s!%s@%s#%s",
 		client_p->name, client_p->username, client_p->host, client_p->info);
 
 	return match(data, buf) ? EXTBAN_MATCH : EXTBAN_NOMATCH;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -925,7 +925,7 @@ chm_ban(struct Client *source_p, struct Channel *chptr,
 		}
 
 		if (removed && removed->forward)
-			removed_mask_pos += snprintf(buf + old_removed_mask_pos, sizeof(buf), "%s$%s", removed->banstr, removed->forward) + 1;
+			removed_mask_pos += snprintf(buf + old_removed_mask_pos, sizeof(buf) - old_removed_mask_pos, "%s$%s", removed->banstr, removed->forward) + 1;
 		else
 			removed_mask_pos += rb_strlcpy(buf + old_removed_mask_pos, mask, sizeof(buf)) + 1;
 		if (removed)

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -2328,7 +2328,7 @@ conf_report_error(const char *fmt, ...)
 	char msg[BUFSIZE + 1] = { 0 };
 
 	va_start(ap, fmt);
-	vsnprintf(msg, BUFSIZE, fmt, ap);
+	vsnprintf(msg, sizeof msg, fmt, ap);
 	va_end(ap);
 
 	if (testing_conf)
@@ -2348,7 +2348,7 @@ conf_report_warning(const char *fmt, ...)
 	char msg[BUFSIZE + 1] = { 0 };
 
 	va_start(ap, fmt);
-	vsnprintf(msg, BUFSIZE, fmt, ap);
+	vsnprintf(msg, sizeof msg, fmt, ap);
 	va_end(ap);
 
 	if (testing_conf)

--- a/ircd/reject.c
+++ b/ircd/reject.c
@@ -100,7 +100,7 @@ reject_exit(void *unused)
 
 		if (ddata->aconf)
 		{
-			snprintf(dynamic_reason, BUFSIZE, form_str(ERR_YOUREBANNEDCREEP) "\r\n",
+			snprintf(dynamic_reason, sizeof dynamic_reason, form_str(ERR_YOUREBANNEDCREEP) "\r\n",
 				me.name, "*", get_user_ban_reason(ddata->aconf));
 			rb_write(ddata->F, dynamic_reason, strlen(dynamic_reason));
 
@@ -108,7 +108,7 @@ reject_exit(void *unused)
 		}
 		else if (ddata->reason)
 		{
-			snprintf(dynamic_reason, BUFSIZE, ":%s 465 %s :%s\r\n",
+			snprintf(dynamic_reason, sizeof dynamic_reason, ":%s 465 %s :%s\r\n",
 				me.name, "*", ddata->reason);
 			rb_write(ddata->F, dynamic_reason, strlen(dynamic_reason));
 		}

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1640,7 +1640,7 @@ change_nick_user_host(struct Client *target_p,	const char *nick, const char *use
 	if(do_qjm)
 	{
 		va_start(ap, format);
-		vsnprintf(reason, 255, format, ap);
+		vsnprintf(reason, sizeof reason, format, ap);
 		va_end(ap);
 
 		sendto_common_channels_local_butone(target_p, NOCAPS, CLICAP_CHGHOST, ":%s!%s@%s QUIT :%s",

--- a/librb/src/event.c
+++ b/librb/src/event.c
@@ -294,22 +294,20 @@ rb_event_init(void)
 void
 rb_dump_events(void (*func) (char *, void *), void *ptr)
 {
-	int len;
 	char buf[512];
 	rb_dlink_node *dptr;
 	struct ev_entry *ev;
-	len = sizeof(buf);
 
-	snprintf(buf, len, "Last event to run: %s", last_event_ran);
+	snprintf(buf, sizeof buf, "Last event to run: %s", last_event_ran);
 	func(buf, ptr);
 
-	rb_strlcpy(buf, "Operation                    Next Execution", len);
+	rb_strlcpy(buf, "Operation                    Next Execution", sizeof buf);
 	func(buf, ptr);
 
 	RB_DLINK_FOREACH(dptr, event_list.head)
 	{
 		ev = dptr->data;
-		snprintf(buf, len, "%-28s %-4ld seconds (frequency=%d)", ev->name,
+		snprintf(buf, sizeof buf, "%-28s %-4ld seconds (frequency=%d)", ev->name,
 			    ev->when - (long)rb_current_time(), (int)ev->frequency);
 		func(buf, ptr);
 	}

--- a/modules/m_map.c
+++ b/modules/m_map.c
@@ -108,7 +108,7 @@ dump_map(struct Client *client_p, struct Client *root_p, char *pbuf)
 	}
 
 	frac = (1000 * rb_dlink_list_length(&root_p->serv->users) + Count.total / 2) / Count.total;
-	snprintf(buf + USER_COL, BUFSIZE - USER_COL,
+	snprintf(buf + USER_COL, sizeof buf - USER_COL,
 		 " | Users: %5lu (%2d.%1d%%)", rb_dlink_list_length(&root_p->serv->users),
 		 frac / 10, frac % 10);
 
@@ -172,7 +172,7 @@ flattened_map(struct Client *client_p)
 		}
 	}
 
-	snprintf(buf + USER_COL, BUFSIZE - USER_COL,
+	snprintf(buf + USER_COL, sizeof buf - USER_COL,
 		" | Users: %5lu (%4.1f%%)", rb_dlink_list_length(&me.serv->users),
 		100 * (float) rb_dlink_list_length(&me.serv->users) / (float) Count.total);
 
@@ -210,7 +210,7 @@ flattened_map(struct Client *client_p)
 			}
 		}
 
-		snprintf(buf + USER_COL, BUFSIZE - USER_COL,
+		snprintf(buf + USER_COL, sizeof buf - USER_COL,
 			" | Users: %5lu (%4.1f%%)", rb_dlink_list_length(&target_p->serv->users),
 			100 * (float) rb_dlink_list_length(&target_p->serv->users) / (float) Count.total);
 

--- a/modules/m_scan.c
+++ b/modules/m_scan.c
@@ -237,7 +237,7 @@ scan_umodes(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 
 		if (mask != NULL)
 		{
-			snprintf(maskbuf, BUFSIZE, "%s!%s@%s",
+			snprintf(maskbuf, sizeof maskbuf, "%s!%s@%s",
 				target_p->name, target_p->username, target_p->host);
 
 			if (!match(mask, maskbuf))


### PR DESCRIPTION
The first commit fixes an actual bug (though since `static char buf[BANLEN * MAXMODEPARAMS];` is 780 bytes, I'm pretty sure it's impossible to hit). The second commit just uses sizeof where possible and can be dropped. Some instance are off by one, but by under counting size not over counting it.