### PR TITLE
Fix extban validation for exception and invite exception modes

### DIFF
--- a/extensions/extb_extgecos.c
+++ b/extensions/extb_extgecos.c
@@ -36,10 +36,6 @@ static int eb_extended(const char *data, struct Client *client_p,
 {
 	(void)chptr;
 
-	/* This type is not safe for exceptions */
-	if (mode_type == CHFL_EXCEPTION || mode_type == CHFL_INVEX)
-		return EXTBAN_INVALID;
-
 	if (data == NULL)
 		return EXTBAN_INVALID;
 


### PR DESCRIPTION
Fixes an issue #200 where unsafe extbans like $r: and $s: could be set in +e and +I 
modes by remote servers.

The extban handlers already check for this and reject it, but the check only ran 
for local clients. Removed the MyClient() check so the validation happens for both 
local and remote servers.