### PR TITLE
modules: quietly succeed at loading a module if already loaded

### DIFF
--- a/ircd/modules.c
+++ b/ircd/modules.c
@@ -77,6 +77,9 @@ init_modules(void)
 		exit(EXIT_FAILURE);
 	}
 
+	memset(&module_list, 0, sizeof(module_list));
+	memset(&mod_paths, 0, sizeof(mod_paths));
+
 	/* Add the default paths we look in to the module system --nenolod */
 	mod_add_path(ircd_paths[IRCD_PATH_MODULES]);
 	mod_add_path(ircd_paths[IRCD_PATH_AUTOLOAD_MODULES]);

--- a/ircd/modules.c
+++ b/ircd/modules.c
@@ -465,6 +465,10 @@ load_a_module(const char *path, bool warn, int origin, bool core)
 	if((c = rb_strcasestr(mod_displayname, LT_MODULE_EXT)) != NULL)
 		*c = '\0';
 
+	/* Quietly succeed if the module is already loaded */
+	if(findmodule_byname(mod_displayname) != NULL)
+		return true;
+
 	tmpptr = lt_dlopenext(path);
 
 	if(tmpptr == NULL)


### PR DESCRIPTION
This allows explicitly loading a module in the config so it's available for later config items that might need it, and skips the double load when main loads all modules, which would cause errors