### PR TITLE
serv_connect(): ensure both sa_bind[]/sa_connect[] are always populated

### DIFF
--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1017,12 +1017,16 @@ serv_connect(struct server_conf *server_p, struct Client *by)
 	else if(server_p->aftype == AF_INET || GET_SS_FAMILY(&server_p->connect4) == AF_INET)
 	{
 		sa_connect[0] = server_p->connect4;
+		sa_connect[1] = server_p->connect6;
 		sa_bind[0] = server_p->bind4;
+		sa_bind[1] = server_p->bind6;
 	}
 	else if(server_p->aftype == AF_INET6 || GET_SS_FAMILY(&server_p->connect6) == AF_INET6)
 	{
 		sa_connect[0] = server_p->connect6;
+		sa_connect[1] = server_p->connect4;
 		sa_bind[0] = server_p->bind6;
+		sa_bind[1] = server_p->bind4;
 	}
 
 	/* log */


### PR DESCRIPTION
Due to [1], linking with SCTP sometimes does not multi-home correctly. This is triggered by the `rand()` on the lines immediately above these.

The `connect{}` blocks already support an `aftype` parameter to instruct IRCd to prefer IPv4 or IPv6. This commit additionally ensures that the other structure is always populated with the other address (if any) if this parameter is specified.

This will allow SCTP server-linking users to work around the bug and ensure that it always multi-homes by setting `connect::aftype` to IPv4. Without this commit, that would cause Solanum to not include the IPv6 addresses (if any) in the connect block in its SCTP setup.

If there isn't a valid IP address in the other sockaddr, this should be of no consequence, because it will not be used by `rb_connect_tcp()`, and both `rb_connect_sctp()` and `rb_sctp_bindx_only()` already verify that there is a valid IP address in the sockaddr before making use of it.

[1] https://marc.info/?l=linux-sctp&m=165684809726472&w=2