### PR TITLE
Add function parameter prototypes for clang

### DIFF
--- a/authd/authd.c
+++ b/authd/authd.c
@@ -199,7 +199,7 @@ main(int argc, char *argv[])
 	rb_set_time();
 	setup_signals();
 
-	authd_option_handlers = rb_dictionary_create("authd options handlers", rb_strcasecmp);
+	authd_option_handlers = rb_dictionary_create("authd options handlers", (DCF)rb_strcasecmp);
 
 	init_resolver();
 	init_providers();

--- a/ircd/authproc.c
+++ b/ircd/authproc.c
@@ -601,7 +601,7 @@ add_dnsbl_entry(const char *host, const char *reason, uint8_t iptype, rb_dlink_l
 	size_t s = 0;
 
 	if(dnsbl_stats == NULL)
-		dnsbl_stats = rb_dictionary_create("dnsbl statistics", rb_strcasecmp);
+		dnsbl_stats = rb_dictionary_create("dnsbl statistics", (DCF)rb_strcasecmp);
 
 	/* Build a list of comma-separated values for authd.
 	 * We don't check for validity - do it elsewhere.

--- a/ircd/cache.c
+++ b/ircd/cache.c
@@ -68,8 +68,8 @@ init_cache(void)
 	oper_motd = cache_file(ircd_paths[IRCD_PATH_IRCD_OMOTD], "opers.motd", 0);
 	memset(&links_cache_list, 0, sizeof(links_cache_list));
 
-	help_dict_oper = rb_dictionary_create("oper help", rb_strcasecmp);
-	help_dict_user = rb_dictionary_create("user help", rb_strcasecmp);
+	help_dict_oper = rb_dictionary_create("oper help", (DCF)rb_strcasecmp);
+	help_dict_user = rb_dictionary_create("user help", (DCF)rb_strcasecmp);
 }
 
 /*

--- a/ircd/capability.c
+++ b/ircd/capability.c
@@ -150,7 +150,7 @@ capability_index_create(const char *name)
 
 	idx = rb_malloc(sizeof(struct CapabilityIndex));
 	idx->name = name;
-	idx->cap_dict = rb_dictionary_create(name, rb_strcasecmp);
+	idx->cap_dict = rb_dictionary_create(name, (DCF)rb_strcasecmp);
 	idx->highest_bit = 1;
 
 	rb_dlinkAdd(idx, &idx->node, &capability_indexes);

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -120,7 +120,7 @@ init_client(void)
 	rb_event_addish("exit_aborted_clients", exit_aborted_clients, NULL, 1);
 	rb_event_add("flood_recalc", flood_recalc, NULL, 1);
 
-	nd_dict = rb_dictionary_create("nickdelay", irccmp);
+	nd_dict = rb_dictionary_create("nickdelay", (DCF)irccmp);
 }
 
 /*

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -275,7 +275,7 @@ handle_encap(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *so
 void
 clear_hash_parse()
 {
-	cmd_dict = rb_dictionary_create("command", rb_strcasecmp);
+	cmd_dict = rb_dictionary_create("command", (DCF)rb_strcasecmp);
 }
 
 /* mod_add_cmd

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -865,7 +865,7 @@ set_default_conf(void)
 	ConfigFileEntry.hide_opers = 0;
 
 	if (!alias_dict)
-		alias_dict = rb_dictionary_create("alias", rb_strcasecmp);
+		alias_dict = rb_dictionary_create("alias", (DCF)rb_strcasecmp);
 }
 
 /*

--- a/librb/include/rb_dictionary.h
+++ b/librb/include/rb_dictionary.h
@@ -33,7 +33,7 @@ typedef struct rb_dictionary_iter rb_dictionary_iter;
 
 struct rb_dictionary;
 
-typedef int (*DCF)(/* const void *a, const void *b */);
+typedef int (*DCF)(const void *a, const void *b);
 
 struct rb_dictionary_element
 {

--- a/librb/src/crypt.c
+++ b/librb/src/crypt.c
@@ -778,7 +778,7 @@ static void   MD5Final (unsigned char [16], MD5_CTX *);
  */
 
 static void
-Encode (unsigned char *output, uint32_t *input, unsigned int len)
+Encode(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i;
 	uint32_t *op = (uint32_t *)output;
@@ -793,7 +793,7 @@ Encode (unsigned char *output, uint32_t *input, unsigned int len)
  */
 
 static void
-Decode (uint32_t *output, const unsigned char *input, unsigned int len)
+Decode(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i;
 	const uint32_t *ip = (const uint32_t *)input;
@@ -846,8 +846,7 @@ static unsigned char PADDING[64] = {
 /* MD5 initialization. Begins an MD5 operation, writing a new context. */
 
 static void
-MD5Init (context)
-	MD5_CTX *context;
+MD5Init(MD5_CTX *context)
 {
 
 	context->count[0] = context->count[1] = 0;
@@ -866,10 +865,7 @@ MD5Init (context)
  */
 
 static void
-MD5Update (context, in, inputLen)
-	MD5_CTX *context;
-	const void *in;
-	unsigned int inputLen;
+MD5Update(MD5_CTX *context, const void *in, unsigned int inputLen)
 {
 	unsigned int i, idx, partLen;
 	const unsigned char *input = in;
@@ -909,8 +905,7 @@ MD5Update (context, in, inputLen)
  */
 
 static void
-MD5Pad (context)
-	MD5_CTX *context;
+MD5Pad(MD5_CTX *context)
 {
 	unsigned char bits[8];
 	unsigned int idx, padLen;
@@ -933,9 +928,7 @@ MD5Pad (context)
  */
 
 static void
-MD5Final (digest, context)
-	unsigned char digest[16];
-	MD5_CTX *context;
+MD5Final(unsigned char digest[16], MD5_CTX *context)
 {
 	/* Do padding. */
 	MD5Pad (context);
@@ -950,9 +943,7 @@ MD5Final (digest, context)
 /* MD5 basic transformation. Transforms state based on block. */
 
 static void
-MD5Transform (state, block)
-	uint32_t state[4];
-	const unsigned char block[64];
+MD5Transform(uint32_t state[4], const unsigned char block[64])
 {
 	uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 

--- a/tests/rb_dictionary1.c
+++ b/tests/rb_dictionary1.c
@@ -33,7 +33,7 @@
 
 static void replace1(void)
 {
-	rb_dictionary *dict = rb_dictionary_create("replace1", strcmp);
+	rb_dictionary *dict = rb_dictionary_create("replace1", (DCF)strcmp);
 	rb_dictionary_element *original = rb_dictionary_add(dict, "test", "data1");
 
 	ok(original != NULL, MSG);


### PR DESCRIPTION
Modern clang (16+) requires all function prototypes to have arguments.

This affects the old K&R style in librb/src/crypt.c and the 'DCF' declaration