### PR TITLE
Don't set the oper flags on client

### DIFF
--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -140,8 +140,6 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define OPER_ENCRYPTED	0x00001
 #define OPER_NEEDSSL    0x80000
 
-#define OPER_FLAGS	0	 /* no oper privs in Client.flags/oper_conf.flags currently */
-
 #define IsOperConfEncrypted(x)	((x)->flags & OPER_ENCRYPTED)
 #define IsOperConfNeedSSL(x)	((x)->flags & OPER_NEEDSSL)
 

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1494,7 +1494,6 @@ oper_up(struct Client *source_p, struct oper_conf *oper_p)
 	SetExtendChans(source_p);
 	SetExemptKline(source_p);
 
-	source_p->flags |= oper_p->flags;
 	source_p->user->opername = rb_strdup(oper_p->name);
 	source_p->user->privset = privilegeset_ref(oper_p->privset);
 

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1177,8 +1177,6 @@ user_mode(struct Client *client_p, struct Client *source_p, int parc, const char
 				if(MyConnect(source_p))
 				{
 					source_p->umodes &= ~ConfigFileEntry.oper_only_umodes;
-					source_p->flags &= ~OPER_FLAGS;
-
 					rb_dlinkFindDestroy(source_p, &local_oper_list);
 				}
 


### PR DESCRIPTION
The oper_conf flags are a different set of flag
bits than the client flags. The oper flags are
hardcoded to have ENCRYPTED set which is the same
flag as PINGSENT on the client struct. This can
cause a client to timeout if the last thing it
does is oper up.