### PR TITLE
modules: remove unused spy code.

### DIFF
--- a/modules/m_admin.c
+++ b/modules/m_admin.c
@@ -42,8 +42,6 @@ static void mr_admin(struct MsgBuf *, struct Client *, struct Client *, int, con
 static void ms_admin(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 static void do_admin(struct Client *source_p);
 
-static void admin_spy(struct Client *);
-
 struct Message admin_msgtab = {
 	"ADMIN", 0, 0, 0, 0,
 	{{mr_admin, 0}, {m_admin, 0}, {ms_admin, 0}, mg_ignore, mg_ignore, {ms_admin, 0}}
@@ -134,9 +132,6 @@ ms_admin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 static void
 do_admin(struct Client *source_p)
 {
-	if(IsPerson(source_p))
-		admin_spy(source_p);
-
 	sendto_one_numeric(source_p, RPL_ADMINME, form_str(RPL_ADMINME), me.name);
 	if(AdminInfo.name != NULL)
 		sendto_one_numeric(source_p, RPL_ADMINLOC1, form_str(RPL_ADMINLOC1), AdminInfo.name);
@@ -144,21 +139,4 @@ do_admin(struct Client *source_p)
 		sendto_one_numeric(source_p, RPL_ADMINLOC2, form_str(RPL_ADMINLOC2), AdminInfo.description);
 	if(AdminInfo.email != NULL)
 		sendto_one_numeric(source_p, RPL_ADMINEMAIL, form_str(RPL_ADMINEMAIL), AdminInfo.email);
-}
-
-/* admin_spy()
- *
- * input	- pointer to client
- * output	- none
- * side effects - event doing_admin is called
- */
-static void
-admin_spy(struct Client *source_p)
-{
-	hook_data hd;
-
-	hd.client = source_p;
-	hd.arg1 = hd.arg2 = NULL;
-
-	call_hook(doing_admin_hook, &hd);
 }

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -45,7 +45,6 @@ static const char info_desc[] =
 static void send_conf_options(struct Client *source_p);
 static void send_birthdate_online_time(struct Client *source_p);
 static void send_info_text(struct Client *source_p);
-static void info_spy(struct Client *);
 
 static void m_info(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 static void mo_info(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
@@ -704,8 +703,6 @@ m_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	if(hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
-	info_spy(source_p);
-
 	send_info_text(source_p);
 	send_birthdate_online_time(source_p);
 
@@ -721,7 +718,6 @@ mo_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 {
 	if(hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) == HUNTED_ISME)
 	{
-		info_spy(source_p);
 		send_info_text(source_p);
 
 		if(IsOperGeneral(source_p))
@@ -899,21 +895,4 @@ send_conf_options(struct Client *source_p)
 	 */
 
 	sendto_one_numeric(source_p, RPL_INFO, form_str(RPL_INFO), "");
-}
-
-/* info_spy()
- *
- * input        - pointer to client
- * output       - none
- * side effects - hook doing_info is called
- */
-static void
-info_spy(struct Client *source_p)
-{
-	hook_data hd;
-
-	hd.client = source_p;
-	hd.arg1 = hd.arg2 = NULL;
-
-	call_hook(doing_info_hook, &hd);
 }

--- a/modules/m_motd.c
+++ b/modules/m_motd.c
@@ -56,8 +56,6 @@ mapi_hlist_av1 motd_hlist[] = {
 
 DECLARE_MODULE_AV2(motd, NULL, NULL, motd_clist, motd_hlist, NULL, NULL, NULL, motd_desc);
 
-static void motd_spy(struct Client *);
-
 /*
 ** m_motd
 **      parv[1] = servername
@@ -83,7 +81,6 @@ m_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	if(hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
-	motd_spy(source_p);
 	send_user_motd(source_p);
 }
 
@@ -97,23 +94,5 @@ mo_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	if(hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
-	motd_spy(source_p);
 	send_user_motd(source_p);
-}
-
-/* motd_spy()
- *
- * input        - pointer to client
- * output       - none
- * side effects - hook doing_motd is called
- */
-static void
-motd_spy(struct Client *source_p)
-{
-	hook_data data;
-
-	data.client = source_p;
-	data.arg1 = data.arg2 = NULL;
-
-	call_hook(doing_motd_hook, &data);
 }

--- a/modules/m_trace.c
+++ b/modules/m_trace.c
@@ -44,8 +44,6 @@ static const char trace_desc[] =
 
 static void m_trace(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 
-static void trace_spy(struct Client *, struct Client *);
-
 struct Message trace_msgtab = {
 	"TRACE", 0, 0, 0, 0,
 	{mg_unreg, {m_trace, 0}, {m_trace, 0}, mg_ignore, mg_ignore, {m_trace, 0}}
@@ -179,14 +177,10 @@ m_trace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			tname = target_p->name;
 		}
 
-		trace_spy(source_p, target_p);
-
 		sendto_one_numeric(source_p, RPL_ENDOFTRACE,
 				   form_str(RPL_ENDOFTRACE), tname);
 		return;
 	}
-
-	trace_spy(source_p, NULL);
 
 	/* give non-opers a limited trace output of themselves (if local),
 	 * opers and servers (if no shide) --fl
@@ -429,21 +423,4 @@ report_this_status(struct Client *source_p, struct Client *target_p)
 	}
 
 	return (cnt);
-}
-
-/* trace_spy()
- *
- * input        - pointer to client
- * output       - none
- * side effects - hook event doing_trace is called
- */
-static void
-trace_spy(struct Client *source_p, struct Client *target_p)
-{
-	hook_data_client hdata;
-
-	hdata.client = source_p;
-	hdata.target = target_p;
-
-	call_hook(doing_trace_hook, &hdata);
 }


### PR DESCRIPTION
The modules where removed in https://github.com/solanum-ircd/solanum/pull/40

This just removes leftover code.