### PR TITLE
MODRESTART/MODRELOAD: Defer reloading more quickly

### DIFF
--- a/modules/core/m_modules.c
+++ b/modules/core/m_modules.c
@@ -286,7 +286,7 @@ do_modreload(struct Client *source_p, const char *module)
 	struct modreload *info = rb_malloc(sizeof *info);
 	strcpy(info->module, module);
 	strcpy(info->id, source_p->id);
-	rb_event_addonce("modules_do_reload", modules_do_reload, info, 1);
+	rb_defer(&modules_do_reload, info);
 }
 
 static void
@@ -304,7 +304,7 @@ do_modrestart(struct Client *source_p)
 	 *
 	 * So, defer the restart to the event loop and return now.
 	 */
-	rb_event_addonce("modules_do_restart", modules_do_restart, NULL, 1);
+	rb_defer(&modules_do_restart, NULL);
 }
 
 static void


### PR DESCRIPTION
Commit 41390bfe5fa3895b8dee fixed a bug whereby the processing of a `MODRESTART` command could result in a crash. The approach taken in this fix was to defer the reloading of all modules so that the call stack does not contain functions located in modules that are being reloaded. It did this by scheduling a one-shot timer event for 1 second in the future, in the absense of any better deferral mechanism at the time. Timers are processed by the event loop, which is core to IRCd and cannot be reloaded.

Commit 59ea3c6753e80d051b20 introduced a mechanism to defer the execution of a function until all events have been processed by the event loop, in order to fix a `REHASH` bug that could result in a crash due to closing and reopening listener sockets with a pending socket connection event to process after the `REHASH` was completed.

Rework commit 41390bfe5fa3895b8dee to use the new deferral mechanism introduced by commit 59ea3c6753e80d051b20 and do the same for module reloads.