### PR TITLE
modules/m_stats: fix hooks not being called

### DIFF
--- a/doc/technical/hooks.txt
+++ b/doc/technical/hooks.txt
@@ -36,9 +36,6 @@ for another server to handle:
 			  (const char *) hdata->arg1 = optional stats l target
 			  (char) hdata->arg2 = statchar being requested
 
-"doing_stats_p"		- Passes hook_data:
-			  hdata->client = client doing STATS p
-
 "doing_trace"		- Passes hook_data_client:
 			  hdata->client = client doing TRACE
 			  hdata->target = optional target of TRACE

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -59,13 +59,11 @@ struct Message stats_msgtab = {
 };
 
 int doing_stats_hook;
-int doing_stats_p_hook;
 int doing_stats_show_idle_hook;
 
 mapi_clist_av1 stats_clist[] = { &stats_msgtab, NULL };
 mapi_hlist_av1 stats_hlist[] = {
 	{ "doing_stats",	&doing_stats_hook },
-	{ "doing_stats_p",	&doing_stats_p_hook },
 	{ "doing_stats_show_idle", &doing_stats_show_idle_hook },
 	{ NULL, NULL }
 };
@@ -224,6 +222,18 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	if(hunt_server(client_p, source_p, ":%s STATS %s :%s", 2, parc, parv) != HUNTED_ISME)
 		return;
+
+	hook_data_int data = {
+		.client = source_p,
+		.arg1 = NULL,
+		.arg2 = (int) statchar,
+		.result = 0,
+	};
+
+	call_hook(doing_stats_hook, &data);
+
+	if (data.result != 0)
+		goto stats_out;
 
 	/* Look up */
 	cmd = &stats_cmd_table[statchar];


### PR DESCRIPTION
Some modules rely on stats hooks being called (e.g. `extensions/helpops`). These calls were removed accidentally by commit 4e89f6603d63b2f8dfde.

Additionally, the last vestiges of the spy-only `doing_stats_p` hook were left around. No module has ever used this hook. Remove it.