### PR TITLE
Add m_quarantine

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -90,6 +90,7 @@
  * /okick support (alternative to override)          -- m_okick
  * /omode support (alternative to override)          -- m_omode
  * /opme support (alternative to override)           -- m_opme
+ * QUARANTINE (restrict unidentified connections)    -- m_quarantine
  * /remove support                                   -- m_remove
  * Send permanent XLINEs and RESVs to remote server  -- m_sendbans
  * Shed users from the server                        -- m_shedding
@@ -154,6 +155,7 @@
 #loadmodule "extensions/m_okick";
 #loadmodule "extensions/m_omode";
 #loadmodule "extensions/m_opme";
+#loadmodule "extensions/m_quarantine";
 #loadmodule "extensions/m_remove";
 #loadmodule "extensions/m_sendbans";
 #loadmodule "extensions/m_shedding";
@@ -1536,6 +1538,36 @@ general {
 	 */
 	drain_reason = "This server is not accepting connections.";
 };
+
+/* The quarantine block is only used if you have the m_quarantine extension loaded;
+ * it will not be valid (and should not exist) otherwise.
+ */
+#quarantine {
+    /* allow_channels: Quarantined users will be able to JOIN and speak in this channel.
+     * If omitted, no channels are allowed. Multiple channels can be listed separated by commas.
+     */
+    #allow_channels = "#help";
+
+    /* apply_msg: Notice sent to users that have been quarantined */
+    #apply_msg = "You have been quarantined and must log into your NickServ account before you can join channels. Please see /STATS p for assistance.";
+
+    /* join_reason: Message displayed to quarantined users when they are denied JOINing a channel */
+    #join_reason = "Cannot join channel (usermode +q) - you need to be logged into your NickServ account";
+
+    /* msg_reason: Message displayed to quarantined users when they are denied messaging a nick/channel */
+    #msg_reason = "Cannot send to nick/channel (usermode +q) - you need to be logged into your NickServ account";
+
+    /* other_msg_reason: Message displayed to other users when they are denied messaging a quarantined user */
+    #other_msg_reason = "Cannot send to user - they are quarantined and will be unable to respond to you";
+
+    /* part_channels: If yes (default), quarantining a user will cause them to part all channels
+     * that are not allowed via allow_channels.
+     */
+    #part_channels = yes;
+
+    /* remove_msg: Notice sent to users that are no longer quarantined */
+    #remove_msg = "You are no longer quarantined and can freely join channels.";
+#};
 
 modules {
 	/* module path: paths to search for modules specified below and

--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -8,52 +8,53 @@ module or define a new hook in a module, see `extensions/example_module.c`.
 
 ## Hook list
 
-| Module    | Hook name                      | Description                                               |
-|-----------|--------------------------------|-----------------------------------------------------------|
-| Core      | after_client_exit              | A user has left the server                                |
-| Core      | burst_client                   | A user was sent to a remote server during a netjoin       |
-| Core      | burst_channel                  | A channel was sent to a remote server during a netjoin    |
-| Core      | burst_finished                 | We finished bursting users/channels during a netjoin      |
-| Core      | can_join                       | A local user is about to join a channel                   |
-| Core      | can_kick                       | A user is about to be kicked from a channel               |
-| Core      | can_send                       | Called when checking if a user can talk on a channel      |
-| Core      | cap_change                     | A user's client capabilities changed                      |
-| Core      | client_exit                    | A user is leaving the server                              |
-| Core      | conf_read_end                  | Called after reading conf files on start or rehash        |
-| Core      | conf_read_start                | Called before reading conf files on start or rehash       |
-| Core      | get_channel_access             | Called when checking a user's privileges on a channel     |
-| Core      | introduce_client               | A user has been introduced to the rest of the network     |
-| Core      | message_handler                | Determine the handler used to process an incoming message |
-| Core      | message_tag                    | Called for each tag on incoming messages                  |
-| Core      | new_local_user                 | A user connected locally, before introducing to network   |
-| Core      | new_remote_user                | A remote user was introduced, before propagating onward   |
-| Core      | outbound_msgbuf                | A message is about to be sent to one or more targets      |
-| Core      | priv_change                    | An oper's privset changed                                 |
-| Core      | privmsg_channel                | A message or PART is about to be sent to a channel        |
-| Core      | privmsg_user                   | A message is about to be sent to a user                   |
-| Core      | rehash                         | The server finished rehashing its conf files              |
-| Core      | server_introduced              | A server has been introduced to the network (pre-burst)   |
-| Core      | server_eob                     | A server has finished processing a netjoin burst from us  |
-| Core      | umode_changed                  | The modes for a user have changed                         |
-| m_info    | doing_info_conf                | Conf entries have been sent to an oper using INFO         |
-| m_invite  | can_invite                     | A local user is about to invite another user to a channel |
-| m_invite  | invite                         | A local user is about to be invited to a channel          |
-| m_join    | can_create_channel             | A user is about to create a channel                       |
-| m_join    | channel_join                   | A user has finished joining a channel                     |
-| m_join    | channel_lowerts                | A remote server gave us a lower TS for a channel          |
-| m_kill    | can_kill                       | A local oper is about to kill a user                      |
-| m_nick    | local_nick_change              | A local user has changed nicknames                        |
-| m_nick    | remote_nick_change             | A remote user has changed nicknames                       |
-| m_quit    | client_quit                    | A user has quit from the network                          |
-| m_stats   | doing_stats                    | A user has run STATS                                      |
-| m_stats   | doing_stats_show_idle          | Called to determine if send/recv data is shown in STATS l |
-| m_trace   | doing_trace_show_idle          | Called to determine if timestamp data is shown in TRACE   |
-| m_version | doing_version_confopts         | Called before sending confopts in VERSION                 |
-| m_who     | doing_who_show_idle            | Called to determine if idle time is shown in WHOX         |
-| m_whois   | doing_whois                    | A local user has run WHOIS                                |
-| m_whois   | doing_whois_channel_visibility | Called to determine which channels to display in WHOIS    |
-| m_whois   | doing_whois_global             | A user has run a remote WHOIS targeting this server       |
-| m_whois   | doing_whois_show_idle          | Called to determine if idle time is shown in WHOIS        |
+| Module     | Hook name                      | Description                                               |
+|------------|--------------------------------|-----------------------------------------------------------|
+| Core       | after_client_exit              | A user has left the server                                |
+| Core       | burst_client                   | A user was sent to a remote server during a netjoin       |
+| Core       | burst_channel                  | A channel was sent to a remote server during a netjoin    |
+| Core       | burst_finished                 | We finished bursting users/channels during a netjoin      |
+| Core       | can_join                       | A local user is about to join a channel                   |
+| Core       | can_kick                       | A user is about to be kicked from a channel               |
+| Core       | can_send                       | Called when checking if a user can talk on a channel      |
+| Core       | cap_change                     | A user's client capabilities changed                      |
+| Core       | client_exit                    | A user is leaving the server                              |
+| Core       | conf_read_end                  | Called after reading conf files on start or rehash        |
+| Core       | conf_read_start                | Called before reading conf files on start or rehash       |
+| Core       | get_channel_access             | Called when checking a user's privileges on a channel     |
+| Core       | introduce_client               | A user has been introduced to the rest of the network     |
+| Core       | message_handler                | Determine the handler used to process an incoming message |
+| Core       | message_tag                    | Called for each tag on incoming messages                  |
+| Core       | new_local_user                 | A user connected locally, before introducing to network   |
+| Core       | new_remote_user                | A remote user was introduced, before propagating onward   |
+| Core       | outbound_msgbuf                | A message is about to be sent to one or more targets      |
+| Core       | priv_change                    | An oper's privset changed                                 |
+| Core       | privmsg_channel                | A message or PART is about to be sent to a channel        |
+| Core       | privmsg_user                   | A message is about to be sent to a user                   |
+| Core       | rehash                         | The server finished rehashing its conf files              |
+| Core       | server_introduced              | A server has been introduced to the network (pre-burst)   |
+| Core       | server_eob                     | A server has finished processing a netjoin burst from us  |
+| Core       | umode_changed                  | The modes for a user have changed                         |
+| m_info     | doing_info_conf                | Conf entries have been sent to an oper using INFO         |
+| m_invite   | can_invite                     | A local user is about to invite another user to a channel |
+| m_invite   | invite                         | A local user is about to be invited to a channel          |
+| m_join     | can_create_channel             | A user is about to create a channel                       |
+| m_join     | channel_join                   | A user has finished joining a channel                     |
+| m_join     | channel_lowerts                | A remote server gave us a lower TS for a channel          |
+| m_kill     | can_kill                       | A local oper is about to kill a user                      |
+| m_nick     | local_nick_change              | A local user has changed nicknames                        |
+| m_nick     | remote_nick_change             | A remote user has changed nicknames                       |
+| m_quit     | client_quit                    | A user has quit from the network                          |
+| m_services | account_change                 | A user's services account has changed                     |
+| m_stats    | doing_stats                    | A user has run STATS                                      |
+| m_stats    | doing_stats_show_idle          | Called to determine if send/recv data is shown in STATS l |
+| m_trace    | doing_trace_show_idle          | Called to determine if timestamp data is shown in TRACE   |
+| m_version  | doing_version_confopts         | Called before sending confopts in VERSION                 |
+| m_who      | doing_who_show_idle            | Called to determine if idle time is shown in WHOX         |
+| m_whois    | doing_whois                    | A local user has run WHOIS                                |
+| m_whois    | doing_whois_channel_visibility | Called to determine which channels to display in WHOIS    |
+| m_whois    | doing_whois_global             | A user has run a remote WHOIS targeting this server       |
+| m_whois    | doing_whois_show_idle          | Called to determine if idle time is shown in WHOIS        |
 
 ## Registering hook functions
 
@@ -132,6 +133,29 @@ between hooked functions and your module, such as if you want other modules to
 be able to pass data back to you by modifying any of the field values.
 
 ## Hook details
+### account_change
+
+This hook is called after a user's services user (account name) has changed.
+The user may be either local or remote. This hook is not called when a user's
+services account changes during registration.
+
+Hook data: `hook_cdata *`
+
+Fields:
+
+- client (`struct Client *`): The user whose services account changed
+- arg1 (`const char *`): The user's previous services account
+- arg2 (`const void *`): Unused (always `NULL`)
+
+The user's updated account is available via `client->user->suser`. If the
+user was previously logged out, `arg1` will be an empty string. If the user
+just logged out, then `client->user->suser` will be an empty string.
+
+Although unlikely, it is possible for the old and updated account names to be
+identical or vary only by casing; no checks are made for this before invoking
+the hook. Hook functions that need to operate only if the services account
+meaningfully changed should compare the two strings via `irccmp()`.
+
 ### after_client_exit
 
 This hook is called after any client (user or server) exits the network. All

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -53,6 +53,7 @@ extension_LTLIBRARIES =		\
   m_okick.la			\
   m_omode.la			\
   m_opme.la			\
+  m_quarantine.la       \
   m_remove.la			\
   m_sendbans.la			\
   m_shedding.la			\

--- a/extensions/m_quarantine.c
+++ b/extensions/m_quarantine.c
@@ -1,0 +1,570 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * m_quarantine.c: restrict connections until they identify to services
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "channel.h"
+#include "chmode.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "logger.h"
+#include "newconf.h"
+#include "numeric.h"
+#include "send.h"
+#include "s_newconf.h"
+#include "s_serv.h"
+#include "s_user.h"
+
+#define IsOperQuarantine(x) (HasPrivilege((x), "oper:quarantine"))
+#define IsQuarantined(x) ((x)->umodes & user_modes['q'])
+#define DEFAULT_JOIN_REASON "Cannot join channel (usermode +q) - you need to be logged into your NickServ account"
+#define DEFAULT_MSG_REASON "Cannot send to nick/channel (usermode +q) - you need to be logged into your NickServ account"
+#define DEFAULT_OTHER_MSG_REASON "Cannot send to user - they are quarantined and will be unable to respond to you"
+#define DEFAULT_APPLY_MSG "You have been quarantined and must log into your NickServ account before you can join channels. Please see /STATS p for assistance."
+#define DEFAULT_REMOVE_MSG "You are no longer quarantined and can freely join channels."
+
+static const char quarantine_desc[] = "QUARANTINE system and umode +q to restrict unidentified connections.";
+static char *join_reason = NULL;
+static char *msg_reason = NULL;
+static char *other_msg_reason = NULL;
+static char *apply_msg = NULL;
+static char *remove_msg = NULL;
+static int part_channels = 1;
+static char **allowed_channels = NULL;
+
+static struct Client *allowed_umode_change = NULL;
+
+static int modinit(void);
+static void moddeinit(void);
+static void me_quarantine(struct MsgBuf *, struct Client *, struct Client *, int, const char *[]);
+static void mo_quarantine(struct MsgBuf *, struct Client *, struct Client *, int, const char *[]);
+static void me_unquarantine(struct MsgBuf *, struct Client *, struct Client *, int, const char *[]);
+static void mo_unquarantine(struct MsgBuf *, struct Client *, struct Client *, int, const char *[]);
+static void add_quarantine(struct Client *source_p, struct Client *target_p, const char *reason);
+static void remove_quarantine(struct Client *source_p, struct Client *target_p);
+static void quarantine_account_change(void *);
+static void quarantine_change_umode(void *);
+static void quarantine_conf_info(void *);
+static void quarantine_default_umode_begin(void *);
+static void quarantine_default_umode_end(void *);
+static void quarantine_join_channel(void *);
+static void quarantine_privmsg_channel(void *);
+static void quarantine_privmsg_user(void *);
+static void quarantine_reset_conf(void *);
+static void quarantine_set_allow_channels(void *);
+
+struct Message quarantine_msgtab = {
+	"QUARANTINE", 0, 0, 0, 0,
+	{ mg_unreg, mg_not_oper, mg_not_oper, mg_ignore, { me_quarantine, 3 }, { mo_quarantine, 3 } }
+};
+
+struct Message unquarantine_msgtab = {
+	"UNQUARANTINE", 0, 0, 0, 0,
+	{ mg_unreg, mg_not_oper, mg_not_oper, mg_ignore, { me_unquarantine, 2 }, { mo_unquarantine, 2 } }
+};
+
+struct ConfEntry conf_quarantine_table[] = {
+	{ "allow_channels", CF_QSTRING | CF_FLIST, quarantine_set_allow_channels, 0, NULL },
+	{ "apply_msg", CF_QSTRING, NULL, BUFSIZE, &apply_msg },
+	{ "join_reason", CF_QSTRING, NULL, BUFSIZE, &join_reason },
+	{ "msg_reason", CF_QSTRING, NULL, BUFSIZE, &msg_reason },
+	{ "other_msg_reason", CF_QSTRING, NULL, BUFSIZE, &other_msg_reason },
+	{ "part_channels", CF_YESNO, NULL, 0, &part_channels },
+	{ "remove_msg", CF_QSTRING, NULL, BUFSIZE, &remove_msg },
+	{ "\0",	0, NULL, 0, NULL }
+};
+
+mapi_clist_av1 quarantine_clist[] = { &quarantine_msgtab, &unquarantine_msgtab, NULL };
+
+mapi_hfn_list_av1 quarantine_hfn_list[] = {
+	{ "account_change", quarantine_account_change },
+	{ "can_join", quarantine_join_channel },
+	{ "conf_read_start", quarantine_reset_conf },
+	{ "doing_info_conf", quarantine_conf_info },
+	{ "introduce_client", quarantine_default_umode_end },
+	{ "new_local_user", quarantine_default_umode_begin, HOOK_MONITOR },
+	{ "privmsg_channel", quarantine_privmsg_channel },
+	{ "privmsg_user", quarantine_privmsg_user },
+	{ "umode_changed", quarantine_change_umode },
+	{ NULL, NULL }
+};
+
+DECLARE_MODULE_AV2(m_quarantine, modinit, moddeinit, quarantine_clist, NULL, quarantine_hfn_list, NULL, NULL, quarantine_desc);
+
+static int
+modinit(void)
+{
+	if (find_top_conf("quarantine") != NULL)
+	{
+		ierror("m_quarantine: a top conf block named quarantine already exists, unloading extension");
+		return -1;
+	}
+
+	user_modes['q'] = find_umode_slot();
+	if (!user_modes['q'])
+	{
+		ierror("m_quarantine: unable to allocate usermode slot for +q, unloading extension");
+		return -1;
+	}
+
+	construct_umodebuf();
+	add_top_conf("quarantine", NULL, NULL, conf_quarantine_table);
+	return 0;
+}
+
+static void
+moddeinit(void)
+{
+	user_modes['q'] = 0;
+	construct_umodebuf();
+	remove_top_conf("quarantine");
+	quarantine_reset_conf(NULL);
+}
+
+static void
+mo_quarantine(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	if (!IsOperQuarantine(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "quarantine");
+		return;
+	}
+
+	struct Client *target_p = find_named_person(parv[1]);
+	if (target_p == NULL)
+	{
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), parv[1]);
+		return;
+	}
+
+	if (MyClient(target_p))
+		add_quarantine(source_p, target_p, parv[2]);
+	else
+		sendto_one(target_p, ":%s ENCAP %s QUARANTINE %s :%s",
+			get_id(source_p, target_p), target_p->servptr->name, get_id(target_p, target_p), parv[2]);
+}
+
+static void
+me_quarantine(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	struct Client *target_p = find_named_person(parv[1]);
+	if (target_p == NULL)
+	{
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), parv[1]);
+		return;
+	}
+
+	if (MyClient(target_p))
+		add_quarantine(source_p, target_p, parv[2]);
+}
+
+static void
+mo_unquarantine(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	if (!IsOperQuarantine(source_p))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "quarantine");
+		return;
+	}
+
+	struct Client *target_p = find_named_person(parv[1]);
+	if (target_p == NULL)
+	{
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), parv[1]);
+		return;
+	}
+
+	if (MyClient(target_p))
+		remove_quarantine(source_p, target_p);
+	else
+		sendto_one(target_p, ":%s ENCAP %s UNQUARANTINE %s",
+			get_id(source_p, target_p), target_p->servptr->name, get_id(target_p, target_p));
+}
+
+static void
+me_unquarantine(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	struct Client *target_p = find_named_person(parv[1]);
+	if (target_p == NULL)
+	{
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK, form_str(ERR_NOSUCHNICK), parv[1]);
+		return;
+	}
+
+	if (MyClient(target_p))
+		remove_quarantine(source_p, target_p);
+}
+
+static void
+add_quarantine(struct Client *source_p, struct Client *target_p, const char *reason)
+{
+	const char *parv[4] = { target_p->name, target_p->name, "+q", NULL };
+
+	if (IsQuarantined(target_p))
+	{
+		sendto_one_notice(source_p, ":*** %s is already quarantined.",
+			target_p->name);
+		return;
+	}
+
+	if (!EmptyString(target_p->user->suser))
+	{
+		sendto_one_notice(source_p, ":*** %s is already logged into services and cannot be quarantined.",
+			target_p->name);
+		return;
+	}
+
+	if (IsOper(target_p))
+	{
+		sendto_one_notice(source_p, ":*** %s is an oper and cannot be put into quarantine.",
+			target_p->name);
+		return;
+	}
+
+	if (IsService(target_p))
+	{
+		sendto_one_notice(source_p, ":*** %s is a network service and cannot be put into quarantine.",
+			target_p->name);
+		return;
+	}
+
+	sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s has put %s into QUARANTINE [%s]",
+		source_p->name, target_p->name, reason);
+	sendto_one_notice(target_p, ":*** %s",
+		EmptyString(apply_msg) ? DEFAULT_APPLY_MSG : apply_msg);
+
+	allowed_umode_change = target_p;
+	user_mode(target_p, target_p, 3, parv);
+	allowed_umode_change = NULL;
+
+	if (part_channels)
+	{
+		rb_dlink_node *ptr, *next_ptr;
+		RB_DLINK_FOREACH_SAFE(ptr, next_ptr, target_p->user->channel.head)
+		{
+			struct membership *msptr = ptr->data;
+			struct Channel *chptr = msptr->chptr;
+			bool allowed = false;
+			if (allowed_channels != NULL)
+			{
+				for (int i = 0; allowed_channels[i] != NULL; i++)
+				{
+					if (!irccmp(chptr->chname, allowed_channels[i]))
+					{
+						allowed = true;
+						break;
+					}
+				}
+			}
+
+			if (!allowed)
+			{
+				sendto_server(NULL, chptr, CAP_TS6, NOCAPS, ":%s PART %s",
+					use_id(source_p), chptr->chname);
+				sendto_channel_local(target_p, ALL_MEMBERS, chptr, ":%s!%s@%s PART %s",
+					target_p->name, target_p->username, target_p->host, chptr->chname);
+				remove_user_from_channel(msptr);
+			}
+		}
+	}
+}
+
+static void
+remove_quarantine(struct Client *source_p, struct Client *target_p)
+{
+	const char *parv[4] = { target_p->name, target_p->name, "-q", NULL };
+
+	if (!IsQuarantined(target_p))
+	{
+		sendto_one_notice(source_p, ":*** %s is not currently quarantined.",
+			target_p->name);
+		return;
+	}
+
+	if (source_p != target_p)
+		sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s has removed %s from QUARANTINE",
+			source_p->name, target_p->name);
+	sendto_one_notice(target_p, ":*** %s",
+		EmptyString(remove_msg) ? DEFAULT_REMOVE_MSG : remove_msg);
+
+	allowed_umode_change = target_p;
+	user_mode(target_p, target_p, 3, parv);
+	allowed_umode_change = NULL;
+}
+
+static void
+quarantine_account_change(void *data_)
+{
+	hook_cdata *data = data_;
+	if (!MyClient(data->client) || !IsQuarantined(data->client))
+		return;
+
+	if (!EmptyString(data->client->user->suser))
+		remove_quarantine(data->client, data->client);
+}
+
+static void
+quarantine_change_umode(void *data_)
+{
+	hook_data_umode_changed *data = data_;
+
+	if (!MyClient(data->client))
+		return;
+
+	/* If someone successfully opers, unquarantine them.
+	 * Services might be down and we don't want to impede them doing what they need to do.
+	 */
+	if (IsOper(data->client) && IsQuarantined(data->client))
+	{
+		sendto_one_notice(data->client, ":*** %s",
+			EmptyString(remove_msg) ? DEFAULT_REMOVE_MSG : remove_msg);
+		data->client->umodes &= ~user_modes['q'];
+		return;
+	}
+
+	bool quarantine_changed = ((data->client->umodes ^ data->oldumodes) & user_modes['q']) == user_modes['q'];
+	if (data->client != allowed_umode_change && quarantine_changed)
+	{
+		if (data->oldumodes & user_modes['q'])
+			data->client->umodes |= user_modes['q'];
+		else
+			data->client->umodes &= ~user_modes['q'];
+	}
+}
+
+static void
+quarantine_conf_info(void *data_)
+{
+	hook_data *data = data_;
+
+	/* quarantine::allow_channels not listed, since INFO in general doesn't seem
+	 * to support sending list-type conf options (e.g. no hidden_caps) */
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::apply_msg",
+		EmptyString(apply_msg) ? DEFAULT_APPLY_MSG : apply_msg,
+		"Notice sent to users that have been quarantined");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::join_reason",
+		EmptyString(join_reason) ? DEFAULT_JOIN_REASON : join_reason,
+		"Sent to +q users when JOIN is denied");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::msg_reason",
+		EmptyString(msg_reason) ? DEFAULT_MSG_REASON : msg_reason,
+		"Sent to +q users when sending a message is denied");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::other_msg_reason",
+		EmptyString(other_msg_reason) ? DEFAULT_OTHER_MSG_REASON : other_msg_reason,
+		"Sent to users trying to message a +q user");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::part_channels",
+		part_channels ? "YES" : "NO",
+		"QUARANTINE causes user to part disallowed channels");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"quarantine::remove_msg",
+		EmptyString(remove_msg) ? DEFAULT_REMOVE_MSG : remove_msg,
+		"Notice sent to users that are no longer quarantined");
+}
+
+static void
+quarantine_default_umode_begin(void *data)
+{
+	/* if ircd.conf has +q as a default umode, and the user didn't identify
+	 * during registration (via SASL or PASS), allow the +q and notify the user
+	 */
+	struct Client *source_p = data;
+	if (!IsAnyDead(source_p) && IsQuarantined(source_p))
+	{
+		if (!EmptyString(source_p->user->suser))
+			source_p->umodes &= ~user_modes['q'];
+		else
+		{
+			sendto_one_notice(source_p, ":*** %s",
+				EmptyString(apply_msg) ? DEFAULT_APPLY_MSG : apply_msg);
+			allowed_umode_change = source_p;
+		}
+	}
+}
+
+static void
+quarantine_default_umode_end(void *data)
+{
+	/* Introducing a new local user calls three hooks in the following order:
+	 * 1. new_local_user
+	 * 2. umode_changed
+	 * 3. introduce_client
+	 * We make sure we clear the allowed_umode_change after introduce_client so it can't linger
+	 * after the client is introduced. Non-local users also call the latter two, but effectively
+	 * no-ops (umode_changed aborts if non-local, this just sets something already NULL to NULL),
+	 * so no issues there
+	 */
+	allowed_umode_change = NULL;
+}
+
+static void
+quarantine_join_channel(void *data_)
+{
+	hook_data_channel *data = data_;
+	if (!MyClient(data->client) || !IsQuarantined(data->client))
+		return;
+
+	/* if some other hook function already rejected this join attempt, keep that rejection */
+	if (data->approved != 0)
+		return;
+
+	if (allowed_channels != NULL)
+	{
+		for (int i = 0; allowed_channels[i] != NULL; i++)
+		{
+			if (!irccmp(data->chptr->chname, allowed_channels[i]))
+				return;
+		}
+	}
+
+	/* Remind the user that they're quarantined */
+	sendto_one_numeric(data->client, ERR_NEEDREGGEDNICK, "%s :%s",
+		data->chptr->chname,
+		EmptyString(join_reason) ? DEFAULT_JOIN_REASON : join_reason);
+	data->approved = ERR_CUSTOM;
+}
+
+static void
+quarantine_privmsg_channel(void *data_)
+{
+	hook_data_privmsg_channel *data = data_;
+	if (!MyClient(data->source_p) || !IsQuarantined(data->source_p))
+		return;
+
+	/* if some other hook function already rejected this attempt, keep that rejection */
+	if (data->approved != 0)
+		return;
+
+	if (allowed_channels != NULL)
+	{
+		for (int i = 0; allowed_channels[i] != NULL; i++)
+		{
+			if (!irccmp(data->chptr->chname, allowed_channels[i]))
+				return;
+		}
+	}
+
+	data->approved = ERR_CANNOTSENDTOCHAN;
+
+	/* Don't give error messages for non-PRIVMSG since many clients autogenerate these (e.g. +typing) */
+	if (data->msgtype == MESSAGE_TYPE_PRIVMSG)
+		sendto_one_numeric(data->source_p, ERR_CANNOTSENDTOCHAN, "%s :%s",
+			data->chptr->chname,
+			EmptyString(msg_reason) ? DEFAULT_MSG_REASON : msg_reason);
+}
+
+static void
+quarantine_privmsg_user(void *data_)
+{
+	hook_data_privmsg_user *data = data_;
+	if (!MyClient(data->source_p))
+		return;
+
+	/* if some other hook function already rejected this attempt, keep that rejection */
+	if (data->approved != 0)
+		return;
+
+	if (!IsQuarantined(data->source_p))
+	{
+		if (IsQuarantined(data->target_p) && !IsOper(data->source_p) && !IsService(data->source_p))
+		{
+			if (data->msgtype == MESSAGE_TYPE_PRIVMSG)
+				sendto_one_numeric(data->source_p, ERR_CANNOTSENDTOCHAN, "%s :%s",
+					data->target_p->name,
+					EmptyString(other_msg_reason) ? DEFAULT_OTHER_MSG_REASON : other_msg_reason);
+			data->approved = ERR_CANNOTSENDTOCHAN;
+		}
+		return;
+	}
+
+	/* let quarantined users message opers and services */
+	if (IsOper(data->target_p) || IsService(data->target_p))
+		return;
+
+	data->approved = ERR_CANNOTSENDTOCHAN;
+
+	/* Don't give error messages for non-PRIVMSG since many clients autogenerate these (e.g. +typing) */
+	if (data->msgtype == MESSAGE_TYPE_PRIVMSG)
+		sendto_one_numeric(data->source_p, ERR_CANNOTSENDTOCHAN, "%s :%s",
+			data->target_p->name,
+			EmptyString(msg_reason) ? DEFAULT_MSG_REASON : msg_reason);
+}
+
+static void
+quarantine_reset_conf(void *unused)
+{
+	if (allowed_channels != NULL)
+	{
+		for (int i = 0; allowed_channels[i] != NULL; i++)
+			rb_free(allowed_channels[i]);
+		rb_free(allowed_channels);
+		allowed_channels = NULL;
+	}
+
+	rb_free(apply_msg);
+	rb_free(join_reason);
+	rb_free(msg_reason);
+	rb_free(other_msg_reason);
+	rb_free(remove_msg);
+
+	apply_msg = NULL;
+	join_reason = NULL;
+	msg_reason = NULL;
+	other_msg_reason = NULL;
+	remove_msg = NULL;
+}
+
+static void
+quarantine_set_allow_channels(void *data)
+{
+	size_t n = 0;
+	for (conf_parm_t *arg = data; arg; arg = arg->next)
+		n++;
+
+	allowed_channels = rb_malloc((n + 1) * sizeof(char *));
+
+	n = 0;
+	for (conf_parm_t *arg = data; arg; arg = arg->next)
+		allowed_channels[n++] = rb_strdup(arg->v.string);
+	allowed_channels[n] = NULL;
+}

