### PR TITLE
Add "automake" and "libtool" to the list of packages required for bui…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These are known issues and workarounds for various platforms.
 # building
 
 ```bash
-sudo apt install build-essential pkg-config libsqlite3-dev # or equivalent for your distribution
+sudo apt install build-essential pkg-config automake libtool libsqlite3-dev # or equivalent for your distribution
 ./autogen.sh
 ./configure --prefix=/path/to/installation
 make


### PR DESCRIPTION
…lding

I was building solanum on Debian, and on the first step running "autogen.sh" it was missing "aclocal" which was in the package automake and "libtoolize" which was in the package libtool. I checked what was included in the build-essential package on Ubuntu, because I thought maybe they were included there, but didn't find them.
Since in the instructions it does give an apt command, I thought these should be added there.