### PR TITLE
chm_regmsg: don't duplicate nick in 415

### DIFF
--- a/extensions/chm_regmsg.c
+++ b/extensions/chm_regmsg.c
@@ -71,7 +71,7 @@ chm_regmsg_process(void *data_)
 		return;
 
 	sendto_one_numeric(data->source_p, ERR_MSGNEEDREGGEDNICK, form_str(ERR_MSGNEEDREGGEDNICK),
-		data->source_p->name, data->chptr->chname);
+		data->chptr->chname);
 	data->approved = ERR_MSGNEEDREGGEDNICK;
 }
 

--- a/include/messages.h
+++ b/include/messages.h
@@ -152,7 +152,7 @@
 #define NUMERIC_STR_412      ":%s 412 %s :No text to send"
 #define NUMERIC_STR_413      "%s :No toplevel domain specified"
 #define NUMERIC_STR_414      "%s :Wildcard in toplevel Domain"
-#define NUMERIC_STR_415      "%s %s :Cannot send message to channel (+R) - you need to be logged into your NickServ account"
+#define NUMERIC_STR_415      "%s :Cannot send message to channel (+R) - you need to be logged into your NickServ account"
 #define NUMERIC_STR_416      ":%s 416 %s %s :output too large, truncated"
 #define NUMERIC_STR_421      ":%s 421 %s %s :Unknown command"
 #define NUMERIC_STR_422      ":%s 422 %s :MOTD File is missing"


### PR DESCRIPTION
sendto_one_numeric already includes the nick, so there's no need to duplicate it. OFTC does not.