### PR TITLE
Fix assert = hard assignments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -497,7 +497,7 @@ elif test "$assert" = soft; then
 	AC_DEFINE(SOFT_ASSERT, 1, [Define this to enable soft asserts.])
 	AC_DEFINE(NDEBUG, 1, [Define this to disable debugging support.])
 elif test "$assert" = yes; then
-	assert = "hard";
+	assert="hard"
 fi
 
 AC_MSG_CHECKING(if you want to do a profile build)

--- a/librb/configure.ac
+++ b/librb/configure.ac
@@ -395,7 +395,7 @@ elif test "$assert" = soft; then
 	AC_DEFINE(SOFT_ASSERT, 1, [Define this to enable soft asserts.])
 	AC_DEFINE(NDEBUG, 1, [Define this to disable debugging support.])
 elif test "$assert" = yes; then
-	assert = "hard";
+	assert="hard"
 fi
 
 AC_MSG_CHECKING(if you want to do a profile build)


### PR DESCRIPTION
The spaces surrounding the = is bad syntax, which causes the shell to try to
execute 'assert'.

Granted, all of this is just cosmetic, as the only use of $assert seems to be
in the echo at the end of the configure run.