### PR TITLE
Fix WHOIS reply not respecting a lack of the multi-prefix capability

### DIFF
--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -279,7 +279,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 			{
 				send_multiline_item(source_p, "%s%s%s",
 						hdata_vis.approved ? "" : "!",
-						find_channel_status(mt, 1),
+						find_channel_status(mt, IsCapable(source_p, CLICAP_MULTI_PREFIX)),
 						chptr->chname);
 			}
 		}


### PR DESCRIPTION
Prior to this commit, `RPL_WHOISCHANNELS` always contained all channel membership prefixes, even when the client had not enabled the multi-prefix capability. This behaviour predates available commit history. Other ircds only return the highest prefix, as prescribed by the RFCs.

(Thanks to @fireonlive for helping me test this!)