### PR TITLE
extensions/umode_hide_idle_time: mask times for hidden sources

### DIFF
--- a/extensions/umode_hide_idle_time.c
+++ b/extensions/umode_hide_idle_time.c
@@ -48,7 +48,7 @@ h_huc_doing_idle_time_hook(void *data_)
 	if (data->approved == 0)
 		return;
 
-	if (data->target->umodes & user_modes['I'])
+	if ((data->client->umodes | data->target->umodes) & user_modes['I'])
 	{
 		if (HasPrivilege(data->client, "auspex:usertimes"))
 			data->approved = WHOIS_IDLE_AUSPEX;

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -24,6 +24,9 @@ User modes: (* designates that the umode is oper only)
          +G     - Deny users not on your /ACCEPT list and not in a channel
                   with you from messaging you and inviting you to channels.
                   This is a softer form of +g.
+       ? +I     - Hides your WHOIS idle time and prevents you seeing the idle
+                  time of other users (unless you have the auspex:usertimes
+                  privilege).
          +Q     - Prevents you from being affected by channel forwarding.
          +R     - Prevents unidentified users that you have not accepted from
                   messaging you.

--- a/help/users/umode
+++ b/help/users/umode
@@ -19,7 +19,8 @@ User modes: (? designates that the umode is provided by an extension
          +G     - Deny users not on your /ACCEPT list and not in a channel
                   with you from messaging you and inviting you to channels.
                   This is a softer form of +g.
-       ? +I     - Hides your idle time.
+       ? +I     - Hides your WHOIS idle time and prevents you seeing the idle
+                  time of other users.
          +Q     - Prevents you from being affected by channel forwarding.
          +R     - Prevents unidentified users that you have not accepted from
                   messaging you.

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -30,10 +30,10 @@
 #include "ircd.h"
 #include "numeric.h"
 #include "s_conf.h"
+#include "s_user.h"
 #include "s_serv.h"
 #include "send.h"
 #include "match.h"
-#include "s_conf.h"
 #include "logger.h"
 #include "msg.h"
 #include "parse.h"
@@ -389,9 +389,12 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 			   hdata_showidle.approved ? (long)(rb_current_time() - target_p->localClient->last) : 0,
 			   (unsigned long)target_p->localClient->firsttime);
 
-		if (hdata_showidle.approved == WHOIS_IDLE_AUSPEX || hdata_showidle.approved == WHOIS_IDLE_HIDE)
+		if (hdata_showidle.approved == WHOIS_IDLE_HIDE && (source_p->umodes & user_modes['I']))
+			/* if the source has hidden their idle time, notify the source that they can't view others' idle times either */
+			sendto_one_numeric(source_p, RPL_WHOISTEXT, form_str(RPL_WHOISTEXT), target_p->name, "has a hidden idle time because your own idle time is hidden");
+		else if (hdata_showidle.approved != WHOIS_IDLE_SHOW)
 			/* if the target has hidden their idle time, notify the source */
-			sendto_one_numeric(source_p, RPL_WHOISTEXT, form_str(RPL_WHOISTEXT), target_p->name, "is using a private idle time");
+			sendto_one_numeric(source_p, RPL_WHOISTEXT, form_str(RPL_WHOISTEXT), target_p->name, "is hiding their idle time");
 	}
 	else
 	{


### PR DESCRIPTION
If the user performing a WHOIS has hidden their idle time (is umode `+I`), also prevent them from seeing other user's idle times,  even if said users are not themselves umode `+I`.

Suggested-by: @Unit193