### PR TITLE
Add semicolon to fix a compile error in librb/src/arc4random.c

### DIFF
--- a/librb/src/arc4random.c
+++ b/librb/src/arc4random.c
@@ -105,7 +105,7 @@ arc4_stir(struct arc4_stream *as)
 		struct rusage buf;
 		getrusage(RUSAGE_SELF, &buf);
 		arc4_addrandom(as, (void *)&buf, sizeof(buf));
-	memset(&buf, 0, sizeof(buf))}
+	memset(&buf, 0, sizeof(buf));}
 
 	fd = open("/dev/urandom", O_RDONLY);
 	if(fd != -1)


### PR DESCRIPTION
For some reason, compiling failed, and GCC said a semicolon was needed here. All tests succeeded locally with a semicolon (make check).
GCC version:
```
gcc (GCC) 11.3.0
```
flex version:
```
flex 2.6.4
```
bison version:
```
bison (GNU Bison) 3.8.2
```
sqlite version:
```
3.38.5 2022-05-06 15:25:27 78d9c993d404cdfaa7fdd2973fa1052e3da9f66215cff9c5540ebe55c407d9fe
```
autoconf version:
```
autoconf (GNU Autoconf) 2.71
```
automake version:
```
automake (GNU automake) 1.16.5
```
cmake version:
```
cmake version 3.22.3
```
pkg-config version:
```
0.29.2
```
libtool version:
```
libtool (GNU libtool) 2.4.7
```
Latest commit:
```
01fb744c405792dd3f0859a53f74cd4cb5fd166f
```
column version:
```
column from util-linux 2.37.4
```
autoreconf version:
```
autoreconf (GNU Autoconf) 2.71
```
Output of make when failing:
```
  CC       arc4random.lo
arc4random.c: In function 'arc4_stir':
arc4random.c:108:37: error: expected ';' before '}' token
  108 |         memset(&buf, 0, sizeof(buf))}
      |                                     ^
      |                                     ;
arc4random.c:113:17: warning: ignoring return value of 'read' declared with attribute 'warn_unused_result' [-Wunused-result]
  113 |                 read(fd, rnd, sizeof(rnd));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
make[5]: *** [Makefile:523: arc4random.lo] Error 1
make[5]: Leaving directory '/home/runner/irc/solanum/librb/src'
make[4]: *** [Makefile:395: all] Error 2
make[4]: Leaving directory '/home/runner/irc/solanum/librb/src'
make[3]: *** [Makefile:472: all-recursive] Error 1
make[3]: Leaving directory '/home/runner/irc/solanum/librb'
make[2]: *** [Makefile:381: all] Error 2
make[2]: Leaving directory '/home/runner/irc/solanum/librb'
make[1]: *** [Makefile:470: all-recursive] Error 1
make[1]: Leaving directory '/home/runner/irc/solanum'
make: *** [Makefile:402: all] Error 2
~/irc/solanum$
```
Sorry if I did something wrong here, I wasn't entirely sure what to do.