### PR TITLE
um_callerid, um_regonlymsg: various cleanups

### DIFF
--- a/modules/um_callerid.c
+++ b/modules/um_callerid.c
@@ -182,9 +182,7 @@ add_callerid_accept_for_source(enum message_type msgtype, struct Client *source_
 	 * as a way of griefing.  --nenolod
 	 */
 	if(msgtype != MESSAGE_TYPE_NOTICE &&
-		IsSetAnyCallerID(source_p) &&
-		!accept_message(target_p, source_p) &&
-		!IsOperGeneral(target_p))
+		!allow_message(target_p, source_p))
 	{
 		if(rb_dlink_list_length(&source_p->localClient->allow_list) <
 				(unsigned long)ConfigFileEntry.max_accept)

--- a/modules/um_regonlymsg.c
+++ b/modules/um_regonlymsg.c
@@ -85,10 +85,10 @@ allow_message(struct Client *source_p, struct Client *target_p)
 	if (IsOper(source_p))
 		return true;
 
-	if (accept_message(source_p, target_p))
+	if (source_p->user->suser[0])
 		return true;
 
-	if (source_p->user->suser[0])
+	if (accept_message(source_p, target_p))
 		return true;
 
 	return false;

--- a/modules/um_regonlymsg.c
+++ b/modules/um_regonlymsg.c
@@ -101,9 +101,7 @@ add_callerid_accept_for_source(enum message_type msgtype, struct Client *source_
 		return true;
 
 	if(msgtype != MESSAGE_TYPE_NOTICE &&
-		IsSetRegOnlyMsg(source_p) &&
-		!accept_message(target_p, source_p) &&
-		!IsOperGeneral(target_p))
+		!allow_message(target_p, source_p))
 	{
 		if(rb_dlink_list_length(&source_p->localClient->allow_list) <
 				(unsigned long)ConfigFileEntry.max_accept)


### PR DESCRIPTION
Uses `allow_message` instead of `accept_message` so that reverse auto-`/accept` entries are only added if reverse messages would not otherwise be allowed.  This change also fixes messages to opers not triggering reverse auto-`/accept`, which is needed with the switch to a usermode (and privilege) to bypass callerid.

Also has `um_regonlymsg` check whether the source is identified before scanning the target's `/accept` list, which saves an unnecessary scan for identified sources.