### PR TITLE
Delay rehashing until we're not processing events

### DIFF
--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -652,7 +652,7 @@ service_rehash(void *data_)
 	struct rehash_data *data = data_;
 	bool sig = data->sig;
 
-	free(data);
+	rb_free(data);
 
 	rb_dlink_node *n;
 

--- a/librb/include/rb_commio.h
+++ b/librb/include/rb_commio.h
@@ -159,6 +159,7 @@ int rb_ignore_errno(int);
 void rb_setselect(rb_fde_t *, unsigned int type, PF * handler, void *client_data);
 void rb_init_netio(void);
 int rb_select(unsigned long);
+void rb_defer(void (*)(void *), void *);
 int rb_fd_ssl(rb_fde_t *F);
 int rb_get_fd(rb_fde_t *F);
 const char *rb_get_ssl_strerror(rb_fde_t *F);

--- a/librb/src/export-syms.txt
+++ b/librb/src/export-syms.txt
@@ -27,6 +27,7 @@ rb_ctime
 rb_current_time
 rb_current_time_tv
 rb_date
+rb_defer
 rb_destroy_patricia
 rb_dictionary_add
 rb_dictionary_create


### PR DESCRIPTION
Fixes bug/probable regression introduced by 0ab6dbbc651ddd1c26cb7baa6e6cf86890a4abd2

rehash() closes listeners. If we happen to get a single epoll() result that wants to first rehash and then accept a connection, the epoll info will point to a freed rb_fde_t. Other selectors should have similar problems, but we didn't investigate that.

rb_fde_ts are normally batched up and freed outside the event processing, but as of the above commit close_listeners() screws that up by closing pending FDs immediately in order to create new listeners.

I think it might be a bit better to revert this behaviour and simply not close listeners if we are going to open new ones over them, but have opted for the smallest reasonable change I can think of.