### PR TITLE
remove old reference to the unsupported directory from extensions readme

### DIFF
--- a/extensions/README
+++ b/extensions/README
@@ -1,6 +1,6 @@
 This directory contains extensions (modules) to solanum ircd that
 have been contributed by other people, or written by our development
-team.  Unsupported extensions live under unsupported/.
+team.
 
 
 Modules


### PR DESCRIPTION
the unsupported directory [was removed](https://github.com/solanum-ircd/solanum/blob/main/NEWS.md#misc-6) by charybdis a while ago