### PR TITLE
ircd/listener: return a fatal TLS alert for early rejected TLS clients

### DIFF
--- a/include/reject.h
+++ b/include/reject.h
@@ -28,7 +28,7 @@
 #define DELAYED_EXIT_TIME	10
 
 void init_reject(void);
-int check_reject(rb_fde_t *F, struct sockaddr *addr);
+int check_reject(rb_fde_t *F, struct sockaddr *addr, bool ssl);
 void add_reject(struct Client *, const char *mask1, const char *mask2, struct ConfItem *aconf, const char *reason);
 int is_reject_ip(struct sockaddr *addr);
 void flush_reject(void);


### PR DESCRIPTION
This is in furtherance of commit 3fdf26aa19628d5e12a3 which added functionality to reply with a TLS record layer alert for D-Lined TLS clients. It turns out that there are other plaintext error messages in this same function that should receive the same treatment.

Also move another error string to a variable and use a compile-time optimised-out strlen for it too, to use the same approach as an existing error string.