### PR TITLE
format_client_tags: Add missing null terminator

### DIFF
--- a/ircd/client_tags.c
+++ b/ircd/client_tags.c
@@ -80,4 +80,5 @@ format_client_tags(char *dst, size_t dst_sz, const char *individual_fmt, const c
 		}
 		start += snprintf((dst + start), dst_sz - start, individual_fmt, supported_client_tags[index].name);
 	}
+    dst[start] = 0;
 }


### PR DESCRIPTION
Without it, clients get uninitialized bytes, eg. `CLIENTTAGDENY=*,\x80-\xc9!\xfd\x7f`