### PR TITLE
Remove ancient portability code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_STDBOOL
 
-AC_CHECK_HEADERS([crypt.h sys/resource.h sys/param.h errno.h sys/syslog.h stddef.h sys/wait.h wait.h sys/epoll.h sys/uio.h machine/endian.h])
+AC_CHECK_HEADERS([crypt.h sys/param.h sys/syslog.h sys/epoll.h machine/endian.h])
 
 dnl Stuff that the memory manager (imalloc) depends on
 dnl ==================================================
@@ -171,32 +171,11 @@ AC_CHECK_FUNCS([strlcat strlcpy])
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T
 
-AC_CHECK_TYPE([sa_family_t], [],
-[AC_DEFINE(sa_family_t, [u_int16_t], [If system does not define sa_family_t, define it here.])],
-[[#include <sys/types.h>
-#include <sys/socket.h>]])
-
 AC_CHECK_TYPES([uintptr_t])
 
 dnl check for various functions...
-AC_CHECK_FUNCS([snprintf vsnprintf socketpair mmap gettimeofday strdup strndup ])
 
 AC_FUNC_ALLOCA
-
-dnl Specialized functions checks
-dnl ============================
-
-dnl check for nanosleep
-AC_CHECK_FUNC(nanosleep,,[AC_CHECK_LIB(rt,nanosleep,
-                 LIBS="${LIBS} -lrt",
-                 [AC_CHECK_LIB(posix4,nanosleep, LIBS="${LIBS} -lposix4"
-                 )])])
-if test x$ac_cv_func_nanosleep = xno && test x$ac_cv_lib_posix4_nanosleep = xno  && test x$ac_cv_lib_rt_nanosleep = xno
-then
-         AC_MSG_RESULT("nanosleep not found..using select for delay")
-else
-	 AC_DEFINE([HAVE_NANOSLEEP], 1, [Define if nanosleep exists])
-fi
 
 dnl OpenSSL support
 AC_MSG_CHECKING(for OpenSSL)

--- a/include/stdinc.h
+++ b/include/stdinc.h
@@ -64,11 +64,7 @@ char *alloca ();
 # endif
 #endif
 
-
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
-
 
 #ifdef HAVE_STDBOOL_H
 # include <stdbool.h>
@@ -98,18 +94,11 @@ typedef bool _Bool;
 #include <ctype.h>
 
 #include <limits.h>
-
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif
-
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/file.h>
-#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
-#endif
-
 
 #include <sys/stat.h>
 
@@ -117,15 +106,8 @@ typedef bool _Bool;
 #include <sys/param.h>
 #endif
 
-#ifdef HAVE_ERRNO_H
 #include <errno.h>
-#else
-extern int errno;
-#endif
-
-#ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
-#endif
 
 #if defined(__INTEL_COMPILER) || defined(__GNUC__)
 # ifdef __unused

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -197,7 +197,6 @@ ircd_shutdown(const char *reason)
 static void
 init_sys(void)
 {
-#if defined(RLIMIT_NOFILE) && defined(HAVE_SYS_RESOURCE_H)
 	struct rlimit limit;
 
 	if(!getrlimit(RLIMIT_NOFILE, &limit))
@@ -211,7 +210,6 @@ init_sys(void)
 		}
 		return;
 	}
-#endif /* RLIMIT_FD_MAX */
 	maxconnections = MAXCONNECTIONS;
 }
 
@@ -425,7 +423,6 @@ check_pidfile(const char *filename)
 static void
 setup_corefile(void)
 {
-#ifdef HAVE_SYS_RESOURCE_H
 	struct rlimit rlim;	/* resource limits */
 
 	/* Set corefilesize to maximum */
@@ -434,7 +431,6 @@ setup_corefile(void)
 		rlim.rlim_cur = rlim.rlim_max;
 		setrlimit(RLIMIT_CORE, &rlim);
 	}
-#endif
 }
 
 static void

