### PR TITLE
Honor +I exemptions for +k

### DIFF
--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -724,6 +724,8 @@ can_join(struct Client *source_p, struct Channel *chptr, const char *key, const 
 		if (matches_mask(&ms, invex->banstr) ||
 				match_extban(invex->banstr, source_p, chptr, CHFL_INVEX))
 			break;
+
+		invex = NULL;
 	}
 
 	if(*chptr->mode.key && !invex &&

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -716,10 +716,6 @@ can_join(struct Client *source_p, struct Channel *chptr, const char *key, const 
 		goto finish_join_check;
 	}
 
-	struct Ban *invex = NULL;
-	struct matchset ms;
-	rb_dlink_node *ptr;
-
 	matchset_for_client(source_p, &ms);
 
 	RB_DLINK_FOREACH(ptr, chptr->invexlist.head)
@@ -736,6 +732,8 @@ can_join(struct Client *source_p, struct Channel *chptr, const char *key, const 
 		moduledata.approved = ERR_BADCHANNELKEY;
 		goto finish_join_check;
 	}
+
+	invex = NULL;
 
 	/* All checks from this point on will forward... */
 	if(forward)


### PR DESCRIPTION
Allow users to bypass a key requirement from `+k` if they have an invite exemption.