### PR TITLE
chmode: Use original string when removing a mask

### DIFF
--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -927,7 +927,7 @@ chm_ban(struct Client *source_p, struct Channel *chptr,
 		if (removed && removed->forward)
 			removed_mask_pos += snprintf(buf + old_removed_mask_pos, sizeof(buf) - old_removed_mask_pos, "%s$%s", removed->banstr, removed->forward) + 1;
 		else
-			removed_mask_pos += rb_strlcpy(buf + old_removed_mask_pos, mask, sizeof(buf)) + 1;
+			removed_mask_pos += rb_strlcpy(buf + old_removed_mask_pos, removed ? removed->banstr : mask, sizeof(buf)) + 1;
 		if (removed)
 		{
 			free_ban(removed);


### PR DESCRIPTION
With this
```
MODE #test +b foo!*@*
MODE #test -b Foo!*@*
```
outputs `MODE #test -b foo!*@*` rather than `MODE #test -b Foo!*@*` which makes state tracking easier.