--- a/librb/acinclude.m4
+++ b/librb/acinclude.m4
@@ -84,15 +84,9 @@ AC_DEFUN([RB_CHECK_TIMER_CREATE],
   [AC_CACHE_CHECK([for a working timer_create(CLOCK_REALTIME)],
     [rb__cv_timer_create_works],
     [AC_TRY_RUN([
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 int main(int argc, char *argv[])
 {
 #if HAVE_TIMER_CREATE
@@ -125,15 +119,9 @@ AC_DEFUN([RB_CHECK_TIMERFD_CREATE],
   [AC_CACHE_CHECK([for a working timerfd_create(CLOCK_REALTIME)],
     [rb__cv_timerfd_create_works],
     [AC_TRY_RUN([
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 #ifdef HAVE_SYS_TIMERFD_H
 #include <sys/timerfd.h>
 #endif

--- a/librb/configure.ac
+++ b/librb/configure.ac
@@ -84,7 +84,7 @@ AC_TYPE_UID_T
 dnl Checks for header files.
 AC_HEADER_STDC
 
-AC_CHECK_HEADERS([crypt.h unistd.h sys/socket.h sys/stat.h sys/time.h time.h netinet/in.h netinet/tcp.h netinet/sctp.h arpa/inet.h errno.h sys/uio.h spawn.h sys/poll.h sys/epoll.h sys/select.h sys/devpoll.h sys/event.h port.h signal.h sys/signalfd.h sys/timerfd.h])
+AC_CHECK_HEADERS([crypt.h netinet/sctp.h sys/poll.h sys/epoll.h sys/select.h sys/devpoll.h sys/event.h port.h sys/signalfd.h sys/timerfd.h])
 AC_HEADER_TIME
 
 dnl Networking Functions
@@ -95,75 +95,15 @@ AC_SEARCH_LIBS(socket, [socket],,)
 
 AC_CHECK_MEMBER([struct sockaddr.sa_len], [AC_DEFINE(SOCKADDR_IN_HAS_LEN, 1, [Define to 1 if sockaddr has a 'sa_len'
 member.])],,[[
-#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif
 ]])
-
-AC_CHECK_TYPE([socklen_t], rb_cv_socklen_t=socklen_t,[
-	AC_MSG_CHECKING([for socklen_t equivalent])
-	AC_CACHE_VAL([rb_cv_socklen_t],
-	[
-	# Systems have either "struct sockaddr *" or
-	# "void *" as the second argument to getpeername
-	rb_cv_socklen_t=
-	for arg2 in "struct sockaddr" void; do
-		for t in int size_t unsigned long "unsigned long"; do
-			AC_TRY_COMPILE([
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
-int getpeername (int, $arg2 *, $t *);
-],[
-$t len;
-getpeername(0,0,&len);
-],[
-	rb_cv_socklen_t="$t"
-	break
-])
-		done
-	done
-
-	if test "x$rb_cv_socklen_t" = x; then
-		AC_MSG_WARN([Cannot find a type to use in place of socklen_t using int])
-		rb_cv_socklen_t=int
-	fi
-	])
-	AC_MSG_RESULT($rb_cv_socklen_t)],
-	[#include <sys/types.h>
-#include <sys/socket.h>])
-
-rb_socklen_t=$rb_cv_socklen_t
-
-
-
-
-
-AC_CHECK_TYPES([struct sockaddr_storage],[
-	rb_have_sockaddr_storage=yes
-        ],[], [
-		#include <sys/types.h>
-		#include <sys/socket.h>
-	])
-
 
 dnl Check for stdarg.h - if we cant find it, halt configure
 AC_CHECK_HEADER(stdarg.h, , [AC_MSG_ERROR([** stdarg.h could not be found - librb will not compile without it **])])
 
-AC_CHECK_TYPE([sa_family_t], [],
-[AC_DEFINE(sa_family_t, [u_int16_t], [If system does not define sa_family_t, define it here.])],
-[[#include <sys/types.h>
-#include <sys/socket.h>]])
-
-
 dnl check for various functions...
-AC_CHECK_FUNCS([snprintf vsnprintf socketpair gettimeofday writev sendmsg gmtime_r strtok_r usleep posix_spawn getexecname strlcpy strlcat strnlen strcasestr strcasecmp strncasecmp fstat signalfd select poll kevent port_create epoll_ctl arc4random getrusage timerfd_create])	
+AC_CHECK_FUNCS([getexecname strlcpy strlcat strcasestr signalfd kevent port_create epoll_ctl arc4random timerfd_create])	
 
 AC_SEARCH_LIBS(dlinfo, dl, AC_DEFINE(HAVE_DLINFO, 1, [Define if you have dlinfo]))
 AC_SEARCH_LIBS(nanosleep, rt posix4, AC_DEFINE(HAVE_NANOSLEEP, 1, [Define if you have nanosleep]))
@@ -457,82 +397,40 @@ if test "x$rb_alloca_h" = "xyes"; then
 	echo '#define RB_HAVE_ALLOCA_H 1' >> $outfile
 fi
 
-if test "x$rb_header_stdc" = "xyes"; then
-	echo '#include <stdlib.h>' >> $outfile
-	echo '#include <stddef.h>' >> $outfile
-elif test "x$rb_header_stdlib" = "xyes"; then
-	echo '#include <stdlib.h>' >> $outfile
-fi
-
-if test "x$rb_header_string_h" = "xyes"; then
-	echo '#include <string.h>' >> $outfile
-fi
-
-if test "x$rb_stdint_h" = "xyes"; then
-	echo '#include <stdint.h>' >> $outfile
-fi
-
-if test "x$rb_inttypes_h" = "xyes"; then
-	echo '#include <inttypes.h>' >> $outfile
-fi
-
-if test "x$rb_sys_types_h" = "xyes"; then
-	echo '#include <sys/types.h>' >> $outfile
-fi
-if test "x$rb_sys_time_h" = "xyes"; then
-	echo '#include <sys/time.h>' >> $outfile
-fi
-if test "x$rb_sys_stat_h" = "xyes"; then
-	echo '#include <sys/stat.h>' >> $outfile
-fi
-if test "x$rb_time_h" = "xyes"; then
-	echo '#include <time.h>' >> $outfile
-fi
-
-if test "x$rb_sys_socket_h" = "xyes"; then
-	echo '#include <sys/socket.h>' >> $outfile
-fi
-
-if test "x$rb_netinet_in_h" = "xyes"; then
-	echo '#include <netinet/in.h>' >> $outfile
-fi
-
-if test "x$rb_netinet_tcp_h" == "xyes"; then
-	echo '#include <netinet/tcp.h>' >> $outfile
-fi
+echo '#include <stdlib.h>' >> $outfile
+echo '#include <stddef.h>' >> $outfile
+echo '#include <string.h>' >> $outfile
+echo '#include <stdint.h>' >> $outfile
+echo '#include <inttypes.h>' >> $outfile
+echo '#include <sys/types.h>' >> $outfile
+echo '#include <sys/time.h>' >> $outfile
+echo '#include <sys/stat.h>' >> $outfile
+echo '#include <time.h>' >> $outfile
+echo '#include <sys/socket.h>' >> $outfile
+echo '#include <netinet/in.h>' >> $outfile
+echo '#include <netinet/tcp.h>' >> $outfile
 
 if test "x$rb_netinet_sctp_h" == "xyes"; then
 	echo '#include <netinet/sctp.h>' >> $outfile
 fi
 
-if test "x$rb_arpa_inet_h" = "xyes"; then
-	echo '#include <arpa/inet.h>' >> $outfile
-fi
-
-if test "x$rb_unistd_h" = "xyes"; then
-	echo '#include <unistd.h>' >> $outfile
-fi
+echo '#include <arpa/inet.h>' >> $outfile
+echo '#include <unistd.h>' >> $outfile
 
 if test "x$rb_crypt_h" = "xyes"; then
 	echo '#include <crypt.h>' >> $outfile
 fi
 
-if test "x$rb_errno_h" = "xyes"; then
-	echo '#include <errno.h>' >> $outfile
-fi
+echo '#include <errno.h>' >> $outfile
 
-echo "typedef $rb_socklen_t rb_socklen_t;" >> $outfile
+echo "typedef socklen_t rb_socklen_t;" >> $outfile
 
 
 if test "x$rb_sockaddr_sa_len" = "xyes"; then
 	echo '#define RB_SOCKADDR_HAS_SA_LEN 1' >> $outfile
 fi
 
-if test "x$rb_sockaddr_storage" = "xyes"; then
-	echo '#define rb_sockaddr_storage sockaddr_storage' >> $outfile
-else
-	echo 'struct rb_sockaddr_storage { uint8_t _padding[[128]]; };' >> $outfile
-fi
+echo '#define rb_sockaddr_storage sockaddr_storage' >> $outfile
 
 cat >> $outfile <<\_______EOF
 #endif /* __LIBRB_CONFIG_H */
@@ -546,15 +444,6 @@ else
 fi
 
 ],[
-	if test x$ac_cv_header_stdc = xyes; then
-		rb_header_stdc=yes
-	fi
-	if test x$ac_cv_header_stdlib_h = xyes; then
-		rb_header_stdlib_h=yes
-	fi
-	if test x$ac_cv_header_string_h = xyes; then
-		rb_header_string_h=yes
-	fi
 	if test x$ac_cv_header_memory_h = xyes; then
 		rb_header_memory_h=yes
 	fi
@@ -566,34 +455,7 @@ fi
 	if test x$ac_cv_member_struct_sockaddr_sa_len = xyes; then
 		rb_sockaddr_sa_len=yes
 	fi
-	if test x$ac_cv_header_sys_socket_h = xyes; then
-		rb_sys_socket_h=yes
-	fi
-	if test x$ac_cv_header_sys_types_h = xyes; then
-		rb_sys_types_h=yes
-	fi
-	if test x$ac_cv_header_sys_stat_h = xyes; then
-		rb_sys_stat_h=yes
-	fi
-	if test x$ac_cv_header_sys_time_h = xyes; then
-		rb_sys_time_h=yes
-	fi
-	if test x$ac_cv_header_time_h = xyes; then
-		rb_time_h=yes
-	fi
 
-	if test x$ac_cv_header_stdint_h = xyes; then
-		rb_stdint_h=yes
-	fi
-	if test x$ac_cv_header_inttypes_h = xyes; then
-		rb_inttypes_h=yes
-	fi
-	if test x$ac_cv_header_netinet_in_h = xyes; then
-		rb_netinet_in_h=yes
-	fi
-	if test x$ac_cv_header_netinet_tcp_h = xyes; then
-		rb_netinet_tcp_h=yes
-	fi
 	if test x$ac_cv_header_netinet_sctp_h = xyes; then
 		rb_netinet_sctp_h=yes
 	fi
@@ -601,27 +463,12 @@ fi
 	if test x$ac_cv_header_crypt_h = xyes; then
 		rb_crypt_h=yes
 	fi
-	if test x$ac_cv_header_errno_h = xyes; then
-		rb_errno_h=yes
-	fi
-	if test x$ac_cv_header_unistd_h = xyes; then
-		rb_unistd_h=yes
-	fi
 
-	rb_socklen_t=$rb_socklen_t
-
-	if test "x$rb_have_sockaddr_storage" = "xyes"; then
-		rb_sockaddr_storage="yes"
-	else
-		rb_sockaddr_storage="no"
-	fi
+	rb_socklen_t="socklen_t"
 
 	rb_mv="$MV"
 	rb_rm="$RM"
-
 ]
-
-
 )
 
 

--- a/librb/include/commio-int.h
+++ b/librb/include/commio-int.h
@@ -34,7 +34,6 @@
 
 #define rb_hash_fd(x) ((x ^ (x >> RB_FD_HASH_BITS) ^ (x >> (RB_FD_HASH_BITS * 2))) & RB_FD_HASH_MASK)
 
-#ifdef HAVE_WRITEV
 #ifndef UIO_MAXIOV
 # if defined(__FreeBSD__) || defined(__APPLE__) || defined(__NetBSD__)
 			/* FreeBSD 4.7 defines it in sys/uio.h only if _KERNEL is specified */
@@ -57,9 +56,6 @@
 # endif
 #else
 #define RB_UIO_MAXIOV UIO_MAXIOV
-#endif
-#else
-#define RB_UIO_MAXIOV 16
 #endif
 struct conndata
 {

--- a/librb/src/arc4random.c
+++ b/librb/src/arc4random.c
@@ -34,10 +34,7 @@
 
 #include "arc4random.h"
 
-#ifdef HAVE_GETRUSAGE
 #include <sys/resource.h>
-#endif
-
 
 
 struct arc4_stream
@@ -104,13 +101,11 @@ arc4_stir(struct arc4_stream *as)
 	rb_gettimeofday(&tv, NULL);
 	arc4_addrandom(as, (void *)&tv.tv_usec, sizeof(&tv.tv_usec));
 
-#if defined(HAVE_GETRUSAGE) && RUSAGE_SELF
 	{
 		struct rusage buf;
 		getrusage(RUSAGE_SELF, &buf);
 		arc4_addrandom(as, (void *)&buf, sizeof(buf));
 	memset(&buf, 0, sizeof(buf))}
-#endif
 
 	fd = open("/dev/urandom", O_RDONLY);
 	if(fd != -1)

--- a/librb/src/epoll.c
+++ b/librb/src/epoll.c
@@ -31,19 +31,19 @@
 #include <rb_lib.h>
 #include <commio-int.h>
 #include <event-int.h>
-#if defined(HAVE_EPOLL_CTL) && (HAVE_SYS_EPOLL_H)
+#if defined(HAVE_EPOLL_CTL) && defined(HAVE_SYS_EPOLL_H)
 #define USING_EPOLL
 #include <fcntl.h>
 #include <sys/epoll.h>
 
-#if defined(HAVE_SIGNALFD) && (HAVE_SYS_SIGNALFD_H) && (USE_TIMER_CREATE) && (HAVE_SYS_UIO_H)
+#if defined(HAVE_SIGNALFD) && defined(HAVE_SYS_SIGNALFD_H) && defined(USE_TIMER_CREATE)
 #include <signal.h>
 #include <sys/signalfd.h>
 #include <sys/uio.h>
 #define EPOLL_SCHED_EVENT 1
 #endif
 
-#if defined(USE_TIMERFD_CREATE)
+#ifdef USE_TIMERFD_CREATE
 #include <sys/timerfd.h>
 #endif
 

--- a/librb/src/linebuf.c
+++ b/librb/src/linebuf.c
@@ -545,7 +545,6 @@ rb_linebuf_flush(rb_fde_t *F, buf_head_t * bufhead)
  * autoconf checks for this..but really just want to use it if we have a
  * native version even if libircd provides a fake version...
  */
-#ifdef HAVE_WRITEV
 	if(!rb_fd_ssl(F))
 	{
 		rb_dlink_node *ptr;
@@ -624,7 +623,6 @@ rb_linebuf_flush(rb_fde_t *F, buf_head_t * bufhead)
 
 		return retval;
 	}
-#endif
 
 	/* this is the non-writev case */
 

--- a/librb/src/poll.c
+++ b/librb/src/poll.c
@@ -26,9 +26,11 @@
 #include <librb_config.h>
 #include <rb_lib.h>
 #include <commio-int.h>
+#include <poll.h>
 
-#if defined(HAVE_POLL) && (HAVE_SYS_POLL_H)
+#ifdef HAVE_SYS_POLL_H
 #include <sys/poll.h>
+#endif
 
 
 /* I hate linux -- adrian */
@@ -228,34 +230,3 @@ rb_select_poll(long delay)
 	}
 	return 0;
 }
-
-#else /* poll not supported */
-int
-rb_init_netio_poll(void)
-{
-	errno = ENOSYS;
-	return -1;
-}
-
-void
-rb_setselect_poll(rb_fde_t *F __attribute__((unused)), unsigned int type __attribute__((unused)), PF * handler __attribute__((unused)), void *client_data __attribute__((unused)))
-{
-	errno = ENOSYS;
-	return;
-}
-
-int
-rb_select_poll(long delay __attribute__((unused)))
-{
-	errno = ENOSYS;
-	return -1;
-}
-
-int
-rb_setup_fd_poll(rb_fde_t *F __attribute__((unused)))
-{
-	errno = ENOSYS;
-	return -1;
-}
-
-#endif

--- a/librb/src/rb_lib.c
+++ b/librb/src/rb_lib.c
@@ -63,12 +63,9 @@ rb_ctime(const time_t t, char *buf, size_t len)
 	struct tm *tp;
 	static char timex[128];
 	size_t tlen;
-#if defined(HAVE_GMTIME_R)
 	struct tm tmr;
 	tp = gmtime_r(&t, &tmr);
-#else
-	tp = gmtime(&t);
-#endif
+
 	if(buf == NULL)
 	{
 		p = timex;
@@ -98,12 +95,8 @@ char *
 rb_date(const time_t t, char *buf, size_t len)
 {
 	struct tm *gm;
-#if defined(HAVE_GMTIME_R)
 	struct tm gmbuf;
 	gm = gmtime_r(&t, &gmbuf);
-#else
-	gm = gmtime(&t);
-#endif
 
 	if(rb_unlikely(gm == NULL))
 	{
@@ -249,44 +242,11 @@ rb_lib_loop(long delay)
 	}
 }
 
-#ifndef HAVE_STRTOK_R
-char *
-rb_strtok_r(char *s, const char *delim, char **save)
-{
-	char *token;
-
-	if(s == NULL)
-		s = *save;
-
-	/* Scan leading delimiters.  */
-	s += strspn(s, delim);
-
-	if(*s == '\0')
-	{
-		*save = s;
-		return NULL;
-	}
-
-	token = s;
-	s = strpbrk(token, delim);
-
-	if(s == NULL)
-		*save = (token + strlen(token));
-	else
-	{
-		*s = '\0';
-		*save = s + 1;
-	}
-	return token;
-}
-#else
 char *
 rb_strtok_r(char *s, const char *delim, char **save)
 {
 	return strtok_r(s, delim, save);
 }
-#endif
-
 
 static const char base64_table[] =
 	{ 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',

--- a/librb/src/sigio.c
+++ b/librb/src/sigio.c
@@ -35,17 +35,16 @@
 #include <event-int.h>
 #include <fcntl.h>		/* Yes this needs to be before the ifdef */
 
-#if defined(HAVE_SYS_POLL_H) && (HAVE_POLL) && (F_SETSIG)
+#if defined(HAVE_SYS_POLL_H) && defined(F_SETSIG)
 #define USING_SIGIO
 #endif
-
 
 #ifdef USING_SIGIO
 
 #include <signal.h>
 #include <sys/poll.h>
 
-#if defined(USE_TIMER_CREATE)
+#ifdef USE_TIMER_CREATE
 #define SIGIO_SCHED_EVENT 1
 #endif
 

--- a/librb/src/tools.c
+++ b/librb/src/tools.c
@@ -133,57 +133,17 @@ rb_string_to_array(char *string, char **parv, int maxpara)
 	return x;
 }
 
-#ifndef HAVE_STRCASECMP
-/* Fallback taken from FreeBSD. --Elizafox */
-int
-rb_strcasecmp(const char *s1, const char *s2)
-{
-	const unsigned char *us1 = (const unsigned char *)s1;
-	const unsigned char *us2 = (const unsigned char *)s2;
-
-	while (tolower(*us1) == tolower(*us2++))
-	{
-		if (*us1++ == '\0')
-			return 0;
-	}
-
-	return (tolower(*us1) - tolower(*--us2));
-}
-#else
 int
 rb_strcasecmp(const char *s1, const char *s2)
 {
 	return strcasecmp(s1, s2);
 }
-#endif
 
-#ifndef HAVE_STRNCASECMP
-/* Fallback taken from FreeBSD. --Elizafox */
-int
-rb_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-	if (n != 0)
-	{
-		const unsigned char *us1 = (const unsigned char *)s1;
-		const unsigned char *us2 = (const unsigned char *)s2;
-
-		do
-		{
-			if (tolower(*us1) != tolower(*us2++))
-				return (tolower(*us1) - tolower(*--us2));
-			if (*us1++ == '\0')
-				break;
-		} while (--n != 0);
-	}
-	return 0;
-}
-#else
 int
 rb_strncasecmp(const char *s1, const char *s2, size_t n)
 {
 	return strncasecmp(s1, s2, n);
 }
-#endif
 
 #ifndef HAVE_STRCASESTR
 /* Fallback taken from FreeBSD. --Elizafox */
@@ -261,22 +221,11 @@ rb_strlcpy(char *dest, const char *src, size_t size)
 #endif
 
 
-#ifndef HAVE_STRNLEN
-size_t
-rb_strnlen(const char *s, size_t count)
-{
-	const char *sc;
-	for(sc = s; count-- && *sc != '\0'; ++sc)
-		;
-	return sc - s;
-}
-#else
 size_t
 rb_strnlen(const char *s, size_t count)
 {
 	return strnlen(s, count);
 }
-#endif
 
 /*
  * rb_snprintf_append()

--- a/librb/src/unix.c
+++ b/librb/src/unix.c
@@ -42,7 +42,6 @@
 #include <sys/sysctl.h>
 #endif
 
-#if defined(HAVE_SPAWN_H) && defined(HAVE_POSIX_SPAWN)
 #include <spawn.h>
 
 #ifndef __APPLE__
@@ -74,56 +73,20 @@ rb_spawn_process(const char *path, const char **argv)
 	}
 	return pid;
 }
-#else
-pid_t
-rb_spawn_process(const char *path, const char **argv)
-{
-	pid_t pid;
-	if(!(pid = vfork()))
-	{
-		execv(path, (const void *)argv);	/* make gcc shut up */
-		_exit(1);	/* if we're still here, we're screwed */
-	}
-	return (pid);
-}
-#endif
 
-#ifndef HAVE_GETTIMEOFDAY
-int
-rb_gettimeofday(struct timeval *tv, void *tz)
-{
-	if(tv == NULL)
-	{
-		errno = EFAULT;
-		return -1;
-	}
-	tv->tv_usec = 0;
-	if(time(&tv->tv_sec) == -1)
-		return -1;
-	return 0;
-}
-#else
 int
 rb_gettimeofday(struct timeval *tv, void *tz)
 {
 	return (gettimeofday(tv, tz));
 }
-#endif
 
 void
 rb_sleep(unsigned int seconds, unsigned int useconds)
 {
-#ifdef HAVE_NANOSLEEP
 	struct timespec tv;
 	tv.tv_nsec = (useconds * 1000);
 	tv.tv_sec = seconds;
 	nanosleep(&tv, NULL);
-#else
-	struct timeval tv;
-	tv.tv_sec = seconds;
-	tv.tv_usec = useconds;
-	select(0, NULL, NULL, NULL, &tv);
-#endif
 }
 
 /* this is to keep some linkers from bitching about exporting a non-existant symbol..bleh */

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -518,14 +518,12 @@ conn_plain_write_sendq(rb_fde_t *fd, void *data)
 static int
 maxconn(void)
 {
-#if defined(RLIMIT_NOFILE) && defined(HAVE_SYS_RESOURCE_H)
 	struct rlimit limit;
 
 	if(!getrlimit(RLIMIT_NOFILE, &limit))
 	{
 		return limit.rlim_cur;
 	}
-#endif /* RLIMIT_FD_MAX */
 	return MAXCONNECTIONS;
 }
 

--- a/wsockd/wsockd.c
+++ b/wsockd/wsockd.c
@@ -213,14 +213,12 @@ setup_signals()
 static int
 maxconn(void)
 {
-#if defined(RLIMIT_NOFILE) && defined(HAVE_SYS_RESOURCE_H)
 	struct rlimit limit;
 
 	if(!getrlimit(RLIMIT_NOFILE, &limit))
 	{
 		return limit.rlim_cur;
 	}
-#endif /* RLIMIT_FD_MAX */
 	return MAXCONNECTIONS;
 }
 


### PR DESCRIPTION
Remove portability code for systems that don't follow at least SUSv3.
This fairly closely aligns with ISO C99, which solanum already requires.