### PR TITLE
Fix crash in message parsing

### DIFF
--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -212,16 +212,16 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 		}
 	}
 
+	s_assert(incoming_client == NULL);
+	s_assert(incoming_message == NULL);
 	incoming_message = &updated_msg;
 	incoming_client = client_p;
 
 	if (mptr == NULL)
 	{
 		do_numeric(numeric, client_p, from, &updated_msg);
-		return;
 	}
-
-	if(handle_command(mptr, &updated_msg, client_p, from) < -1)
+	else if (handle_command(mptr, &updated_msg, client_p, from) < -1)
 	{
 		char *p;
 		for (p = pbuffer; p <= end; p += 8)


### PR DESCRIPTION
The incoming_client and incoming_message globals were not properly cleared after processing a numeric command. Ensure they are cleared by not returning early after setting those global values. This fixes a regression introduced in e2a499f7192fa5e966dab03b7980e3240111d7b3