### PR TITLE
Stop sending ERR_NOTEXTTOSEND on empty TAGMSG

### DIFF
--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -249,10 +249,7 @@ m_message(enum message_type msgtype, struct MsgBuf *msgbuf_p,
 		}
 
 		if (!found_client_tag)
-		{
-			sendto_one(source_p, form_str(ERR_NOTEXTTOSEND), me.name, source_p->name);
 			return;
-		}
 	}
 
 	/* Finish the flood grace period if they're not messaging themselves


### PR DESCRIPTION
Per the message-tags spec, clients are allowed to send tags blocked by CLIENTTAGDENY, and some clients make use of this allowance to send tags that are otherwise stripped out (e.g. +typing if that module is not loaded). If a TAGMSG did not have any client tags after processing, we previously returned ERR_NOTEXTTOSEND (412) however this results in a fair amount of spam in the server buffer of such clients. Make the command silently fail instead.

An open question remains on how this interacts with echo-message, as the spec is not well-written to cover what happens during failure/error cases. A strict reading of the spec would require an echo-message on every received PRIVMSG/NOTICE/TAGMSG, including cases where we are already sending an error numeric. This does not seem intended, and would complicate labeled-response by requiring a batch in error cases.

A looser reading of the spec seems to permit not sending any echo-message in the case that messages are filtered out (as the portion of the spec allowing "fake messages" is a MAY). Since we currently do not send any echo-message for empty NOTICE (and do not send any numerics either), apply the same treatment for empty TAGMSG: the server silently drops the command and does not echo anything back to the client.

I'm fine with adjusting this to actually echo the empty TAGMSG back to the client, but given the above it seemed unnecessary. labeled-response is a much better way for clients to know that a server received a particular command and I plan on submitting a PR for that within the first quarter of 2026 once the batch PR is merged.