### PR TITLE
Make MODLIST a public command

### DIFF
--- a/help/opers/modlist
+++ b/help/opers/modlist
@@ -1,8 +1,14 @@
 MODLIST [match string]
 
--- List the modules that are currently loaded into the
-ircd, along with their address and version.
+List the modules that are currently loaded into the
+ircd, along with their description, version, and
+address (viewing address requires oper:admin).
 When a match string is provided, modlist only prints
 modules with names matching the match string.
+
+MODLIST <match string> <server mask>
+
+View the module list for remote servers matching
+the provided server mask.
 
 - Requires Oper Priv: oper:admin

--- a/help/users/modlist
+++ b/help/users/modlist
@@ -1,0 +1,6 @@
+MODLIST [match string]
+
+List the modules that are currently loaded into the
+ircd, along with their description and version.
+When a match string is provided, modlist only prints
+modules with names matching the match string.


### PR DESCRIPTION
This increases transparency for users by letting them see precisely which modules are loaded into the ircd. The address a module is loaded at still requires oper:admin (showing 0 for all other users). Viewing the modlist of a remote server or remote servers also still requires oper:admin since it gets sent through ENCAP and there's no guarantee that the remote server has this updated module loaded (thus risking exposing module addresses to remote users).