### PR TITLE
REHASH: Move privilege check for oper:remoteban to appropriate places

### DIFF
--- a/modules/m_rehash.c
+++ b/modules/m_rehash.c
@@ -67,6 +67,13 @@ struct hash_commands
 static void
 rehash_bans_loc(struct Client *source_p)
 {
+	if(!IsOperRemoteBan(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			me.name, source_p->name, "remoteban");
+		return;
+	}
+
 	sendto_realops_snomask(SNO_GENERAL, L_ALL, "%s is rehashing bans",
 				get_oper_name(source_p));
 	if (!MyConnect(source_p))
@@ -130,6 +137,13 @@ rehash_omotd(struct Client *source_p)
 static void
 rehash_tklines(struct Client *source_p)
 {
+	if(!IsOperRemoteBan(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			me.name, source_p->name, "remoteban");
+		return;
+	}
+
 	struct ConfItem *aconf;
 	rb_dlink_node *ptr, *next_ptr;
 	int i;
@@ -154,6 +168,13 @@ rehash_tklines(struct Client *source_p)
 static void
 rehash_tdlines(struct Client *source_p)
 {
+	if(!IsOperRemoteBan(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			me.name, source_p->name, "remoteban");
+		return;
+	}
+
 	struct ConfItem *aconf;
 	rb_dlink_node *ptr, *next_ptr;
 	int i;
@@ -178,6 +199,13 @@ rehash_tdlines(struct Client *source_p)
 static void
 rehash_txlines(struct Client *source_p)
 {
+	if(!IsOperRemoteBan(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			me.name, source_p->name, "remoteban");
+		return;
+	}
+
 	struct ConfItem *aconf;
 	rb_dlink_node *ptr;
 	rb_dlink_node *next_ptr;
@@ -202,6 +230,13 @@ rehash_txlines(struct Client *source_p)
 static void
 rehash_tresvs(struct Client *source_p)
 {
+	if(!IsOperRemoteBan(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			me.name, source_p->name, "remoteban");
+		return;
+	}
+
 	struct ConfItem *aconf;
 	rb_radixtree_iteration_state iter;
 	rb_dlink_node *ptr;
@@ -384,12 +419,6 @@ mo_rehash(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 
 	if (target_server != NULL)
 	{
-		if(!IsOperRemoteBan(source_p))
-		{
-			sendto_one(source_p, form_str(ERR_NOPRIVS),
-				me.name, source_p->name, "remoteban");
-			return;
-		}
 		sendto_match_servs(source_p, target_server,
 				CAP_ENCAP, NOCAPS,
 				"ENCAP %s REHASH %s",


### PR DESCRIPTION
The current situation is that one needs `oper:remoteban` privilege in order to send a remote REHASH of any type.  Hilariously, this includes re-reading the HELP files, re-reading `/etc/resolv.conf`, re-reading the MOTD and OMOTD files, or restarting `ssld` -- things that have nothing to do with banning.

In days gone by, servers would be unable to check the privileges of remote opers.  This is no longer the case since commit ed3ca2ff16a1dc921d90.

I note that the `rehash_ssld()` function already includes a possibly-remote privilege check for `oper:admin` since commit fbd3e77eac3889b95855 which pre-dates bursting of operators and their privsets.