### PR TITLE
Remote the `compressed` server flag

### DIFF
--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -359,7 +359,6 @@ static struct mode_table auth_table[] = {
 
 static struct mode_table connect_table[] = {
 	{ "autoconn",	SERVER_AUTOCONN		},
-	{ "compressed",	0			},
 	{ "encrypted",	SERVER_ENCRYPTED	},
 	{ "topicburst",	SERVER_TB		},
 	{ "sctp",	SERVER_SCTP		},


### PR DESCRIPTION
This is a follow-up to 81531536aac9adb585c5a17b448aa0496bf68ebd where the ziplinks feature had been ripped out. Unfortunately the value of the `compressed` flag had been set to `0` instead of `-1`, or removed entirely. This led to resetting a connect blocks flags being reset whenever the `compressed` flag was being set.

When you'd set the flags (in this order) `topicburst, compressed, ssl` you'd end up with just the `ssl` flag as setting `compressed` would reset all of the flag back to zero (newconf.c:439) as set_modes_from_table excepts `-1` to be passed as not-found / invalid flag value.

With this (trivial) patch the log will contain a helpful line telling operators that the `compressed` flag is unknown. It doesn't fail config parsing/rehashing:

> Warning -- unknown flag compressed.