--- a/extensions/meson.build
+++ b/extensions/meson.build
@@ -46,6 +46,7 @@ extension_modules = [
   'm_okick',
   'm_omode',
   'm_opme',
+  'm_quarantine',
   'm_remove',
   'm_sendbans',
   'm_shedding',

--- a/help/opers/quarantine
+++ b/help/opers/quarantine
@@ -1,0 +1,22 @@
+QUARANTINE <nick> :<reason>
+
+Applies user mode +q to nick, preventing them from
+taking the following actions:
+
+- Joining channels (except channels allowed in
+  quarantine::allow_channels)
+- Sending messages to channels (except channels
+  allowed in quarantine::allow_channels)
+- Sending messages to users (except services and
+  opers)
+
+Users who are not opers or marked as services will
+additionally be unable to send private messages to
+quarantined users.
+
+A quarantined user who identifies to services will
+automatically lose the +q user mode. Attempting to
+use this command on a user already identified to
+services will fail.
+
+- Requires oper priv: oper:quarantine

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -6,18 +6,21 @@ User modes: (* designates that the umode is oper only)
 
      USERMODE     DESCRIPTION
 -----------------------------------------------------------------
-         +i     - Designates this client 'invisible'.
+       * +a     - Is marked as a server admin in whois.
          +g     - Deny users not on your /ACCEPT list from messaging you and
                   inviting you to channels.
-         +w     - Can see oper and server wallops.
-       ? +h     - Has a cloaked host. May be +x depending on cloaking module
+      ?* +h     - Show on /STATS p and marked as available for help in whois.
+         +i     - Designates this client 'invisible'.
+       * +l     - Can see oper locops (local wallops).
          +o     - Designates this client is an IRC Operator.
                   Use the /oper command to attain this.
-       * +a     - Is marked as a server admin in whois.
-       * +l     - Can see oper locops (local wallops).
+       ? +q     - Prevents you from joining channels or sending private messages
+                  until you identify to services (cannot be set or unset).
        * +s     - Can see server notices (see /quote help snomask).
        ? +u     - Receive messages that would otherwise be filtered server side
                   based on content.
+         +w     - Can see oper and server wallops.
+       ? +x     - Has a cloaked host. May be +h depending on cloaking module
        * +z     - Can see operwalls.
        ? +C     - Prevents you from receiving CTCPs other than ACTION.
          +D     - Deaf - ignores all channel messages.

--- a/help/opers/unquarantine
+++ b/help/opers/unquarantine
@@ -1,0 +1,7 @@
+UNQUARANTINE <nick>
+
+Removes the quarantine user mode (-q) from nick,
+allowing them to join channels and speak as a
+regular user would.
+
+- Requires oper priv: oper:quarantine

--- a/help/users/umode
+++ b/help/users/umode
@@ -8,12 +8,14 @@ User modes: (? designates that the umode is provided by an extension
          +o     - Designates this client is an IRC Operator.
                   Use the /oper command to attain this.
          +i     - Designates this client 'invisible'.
-       ? +h     - Has a cloaked host. May be +x depending on cloaking module
          +g     - Deny users not on your /ACCEPT list from messaging you and
                   inviting you to channels.
+       ? +q     - Prevents you from joining channels or sending private messages
+                  until you identify to services (cannot be set or unset).
        ? +u     - Receive messages that would otherwise be filtered server side
                   based on content.
          +w     - Can see oper wallops.
+       ? +x     - Has a cloaked host. May be +h depending on cloaking module
        ? +C     - Prevents you from receiving CTCPs other than ACTION.
          +D     - Deaf - ignores all channel messages.
          +G     - Deny users not on your /ACCEPT list and not in a channel

--- a/modules/m_services.c
+++ b/modules/m_services.c
@@ -46,6 +46,7 @@
 #include "monitor.h"
 #include "supported.h"
 
+static int h_account_change;
 static const char services_desc[] = "Provides support for running a services daemon";
 
 static int _modinit(void);
@@ -85,6 +86,12 @@ struct Message nickdelay_msgtab = {
 mapi_clist_av1 services_clist[] = {
 	&su_msgtab, &login_msgtab, &rsfnc_msgtab, &nickdelay_msgtab, NULL
 };
+
+mapi_hlist_av1 services_hlist[] = {
+	{ "account_change", &h_account_change },
+	{ NULL, NULL }
+};
+
 mapi_hfn_list_av1 services_hfnlist[] = {
 	{ "doing_stats",	h_svc_stats },
 	{ "doing_whois",	h_svc_whois },
@@ -95,7 +102,7 @@ mapi_hfn_list_av1 services_hfnlist[] = {
 	{ NULL, NULL }
 };
 
-DECLARE_MODULE_AV2(services, _modinit, _moddeinit, services_clist, NULL, services_hfnlist, NULL, NULL, services_desc);
+DECLARE_MODULE_AV2(services, _modinit, _moddeinit, services_clist, services_hlist, services_hfnlist, NULL, NULL, services_desc);
 
 static int
 _modinit(void)
@@ -116,6 +123,7 @@ me_su(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 	int parc, const char *parv[])
 {
 	struct Client *target_p;
+	char old_suser[NICKLEN + 1] = { 0 };
 
 	if(!(source_p->flags & FLAGS_SERVICE))
 	{
@@ -129,6 +137,8 @@ me_su(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 
 	if(!target_p->user)
 		return;
+
+	rb_strlcpy(old_suser, target_p->user->suser, sizeof(old_suser));
 
 	if(EmptyString(parv[2]))
 		target_p->user->suser[0] = '\0';
@@ -150,16 +160,22 @@ me_su(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 	}
 
 	invalidate_bancache_user(target_p);
+	hook_cdata hdata = { target_p, old_suser, NULL };
+	call_hook(h_account_change, &hdata);
 }
 
 static void
 me_login(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 	int parc, const char *parv[])
 {
+	char old_suser[NICKLEN + 1] = { 0 };
 	if(!IsPerson(source_p))
 		return;
 
+	rb_strlcpy(old_suser, source_p->user->suser, sizeof(old_suser));
 	rb_strlcpy(source_p->user->suser, parv[1], sizeof(source_p->user->suser));
+	hook_cdata hdata = { source_p, old_suser, NULL };
+	call_hook(h_account_change, &hdata);
 }
 
 /* me_rsfnc()

--- a/modules/m_signon.c
+++ b/modules/m_signon.c
@@ -48,6 +48,7 @@
 #include "match.h"
 #include "s_user.h"
 
+static int h_account_change;
 static const char signon_desc[] = "Provides account login/logout support for services";
 
 static void me_svslogin(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
@@ -64,11 +65,16 @@ struct Message signon_msgtab = {
 	{mg_ignore, mg_ignore, {ms_signon, 6}, mg_ignore, mg_ignore, mg_ignore}
 };
 
+mapi_hlist_av1 signon_hlist[] = {
+	{ "account_change", &h_account_change },
+	{ NULL, NULL }
+};
+
 mapi_clist_av1 signon_clist[] = {
 	&svslogin_msgtab, &signon_msgtab, NULL
 };
 
-DECLARE_MODULE_AV2(signon, NULL, NULL, signon_clist, NULL, NULL, NULL, NULL, signon_desc);
+DECLARE_MODULE_AV2(signon, NULL, NULL, signon_clist, signon_hlist, NULL, NULL, NULL, signon_desc);
 
 #define NICK_VALID	1
 #define USER_VALID	2
@@ -406,10 +412,12 @@ send_signon(struct Client *client_p, struct Client *target_p,
 		const char *nick, const char *user, const char *host,
 		unsigned int newts, const char *login)
 {
+	char old_suser[NICKLEN + 1] = { 0 };
 	sendto_server(client_p, NULL, CAP_TS6, NOCAPS, ":%s SIGNON %s %s %s %ld %s",
 			use_id(target_p), nick, user, host,
 			(long) target_p->tsinfo, *login ? login : "0");
 
+	rb_strlcpy(old_suser, target_p->user->suser, sizeof(old_suser));
 	rb_strlcpy(target_p->user->suser, login, sizeof(target_p->user->suser));
 
 	if (irccmp(target_p->orighost, host))
@@ -418,4 +426,6 @@ send_signon(struct Client *client_p, struct Client *target_p,
 		ClearDynSpoof(target_p);
 
 	change_nick_user_host(target_p, nick, user, host, newts, "Signing %s (%s)", *login ?  "in" : "out", nick);
+	hook_cdata hdata = { target_p, old_suser, NULL };
+	call_hook(h_account_change, &hdata);
 }


### PR DESCRIPTION
This extension module provides a new usermode (+q) and two commands that allow opers to set/unset that mode. The mode can be set either via ircd.conf (general::default_umodes or auth::umodes) or via the QUARANTINE command. When using the command, a reason is required which will be broadcast to all other opers via the snote.

When set, a quarantined user will not be able to join channels or send messages to channels, with exception of explicitly allowlisted channels in ircd.conf. They will also not be able to send private messages to other users except opers or services.

The quarantine will be automatically removed if the target opers up or logs into a services account, and opers and logged in users cannot be quarantined. The UNQUARNTINE command may additionally be used to remove the quarantine status from a user. Users cannot otherwise set or remove this usermode from themselves.

The QUARANTINE and UNQUARANTINE commands require a new priv oper:quarantine.

To support this, a new account_change hook was added to m_services and m_signon. This hook is fired whenever a user's services account changes (via logging in or logging out) from the SVSLOGIN, SIGNON, LOGIN, or SU services commands. It is **not** fired for SVSLOGIN on unknown (pre-registration) users.

Documentation was updated for the new usermode, hook, and commands. Usermode help was alphabetized for consistency, a missing entry for helpops was added, and cloaking was moved to +x (since all modern cloaking modules use that mode instead) since I was touching the file anyway.