### PR TITLE
Add dedicated hook data type for can_create_channel

### DIFF
--- a/extensions/createauthonly.c
+++ b/extensions/createauthonly.c
@@ -31,7 +31,7 @@ DECLARE_MODULE_AV2(createauthonly, NULL, NULL, NULL, NULL, restrict_hfnlist, NUL
 static void
 h_can_create_channel_authenticated(void *data_)
 {
-	hook_data_client_approval *data = data_;
+	hook_data_can_create_channel *data = data_;
 	struct Client *source_p = data->client;
 
 	if (*source_p->user->suser == '\0' && !IsOperGeneral(source_p))

--- a/extensions/createoperonly.c
+++ b/extensions/createoperonly.c
@@ -31,7 +31,7 @@ DECLARE_MODULE_AV2(createoperonly, NULL, NULL, NULL, NULL, restrict_hfnlist, NUL
 static void
 h_can_create_channel_authenticated(void *data_)
 {
-	hook_data_client_approval *data = data_;
+	hook_data_can_create_channel *data = data_;
 	struct Client *source_p = data->client;
 
 	if (!IsOperGeneral(source_p))

--- a/include/hook.h
+++ b/include/hook.h
@@ -101,6 +101,13 @@ typedef struct
 typedef struct
 {
 	struct Client *client;
+	const char *name;
+	int approved;
+} hook_data_can_create_channel;
+
+typedef struct
+{
+	struct Client *client;
 	struct Channel *chptr;
 	const char *key;
 } hook_data_channel_activity;

--- a/modules/core/m_join.c
+++ b/modules/core/m_join.c
@@ -253,9 +253,10 @@ m_join(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		}
 		else
 		{
-			hook_data_client_approval moduledata;
+			hook_data_can_create_channel moduledata;
 
 			moduledata.client = source_p;
+			moduledata.name = name;
 			moduledata.approved = 0;
 
 			call_hook(h_can_create_channel, &moduledata);


### PR DESCRIPTION
`hook_data_can_create_channel` includes the name of the channel being created, which is necessary for any non-trivial restriction of channel creation as well as sending correct error messages.

The new hook data matches the layout of the previous hook data, taking advantage of a disused pointer field in `hook_data_client_approval` as used by callers of the hook (`m_join`).

There are two in-tree extensions that use can_create_channel. This PR doesn't currently attempt to change either of them to benefit from the new functionality.