### PR TITLE
Add max_autoconn to documentation

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -138,6 +138,7 @@ class "server" {
 	ping_time = 5 minutes;
 	connectfreq = 5 minutes;
 	max_number = 1;
+	max_autoconn = 1;
 	sendq = 4 megabytes;
 };
 

--- a/doc/oper-guide/config.rst
+++ b/doc/oper-guide/config.rst
@@ -138,6 +138,7 @@ class {} block
             ping_time = duration;
             connectfreq = duration;
             max_number = number;
+            max_autoconn = number;
             sendq = size;
     };    
    
@@ -200,9 +201,15 @@ connectfreq
     minute, as autoconnects are evaluated with that granularity.
 
 max\_number
-    The amount of servers to autoconnect to in this class. More
-    precisely, no autoconnects are done if the number of servers in this
-    class is greater than or equal max\_number
+    The amount of servers that can be connected in this class.
+
+max\_autoconn
+    The amount of servers to autoconnect to. If the number of servers
+    in the class is or exceeds this, no more servers in the class are
+    autoconnected. Oper initiated connects are unaffected. This should
+    usually be set to either 0 or 1 (autoconnecting from hubs to
+    leaves may cause leaves to function as hubs by having multiple
+    servers connected to them).
 
 sendq
     The maximum size of the queue of data to be sent to a server before


### PR DESCRIPTION
7c7065b0 introduced class::max_autoconn configuration parameter. However, this parameter was never added to config.rst and the example config. This commits adds them there as well.