### PR TITLE
Fix msgid tags with echo-message

### DIFF
--- a/extensions/tag_message_id.c
+++ b/extensions/tag_message_id.c
@@ -35,19 +35,21 @@
 #include "parse.h"
 #include "inline/stringops.h"
 
-/* format version for message ids, increment if the representation changes in a meaningful way
- * e.g. if we start encoding information in the ID that we or other servers can later extract */
-#define MESSAGE_ID_FORMAT 1
-
 static const char tag_message_id_desc[] = "Provides the msgid tag";
 static void tag_message_id_incoming(void *);
-static void tag_message_id_outgoing(void *);
+static void add_message_id_user(void *);
+static void add_message_id_channel(void *);
 
 mapi_hfn_list_av1 tag_message_id_hfnlist[] = {
 	{ "message_tag", tag_message_id_incoming },
-	{ "outbound_msgbuf", tag_message_id_outgoing },
+	{ "privmsg_user", add_message_id_user },
+	{ "privmsg_channel", add_message_id_channel },
 	{ NULL, NULL }
 };
+
+DECLARE_MODULE_AV2(tag_message_id, NULL, NULL, NULL, NULL, tag_message_id_hfnlist, NULL, NULL, tag_message_id_desc);
+
+static void generate_msgid(char *buf, size_t len, struct Client *source_p, const char *target);
 
 static void
 tag_message_id_incoming(void *data_)
@@ -60,84 +62,89 @@ tag_message_id_incoming(void *data_)
 }
 
 static void
