### PR TITLE
client: refactor del_all_accepts to allow skipping own accept list

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -603,7 +603,7 @@ extern struct Client *find_named_person(const char *);
 extern struct Client *next_client(struct Client *, const char *);
 
 #define accept_message(s, t) ((s) == (t) || (rb_dlinkFind((s), &((t)->localClient->allow_list))))
-extern void del_all_accepts(struct Client *client_p);
+extern void del_all_accepts(struct Client *client_p, bool self_too);
 
 extern void dead_link(struct Client *client_p, int sendqex);
 extern int show_ip(struct Client *source_p, struct Client *target_p);

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1725,7 +1725,7 @@ change_nick_user_host(struct Client *target_p,	const char *nick, const char *use
 	if(changed)
 	{
 		monitor_signon(target_p);
-		del_all_accepts(target_p);
+		del_all_accepts(target_p, false);
 	}
 }
 

--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -619,8 +619,6 @@ static void
 change_local_nick(struct Client *client_p, struct Client *source_p,
 		char *nick, int dosend)
 {
-	struct Client *target_p;
-	rb_dlink_node *ptr, *next_ptr;
 	struct Channel *chptr;
 	char note[NICKLEN + 10];
 	int samenick;
@@ -704,20 +702,7 @@ change_local_nick(struct Client *client_p, struct Client *source_p,
 	/* Make sure everyone that has this client on its accept list
 	 * loses that reference.
 	 */
-	/* we used to call del_all_accepts() here, but theres no real reason
-	 * to clear a clients own list of accepted clients.  So just remove
-	 * them from everyone elses list --anfl
-	 */
-	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, source_p->on_allow_list.head)
-	{
-		target_p = ptr->data;
-
-		if (!has_common_channel(source_p, target_p))
-		{
-			rb_dlinkFindDestroy(source_p, &target_p->localClient->allow_list);
-			rb_dlinkDestroy(ptr, &source_p->on_allow_list);
-		}
-	}
+	del_all_accepts(source_p, false);
 
 	snprintf(note, sizeof(note), "Nick: %s", nick);
 	rb_note(client_p->localClient->F, note);

--- a/modules/m_services.c
+++ b/modules/m_services.c
@@ -280,7 +280,10 @@ doit:
 
 	monitor_signon(target_p);
 
-	del_all_accepts(target_p);
+	/* Make sure everyone that has this client on its accept list
+	 * loses that reference.
+	 */
+	del_all_accepts(target_p, false);
 
 	snprintf(note, sizeof(note), "Nick: %s", target_p->name);
 	rb_note(target_p->localClient->F, note);


### PR DESCRIPTION
This allows reusing this function for other uses that just need to remove this client from others' accept lists on nick change and not have duplicates of this code everywhere