### PR TITLE
Remove channel::kick_on_split_riding

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -358,7 +358,6 @@ channel {
 	no_create_on_split = no;
 	no_join_on_split = no;
 	burst_topicwho = yes;
-	kick_on_split_riding = no;
 	only_ascii_channels = no;
 	resv_forcepart = yes;
 	channel_target_change = yes;

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -821,15 +821,6 @@ channel {
 	/* burst topicwho: when bursting topics, also burst the topic setter */
 	burst_topicwho = yes;
 
-	/* kick on split riding: kick users riding splits to join +i or +k
-	 * channels. more precisely, if a bursting server sends an SJOIN
-	 * for a channel with a lower TS with either a +i mode or a +k
-	 * mode with a different key, kick all local users.
-	 *
-	 * note: this does not take +r, +b, +e and +I into account.
-	 */
-	kick_on_split_riding = no;
-
 	/* only ascii channels: disable local users joining channels
 	 * containing characters outside the range 33-126 (non-printable
 	 * or non-ASCII).

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -287,7 +287,6 @@ struct config_channel_entry
 	int default_split_server_count;
 	int default_split_user_count;
 	int burst_topicwho;
-	int kick_on_split_riding;
 	int only_ascii_channels;
 	int resv_forcepart;
 	int channel_target_change;

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -1828,6 +1828,13 @@ conf_set_alias_target(void *data)
 }
 
 static void
+conf_set_channel_kick_on_split_riding(void *data)
+{
+	conf_report_warning("Ignoring deprecated option channel::kick_on_split_riding;"
+		" please remove it from ircd.conf entirely");
+}
+
+static void
 conf_set_channel_autochanmodes(void *data)
 {
 	char *pm;
@@ -2792,7 +2799,7 @@ static struct ConfEntry conf_channel_table[] =
 	{ "default_split_user_count",	CF_INT,  NULL, 0, &ConfigChannel.default_split_user_count	 },
 	{ "default_split_server_count",	CF_INT,	 NULL, 0, &ConfigChannel.default_split_server_count },
 	{ "burst_topicwho",	CF_YESNO, NULL, 0, &ConfigChannel.burst_topicwho	},
-	{ "kick_on_split_riding", CF_YESNO, NULL, 0, &ConfigChannel.kick_on_split_riding },
+	{ "kick_on_split_riding", CF_YESNO, conf_set_channel_kick_on_split_riding, 0, NULL },
 	{ "knock_delay",	CF_TIME,  NULL, 0, &ConfigChannel.knock_delay		},
 	{ "knock_delay_channel",CF_TIME,  NULL, 0, &ConfigChannel.knock_delay_channel	},
 	{ "max_bans",		CF_INT,   NULL, 0, &ConfigChannel.max_bans		},

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -795,7 +795,6 @@ set_default_conf(void)
 	ConfigChannel.max_bans_large = 500;
 	ConfigChannel.only_ascii_channels = false;
 	ConfigChannel.burst_topicwho = false;
-	ConfigChannel.kick_on_split_riding = false;
 
 	ConfigChannel.default_split_user_count = 15000;
 	ConfigChannel.default_split_server_count = 10;

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -556,11 +556,6 @@ static struct InfoStruct info_table[] = {
 		INFO_DECIMAL(&ConfigChannel.knock_delay_channel),
 	},
 	{
-		"kick_on_split_riding",
-		"Kick users riding splits to join +i or +k channels",
-		INFO_INTBOOL_YN(&ConfigChannel.kick_on_split_riding),
-	},
-	{
 		"disable_local_channels",
 		"Disable local channels (&channels)",
 		INFO_INTBOOL_YN(&ConfigChannel.disable_local_channels),


### PR DESCRIPTION
This feature had numerous pitfalls (such as not checking +beI) and services does it better than we can. Remove it and alert opers that the feature no longer exists if they had it configured.