-tag_message_id_outgoing(void *data_)
+add_message_id_user(void *data_)
 {
 	static char buf[BUFSIZE];
+	hook_data_privmsg_user *data = data_;
+
+	if (msgbuf_get_tag(data->msgbuf, "msgid"))
+		return;
+
+	/* don't add msgid to messages received from remote servers to avoid desynced ids across servers */
+	if (data->source_p == NULL || !MyClient(data->source_p))
+		return;
+
+	generate_msgid(buf, sizeof(buf), data->source_p, NULL);
+	msgbuf_append_tag(data->msgbuf, "msgid", buf, CLICAP_MESSAGE_TAGS);
+}
+
+static void
+add_message_id_channel(void *data_)
+{
+	static char buf[BUFSIZE];
+	hook_data_privmsg_channel *data = data_;
+
+	if (msgbuf_get_tag(data->msgbuf, "msgid"))
+		return;
+
+	/* don't add msgid to messages received from remote servers to avoid desynced ids across servers */
+	if (data->source_p == NULL || !MyClient(data->source_p))
+		return;
+
+	generate_msgid(buf, sizeof(buf), data->source_p, data->chptr->chname);
+	msgbuf_append_tag(data->msgbuf, "msgid", buf, CLICAP_MESSAGE_TAGS);
+}
+
+static void
+generate_msgid(char *buf, size_t len, struct Client *source_p, const char *target)
+{
 	static time_t prev_ts = 0;
 	static unsigned short prev_ms = 0;
 	static unsigned short ctr;
-	const char *incoming_msgid;
 
-	hook_data *data = data_;
 	const struct timeval *tv = rb_current_time_tv();
 	time_t ts = tv->tv_sec;
 	unsigned short ms = tv->tv_usec / 1000;
 
-	struct MsgBuf *msgbuf = data->arg1;
-
-	if (msgbuf_get_tag(msgbuf, "msgid"))
-		return;
-
-	if (incoming_client != NULL && IsServer(incoming_client) && (incoming_msgid = msgbuf_get_tag(incoming_message, "msgid")) != NULL)
-	{
-		msgbuf_append_tag(msgbuf, "msgid", incoming_msgid, CLICAP_MESSAGE_TAGS);
-		return;
-	}
-
-	if (data->client == NULL || IsMe(data->client) || !MyClient(data->client) || msgbuf->cmd == NULL)
-		return;
-
-	if (!strcmp(msgbuf->cmd, "PRIVMSG") || !strcmp(msgbuf->cmd, "NOTICE") || !strcmp(msgbuf->cmd, "TAGMSG"))
-	{
-		/* Invalid target? */
-		if (msgbuf->n_para < 2 || EmptyString(msgbuf->para[1]))
-			return;
-
-		/* (re-)initialize counter if the timestamp changed so it is less useful
+	/* (re-)initialize counter if the timestamp changed so it is less useful
 		 * to determine exactly how many messages are sent over time */
-		if (ts > prev_ts)
-		{
-			prev_ts = ts;
-			prev_ms = ms;
-			rb_get_random(&ctr, sizeof(ctr));
-			/* clear top bit to allow for overflow */
-			ctr &= 0x7fff;
-		} else if (ms > prev_ms)
-			prev_ms = ms;
+	if (ts > prev_ts)
+	{
+		prev_ts = ts;
+		prev_ms = ms;
+		rb_get_random(&ctr, sizeof(ctr));
+		/* clear top bit to allow for overflow */
+		ctr &= 0x7fff;
+	} else if (ms > prev_ms)
+		prev_ms = ms;
 
-		/* handle unlikely overflow case to keep message ids in correctly-sortable order and to avoid dupes */
-		if (++ctr == 0)
+	/* handle unlikely overflow case to keep message ids in correctly-sortable order and to avoid dupes */
+	if (++ctr == 0)
+	{
+		prev_ms++;
+		if (prev_ms == 1000)
 		{
-			prev_ms++;
-			if (prev_ms == 1000)
-			{
-				prev_ts++;
-				prev_ms = 0;
-			}
+			prev_ts++;
+			prev_ms = 0;
 		}
-
-		/* Format version 1 contains the following (in order):
-		 * 1. The character '1'
-		 * 2. Current seconds since epoch (10 characters)
-		 * 3. Current milliseconds value for current time (3 characters)
-		 * 4. Counter value (6 characters)
-		 * 5. Client UID (9 characters)
-		 * 6. Base64-encoded channel name if target is a channel (variable number of characters),
-		 *    empty string if target is not a channel. We know this is PRIVMSG, NOTICE, or TAGMSG
-		 *    so msgbuf->para[1] is guaranteed to be our target.
-		 */
-		char *encoded = NULL;
-		if (IsChannelName(msgbuf->para[1]) || IsChannelName(msgbuf->para[1] + 1))
-			encoded = rb_base64_encode(msgbuf->para[1], strlen(msgbuf->para[1]));
-
-		snprintf(buf, sizeof(buf), "%c%010d%03d%06d%s%s",
-			MESSAGE_ID_FORMAT + '0', (unsigned)prev_ts, prev_ms, ctr, data->client->id,
-			encoded == NULL ? "" : encoded);
-		if (encoded != NULL)
-			rb_free(encoded);
-
-		msgbuf_append_tag(msgbuf, "msgid", buf, CLICAP_MESSAGE_TAGS);
 	}
-}
 
-DECLARE_MODULE_AV2(tag_message_id, NULL, NULL, NULL, NULL, tag_message_id_hfnlist, NULL, NULL, tag_message_id_desc);
+	/* Format version 1 contains the following (in order):
+	 * 1. The character '1'
+	 * 2. Current seconds since epoch (10 characters)
+	 * 3. Current milliseconds value for current time (3 characters)
+	 * 4. Counter value (6 characters)
+	 * 5. Client UID (9 characters)
+	 * 6. Base64-encoded channel name if target is a channel (variable number of characters),
+	 *    empty string if target is not a channel.
+	 */
+	char *encoded = NULL;
+	if (target != NULL)
+		encoded = rb_base64_encode(target, strlen(target));
+
+	snprintf(buf, len, "1%010d%03d%06d%s%s",
+		(unsigned)prev_ts, prev_ms, ctr, source_p->id, encoded == NULL ? "" : encoded);
+
+	if (encoded != NULL)
+		rb_free(encoded);
+}

--- a/include/hook.h
+++ b/include/hook.h
@@ -210,6 +210,7 @@ typedef struct
 	struct Channel *chptr;
 	const char *text;
 	int approved;
+	struct MsgBuf *msgbuf;
 } hook_data_privmsg_channel;
 
 typedef struct
@@ -219,6 +220,7 @@ typedef struct
 	struct Client *target_p;
 	const char *text;
 	int approved;
+	struct MsgBuf *msgbuf;
 } hook_data_privmsg_user;
 
 typedef struct


### PR DESCRIPTION
msgid generation has been moved to the privmsg_user and privmsg_channel hooks, which are called on every normal PRIVMSG/NOTICE/TAGMSG. They are not called when messaging user@server, opers@server, or mass-messages and as such none of those things will have msgid attached. This seems fine as user@server is rejected by solanum and exists solely for messaging pseudoservers, opers@server is turned into a snote, and mass-messages are oper-only and thus unlikely to need anything that keys off msgid in the future.

Moving this solves the interaction with msgid and echo-message. Now, we ensure that an echoed message always has a msgid, and that msgid is always the same as the msgid shown to other clients.

This requires expanding the hook_data structures for those two hooks. While a core restart is not needed, attempting to reload tag_message_id before reloading m_message may cause crashes. When updating your servers, please reload m_message first.