### PR TITLE
OpenSSL 3.0 compatibility

### DIFF
--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -121,7 +121,11 @@ struct oper_conf
 
 #ifdef HAVE_LIBCRYPTO
 	char *rsa_pubkey_file;
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+	EVP_PKEY *rsa_pubkey;
+#else
 	RSA *rsa_pubkey;
+#endif
 #endif
 };
 

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -6,6 +6,10 @@
 #ifdef HAVE_LIBCRYPTO
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+#include <openssl/decoder.h>
+#include <openssl/core.h>
+#endif
 #endif
 
 #include "newconf.h"
@@ -631,8 +635,15 @@ conf_end_oper(struct TopConf *tc)
 				return 0;
 			}
 
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+			OSSL_DECODER_CTX *const ctx = OSSL_DECODER_CTX_new_for_pkey(&yy_tmpoper->rsa_pubkey, "PEM", NULL, "RSA", OSSL_KEYMGMT_SELECT_PUBLIC_KEY, NULL, NULL);
+			if (ctx != NULL)
+				OSSL_DECODER_from_bio(ctx, file);
+			OSSL_DECODER_CTX_free(ctx);
+#else
 			yy_tmpoper->rsa_pubkey =
 				(RSA *) PEM_read_bio_RSA_PUBKEY(file, NULL, 0, NULL);
+#endif
 
 			(void)BIO_set_close(file, BIO_CLOSE);
 			BIO_free(file);

--- a/ircd/s_newconf.c
+++ b/ircd/s_newconf.c
@@ -235,7 +235,11 @@ free_oper_conf(struct oper_conf *oper_p)
 	rb_free(oper_p->rsa_pubkey_file);
 
 	if(oper_p->rsa_pubkey)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+		OPENSSL_free((void *)oper_p->rsa_pubkey);
+#else
 		RSA_free(oper_p->rsa_pubkey);
+#endif
 #endif
 
 	rb_free(oper_p);


### PR DESCRIPTION
Attempts to clean up the deprecated functions in OpensSSL 3.0

m_challenge.c's #if's could be removed if librb/src/openssl_ratbox.h is updated
to handle EVP_MD_CTX_create/EVP_MD_CTX_destroy vs EVP_MD_CTX_new/EVP_MD_CTX_free

Only compile tested so far, as I don't have challenge setup in my environment
currently.