### PR TITLE
Revert "msgbuf: duplicate the string during partial parse and constify line"

### DIFF
--- a/include/msgbuf.h
+++ b/include/msgbuf.h
@@ -95,7 +95,7 @@ int msgbuf_parse(struct MsgBuf *msgbuf, char *line);
  * Parse partially a msgbuf without tags
  * assuming msgbuf is already initialized.
  */
-int msgbuf_partial_parse(struct MsgBuf *msgbuf, const char *line);
+int msgbuf_partial_parse(struct MsgBuf *msgbuf, char *line);
 
 /*
  * Unparse the tail of a msgbuf perfectly, preserving framing details

--- a/ircd/msgbuf.c
+++ b/ircd/msgbuf.c
@@ -138,9 +138,9 @@ msgbuf_parse(struct MsgBuf *msgbuf, char *line)
 }
 
 int
-msgbuf_partial_parse(struct MsgBuf *msgbuf, const char *line)
+msgbuf_partial_parse(struct MsgBuf *msgbuf, char *line)
 {
-	char *ch = strdup(line);
+	char *ch = line;
 	const char *start = ch;
 
 	/* truncate message if it's too long */

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -268,7 +268,7 @@ linebuf_put_msgf(buf_head_t *linebuf, const rb_strf_t *message, const char *form
  * side effects - a msgbuf object is populated with the full command and relevant tags
  */
 static void
-build_msgbuf(struct MsgBuf *msgbuf, struct Client *from, const char *line, size_t n_tags, const struct MsgTag tags[])
+build_msgbuf(struct MsgBuf *msgbuf, struct Client *from, char *line, size_t n_tags, const struct MsgTag tags[])
 {
 	hook_data hdata;
 


### PR DESCRIPTION
This reverts commit 5b253939da8f6b0a44ce6787ed12e26450ac6a63 to fix a memory leak:

```
==825564== 818 bytes in 4 blocks are definitely lost in loss record 616 of 648
==825564==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==825564==    by 0x49CD7A9: strdup (strdup.c:42)
==825564==    by 0x4888A2E: msgbuf_partial_parse (msgbuf.c:143)
==825564==    by 0x489DA84: build_msgbuf (send.c:276)
==825564==    by 0x489DA84: sendto_one_numeric (send.c:431)
==825564==    by 0x48A3CD7: show_isupport (supported.c:181)
==825564==    by 0x489A9F2: user_welcome (s_user.c:1433)
==825564==    by 0x489B114: register_local_user (s_user.c:718)
==825564==    by 0x488FC08: handle_command (parse.c:310)
==825564==    by 0x488FC08: parse (parse.c:224)
==825564==    by 0x488EEF8: parse_client_queued.part.0 (packet.c:67)
==825564==    by 0x488F084: parse_client_queued (packet.c:49)
==825564==    by 0x488F084: read_packet (packet.c:306)
==825564==    by 0x4B3C47B: rb_select_epoll (epoll.c:199)
==825564==    by 0x4B3716F: rb_select (commio.c:2038)
==825564==
[...]
==825564==
==825564== 3,012 bytes in 15 blocks are definitely lost in loss record 627 of 648
==825564==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==825564==    by 0x49CD7A9: strdup (strdup.c:42)
==825564==    by 0x4888A2E: msgbuf_partial_parse (msgbuf.c:143)
==825564==    by 0x489D3CE: build_msgbuf (send.c:276)
==825564==    by 0x489D3CE: sendto_realops_snomask (send.c:1431)
==825564==    by 0x4887C0D: load_a_module (modules.c:712)
==825564==    by 0x488801D: load_core_modules (modules.c:257)
==825564==    by 0x488124A: solanum_main (ircd.c:664)
==825564==    by 0x494DCA7: (below main) (libc_start_call_main.h:58)
```