### PR TITLE
librb/helper: pass our fd limit to the child

### DIFF
--- a/librb/src/helper.c
+++ b/librb/src/helper.c
@@ -105,7 +105,7 @@ rb_helper_start(const char *name, const char *fullpath, rb_helper_cb * read_cb,
 	rb_helper *helper;
 	const char *parv[2];
 	char buf[128];
-	char fx[16], fy[16];
+	char fx[16], fy[16], maxfd[16];
 	rb_fde_t *in_f[2];
 	rb_fde_t *out_f[2];
 	pid_t pid;
@@ -130,6 +130,7 @@ rb_helper_start(const char *name, const char *fullpath, rb_helper_cb * read_cb,
 
 	snprintf(fx, sizeof(fx), "%d", rb_get_fd(in_f[1]));
 	snprintf(fy, sizeof(fy), "%d", rb_get_fd(out_f[0]));
+	snprintf(maxfd, sizeof(maxfd), "%d", rb_getmaxconnect());
 
 	rb_set_nb(in_f[0]);
 	rb_set_nb(in_f[1]);
@@ -138,7 +139,7 @@ rb_helper_start(const char *name, const char *fullpath, rb_helper_cb * read_cb,
 
 	rb_setenv("IFD", fy, 1);
 	rb_setenv("OFD", fx, 1);
-	rb_setenv("MAXFD", "256", 1);
+	rb_setenv("MAXFD", maxfd, 1);
 
 	snprintf(buf, sizeof(buf), "-ircd %s daemon", name);
 	parv[0] = buf;


### PR DESCRIPTION
Instead of arbitrarily limiting it to 256.  This avoids an issue with 
busy authds "running out" of fds because librb says no more.