### PR TITLE
doc/connecting-servers: update example atheme protocol module

### DIFF
--- a/doc/connecting-servers.rst
+++ b/doc/connecting-servers.rst
@@ -112,7 +112,7 @@ hostname.
 
 For example, with atheme::
 
-   loadmodule "modules/protocol/charybdis";
+   loadmodule "modules/protocol/solanum";
 
    uplink "a.example.org" {
            host = "localhost";


### PR DESCRIPTION
Atheme has had a [protocol module](https://github.com/atheme/atheme/blob/master/modules/protocol/solanum.c) designed specifically for Solanum for some time now that includes proper support for new IRCd features.