### PR TITLE
Permit TLS client certificates without the clientAuth EKU

### DIFF
--- a/librb/src/openssl.c
+++ b/librb/src/openssl.c
@@ -587,6 +587,7 @@ rb_get_ssl_certfp(rb_fde_t *const F, uint8_t certfp[const RB_SSL_CERTFP_LEN], co
 	case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
 	case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
 	case X509_V_ERR_CERT_UNTRUSTED:
+	case X509_V_ERR_INVALID_PURPOSE:
 		len = make_certfp(peer_cert, certfp, method);
 		// fallthrough
 	default:


### PR DESCRIPTION
cf. #453 

I have also tested MbedTLS; it doesn't care as-is.

I am unable to test GNUTLS; I cannot even connect an IRC client to IRCd. It simply immediately closes the connection after ChangeCipherSpec is sent to the client. I will look into this some more.