### PR TITLE
clang annoyances

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -592,6 +592,7 @@ SOLANUM_C_GCC_TRY_FLAGS([-Wunused-function -Wunused-label -Wunused-value -Wunuse
 SOLANUM_C_GCC_TRY_FLAGS([-Wredundant-decls], solanum_cv_c_gcc_w_redundant_decls)
 SOLANUM_C_GCC_TRY_FLAGS([-Wfloat-equal], solanum_cv_c_gcc_w_float_equal)
 SOLANUM_C_GCC_TRY_FLAGS([-Wformat -Wformat-y2k -Wno-format-security], solanum_cv_c_gcc_w_format)
+SOLANUM_C_GCC_TRY_FLAGS([-Wno-compound-token-split-by-macro], solanum_cv_c_gcc_w_compound_split)
 
 IRC_CFLAGS="$CFLAGS"
 ],[])

--- a/librb/configure.ac
+++ b/librb/configure.ac
@@ -366,7 +366,7 @@ fi
 
 AC_ARG_ENABLE(warnings,
 AC_HELP_STRING([--enable-warnings],[Enable all sorts of warnings for debugging.]),
-[CFLAGS="$CFLAGS -Wall -Werror -Wcast-qual -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -W -Wno-unused -Wunused-function -Wunused-variable -Wno-unused-parameter"],[])
+[CFLAGS="$CFLAGS -Wall -Werror -Wcast-qual -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -W -Wno-unused -Wunused-function -Wunused-variable -Wno-unused-parameter -Wno-unused-command-line-argument"],[])
 
 AC_SUBST(LDFLAGS)
 AC_SUBST(PICFLAGS)


### PR DESCRIPTION
-Wno-unused-command-line-argument for librb/configure since it uses -Wall. This gets rid of errors when flags like
-L/usr/local/lib are needed by some modules and not others.

-Wno-compound-token-split-by-macro to get it to shut up about libltdl/ macros that we have no control over.

gcc probably doesn't grok the first one, but it also seems to silently ignore -Wno-* flags that it doesn't understand, at least on gcc 12.