### PR TITLE
doc/reference.conf: document the auth::umodes configuration option

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -360,6 +360,11 @@ auth {
 	user = "*@198.51.100.0/24";
 	user = "*test@2001:db8:1:*";
 
+	/* umodes; the user mode character string to apply to users
+	 * when they get placed into this auth block.
+	 */
+	#umodes = "+w";
+
 	/* auth_user: This allows specifying a username:password instead of
 	 * just a password in PASS, so that a fixed user@host is not
 	 * necessary for a specific auth{} block.


### PR DESCRIPTION
Fixes: 4d8088c386c23049fcfe ("Allow auth{} to apply extra umodes")