### PR TITLE
Accept expired certificates

### DIFF
--- a/librb/src/openssl.c
+++ b/librb/src/openssl.c
@@ -581,6 +581,7 @@ rb_get_ssl_certfp(rb_fde_t *const F, uint8_t certfp[const RB_SSL_CERTFP_LEN], co
 	switch(SSL_get_verify_result(SSL_P(F)))
 	{
 	case X509_V_OK:
+	case X509_V_ERR_CERT_HAS_EXPIRED:
 	case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
 	case X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE:
 	case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:


### PR DESCRIPTION
We're only using x509 certificates as a carrier for public keys. Expiration dates are useless here because revocation is done in NickServ by removing fingerprints. We don't rely on time-bounded CA signature like common PKI.

Expiration dates only serve to confuse and lock out legitimate users.