### PR TITLE
Make auto-accept on message conditional on oper:always_message...

### DIFF
--- a/modules/um_callerid.c
+++ b/modules/um_callerid.c
@@ -184,7 +184,7 @@ add_callerid_accept_for_source(enum message_type msgtype, struct Client *source_
 	if(msgtype != MESSAGE_TYPE_NOTICE &&
 		IsSetAnyCallerID(source_p) &&
 		!accept_message(target_p, source_p) &&
-		!IsOperGeneral(target_p))
+		!MayHavePrivilege(source_p, "oper:always_message"))
 	{
 		if(rb_dlink_list_length(&source_p->localClient->allow_list) <
 				(unsigned long)ConfigFileEntry.max_accept)


### PR DESCRIPTION
…not oper:general. This updates the test to match current behaviour of +g.

This part of the code seems to have missed being updated for several rounds of changes to +g behaviour for opers.

The rationale for the test being this is: a user with oper:always_message will never need to be on the accept list, so there's no need for auto-accept in that instance. If the target user has +M set then they don't need an auto-accept right now, but their +M mode will time out before too long, and they should retain the ability to message after that happens.