### PR TITLE
m_whois: restore original multi-prefix behavior

### DIFF
--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -279,7 +279,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 			{
 				send_multiline_item(source_p, "%s%s%s",
 						hdata_vis.approved ? "" : "!",
-						find_channel_status(mt, 0),
+						find_channel_status(mt, 1),
 						chptr->chname);
 			}
 		}


### PR DESCRIPTION
The original behavior has existed since before git history, and has no known impact on clients that exist today.

This reverts commit 746ced2