### PR TITLE
Pass msgbuf to PART's privmsg_channel hook and propagate PART tags

### DIFF
--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -1051,7 +1051,6 @@ or parameter array is not recommended and may not function as expected.
 
 The following send functions currently do not call this hook:
 
-- sendto_server
 - kill_client
 - kill_client_serv_butone
 

--- a/extensions/tag_message_id.c
+++ b/extensions/tag_message_id.c
@@ -84,6 +84,10 @@ add_message_id_channel(void *data_)
 	static char buf[BUFSIZE];
 	hook_data_privmsg_channel *data = data_;
 
+	/* don't give msgid to PARTs */
+	if (data->msgtype == MESSAGE_TYPE_PART)
+		return;
+
 	if (msgbuf_get_tag(data->msgbuf, "msgid"))
 		return;
 

--- a/include/send.h
+++ b/include/send.h
@@ -54,6 +54,10 @@ extern void sendto_one_tags(struct Client *target_p, int serv_cap, int serv_negc
 extern void sendto_server(struct Client *one, struct Channel *chptr,
 			  unsigned long caps, unsigned long nocaps,
 			  const char *format, ...) AFP(5, 6);
+extern void sendto_server_tags(struct Client *one, struct Channel *chptr,
+			  unsigned long caps, unsigned long nocaps,
+			  size_t n_tags, const struct MsgTag tags[],
+			  const char *format, ...) AFP(7, 8);
 
 extern void sendto_channel_flags(struct Client *one, int type, struct Client *source_p,
 				 struct Channel *chptr, const char *, ...) AFP(5, 6);


### PR DESCRIPTION
The privmsg_channel hook gained a new msgbuf member which was uninitialized in m_part. Properly pass the msgbuf to that parameter and propagate any tags set by the hook to downstream servers.

This requires introducing sendto_server_tags(), and I refactored sendto_server() to call the same helper internal method as sendto_server_tags(). I took the opportunity to update the method to use msgbuf instead of linebuf directly (meaning sendto_server() now calls outbound_msgbuf).

Fixes #484