### PR TITLE
Add doing_info_conf hook and cleanup unused hooks

### DIFF
--- a/include/hook.h
+++ b/include/hook.h
@@ -42,10 +42,6 @@ enum message_tag_approval
 
 typedef void (*hookfn) (void *data);
 
-extern int h_iosend_id;
-extern int h_iorecv_id;
-extern int h_iorecvctrl_id;
-
 extern int h_burst_client;
 extern int h_burst_channel;
 extern int h_burst_finished;

--- a/modules/m_admin.c
+++ b/modules/m_admin.c
@@ -47,15 +47,9 @@ struct Message admin_msgtab = {
 	{{mr_admin, 0}, {m_admin, 0}, {ms_admin, 0}, mg_ignore, mg_ignore, {ms_admin, 0}}
 };
 
-int doing_admin_hook;
-
 mapi_clist_av1 admin_clist[] = { &admin_msgtab, NULL };
-mapi_hlist_av1 admin_hlist[] = {
-	{ "doing_admin",	&doing_admin_hook },
-	{ NULL, NULL }
-};
 
-DECLARE_MODULE_AV2(admin, NULL, NULL, admin_clist, admin_hlist, NULL, NULL, NULL, admin_desc);
+DECLARE_MODULE_AV2(admin, NULL, NULL, admin_clist, NULL, NULL, NULL, NULL, admin_desc);
 
 /*
  * mr_admin - ADMIN command handler

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -54,11 +54,11 @@ struct Message info_msgtab = {
 	{mg_unreg, {m_info, 0}, {mo_info, 0}, mg_ignore, mg_ignore, {mo_info, 0}}
 };
 
-int doing_info_hook;
+int doing_info_conf_hook;
 
 mapi_clist_av1 info_clist[] = { &info_msgtab, NULL };
 mapi_hlist_av1 info_hlist[] = {
-	{ "doing_info",		&doing_info_hook },
+	{ "doing_info_conf", &doing_info_conf_hook },
 	{ NULL, NULL }
 };
 
@@ -889,6 +889,9 @@ send_conf_options(struct Client *source_p)
 				info_table[i].desc ? info_table[i].desc : "<none>");
 	}
 
+	/* Let hooks send any conf options they dynamically defined */
+	hook_data hdata = { source_p, NULL, NULL };
+	call_hook(doing_info_conf_hook, &hdata);
 
 	/* Don't send oper_only_umodes...it's a bit mask, we will have to decode it
 	 ** in order for it to show up properly to opers who issue INFO

--- a/modules/m_motd.c
+++ b/modules/m_motd.c
@@ -46,15 +46,9 @@ struct Message motd_msgtab = {
 	{mg_unreg, {m_motd, 0}, {mo_motd, 0}, mg_ignore, mg_ignore, {mo_motd, 0}}
 };
 
-int doing_motd_hook;
-
 mapi_clist_av1 motd_clist[] = { &motd_msgtab, NULL };
-mapi_hlist_av1 motd_hlist[] = {
-	{ "doing_motd",	&doing_motd_hook },
-	{ NULL, NULL }
-};
 
-DECLARE_MODULE_AV2(motd, NULL, NULL, motd_clist, motd_hlist, NULL, NULL, NULL, motd_desc);
+DECLARE_MODULE_AV2(motd, NULL, NULL, motd_clist, NULL, NULL, NULL, NULL, motd_desc);
 
 /*
 ** m_motd

--- a/modules/m_trace.c
+++ b/modules/m_trace.c
@@ -49,12 +49,10 @@ struct Message trace_msgtab = {
 	{mg_unreg, {m_trace, 0}, {m_trace, 0}, mg_ignore, mg_ignore, {m_trace, 0}}
 };
 
-int doing_trace_hook;
 int doing_trace_show_idle_hook;
 
 mapi_clist_av1 trace_clist[] = { &trace_msgtab, NULL };
 mapi_hlist_av1 trace_hlist[] = {
-	{ "doing_trace",	&doing_trace_hook },
 	{ "doing_trace_show_idle", &doing_trace_show_idle_hook },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
doing_info_conf is called during INFO commands after all conf options have been sent to opers. Modules can use this hook to expose any conf options they define by sending relevant RPL_INFO replies to the oper. This addition removes the final barrier to defining new ircd.conf options inside of extension modules rather than requiring core changes for extension configuration.

Additionally, some cleanup has been performed for hook definitions that are not called anywhere inside of solanum. Three hooks were declared in hook.h as extern int but were not defined or referenced in any other file: iosend_id, iorecv_id, and iorecvctrl_id. The doing_admin, doing_info, doing_motd, and doing_trace "spy" hooks were defined in the module headers for those modules, however the modules never actually invoked those hooks. All of the lingering declarations for these hooks have now been removed as they weren't doing anything anyway.