### PR TITLE
Separate client vs server caps

### DIFF
--- a/extensions/cap_oper.c
+++ b/extensions/cap_oper.c
@@ -33,10 +33,10 @@ static void cap_oper_outbound_msgbuf(void *);
 static void cap_oper_umode_changed(void *);
 static void cap_oper_cap_change(void *);
 
-static unsigned CLICAP_OPER;
-static unsigned CLICAP_OPER_AUSPEX;
-static unsigned CLICAP_OPER_JUSTOPER;
-static unsigned CLICAP_OPER_NORMAL;
+static uint64_t CLICAP_OPER;
+static uint64_t CLICAP_OPER_AUSPEX;
+static uint64_t CLICAP_OPER_JUSTOPER;
+static uint64_t CLICAP_OPER_NORMAL;
 
 static struct ClientCapability capdata_oper_oper = {
 	.visible = cap_oper_oper_visible,

--- a/extensions/cap_oper.c
+++ b/extensions/cap_oper.c
@@ -88,25 +88,25 @@ static inline void
 update_clicap_oper(struct Client *client)
 {
 	/* clear out old caps */
-	client->localClient->caps &= ~CLICAP_OPER_AUSPEX;
-	client->localClient->caps &= ~CLICAP_OPER_JUSTOPER;
-	client->localClient->caps &= ~CLICAP_OPER_NORMAL;
+	ClearClientCap(client, CLICAP_OPER_AUSPEX);
+	ClearClientCap(client, CLICAP_OPER_JUSTOPER);
+	ClearClientCap(client, CLICAP_OPER_NORMAL);
 
-	if (client->localClient->caps & CLICAP_OPER && HasPrivilege(client, "auspex:oper"))
+	if (IsClientCapable(client, CLICAP_OPER) && HasPrivilege(client, "auspex:oper"))
 	{
 		/* if the client is an oper with auspex, let them see everything */
-		client->localClient->caps |= CLICAP_OPER_AUSPEX;
+		client->localClient->client_caps |= CLICAP_OPER_AUSPEX;
 	}
-	else if (client->localClient->caps & CLICAP_OPER && IsOper(client))
+	else if (IsClientCapable(client, CLICAP_OPER) && IsOper(client))
 	{
 		/* if the client is an oper, let them see other opers */
-		client->localClient->caps |= CLICAP_OPER_JUSTOPER;
+		client->localClient->client_caps |= CLICAP_OPER_JUSTOPER;
 	}
-	else if (client->localClient->caps & CLICAP_OPER)
+	else if (IsClientCapable(client, CLICAP_OPER))
 	{
 		/* if the client is a normal user, let them see opers
 		   provided that server wide oper hiding is not enabled */
-		client->localClient->caps |= CLICAP_OPER_NORMAL;
+		client->localClient->client_caps |= CLICAP_OPER_NORMAL;
 	}
 }
 

--- a/extensions/cap_oper.c
+++ b/extensions/cap_oper.c
@@ -95,18 +95,18 @@ update_clicap_oper(struct Client *client)
 	if (IsClientCapable(client, CLICAP_OPER) && HasPrivilege(client, "auspex:oper"))
 	{
 		/* if the client is an oper with auspex, let them see everything */
-		client->localClient->client_caps |= CLICAP_OPER_AUSPEX;
+		SetClientCap(client, CLICAP_OPER_AUSPEX);
 	}
 	else if (IsClientCapable(client, CLICAP_OPER) && IsOper(client))
 	{
 		/* if the client is an oper, let them see other opers */
-		client->localClient->client_caps |= CLICAP_OPER_JUSTOPER;
+		SetClientCap(client, CLICAP_OPER_JUSTOPER);
 	}
 	else if (IsClientCapable(client, CLICAP_OPER))
 	{
 		/* if the client is a normal user, let them see opers
 		   provided that server wide oper hiding is not enabled */
-		client->localClient->client_caps |= CLICAP_OPER_NORMAL;
+		SetClientCap(client, CLICAP_OPER_NORMAL);
 	}
 }
 

--- a/extensions/cap_realhost.c
+++ b/extensions/cap_realhost.c
@@ -32,8 +32,8 @@ static void cap_realhost_outbound_msgbuf(void *);
 static void cap_realhost_umode_changed(void *);
 static void cap_realhost_cap_change(void *);
 
-static unsigned CLICAP_REALHOST;
-static unsigned CLICAP_OPER_REALHOST;
+static uint64_t CLICAP_REALHOST;
+static uint64_t CLICAP_OPER_REALHOST;
 
 static struct ClientCapability capdata_oper_realhost = {
 	.visible = cap_oper_realhost_visible,

--- a/extensions/cap_realhost.c
+++ b/extensions/cap_realhost.c
@@ -83,7 +83,7 @@ update_clicap_oper_realhost(struct Client *client)
 	ClearClientCap(client, CLICAP_OPER_REALHOST);
 	if (IsClientCapable(client, CLICAP_REALHOST) && HasPrivilege(client, "auspex:hostname"))
 	{
-		client->localClient->client_caps |= CLICAP_OPER_REALHOST;
+		SetClientCap(client, CLICAP_OPER_REALHOST);
 	}
 }
 

--- a/extensions/cap_realhost.c
+++ b/extensions/cap_realhost.c
@@ -80,10 +80,10 @@ cap_realhost_outbound_msgbuf(void *data_)
 static inline void
 update_clicap_oper_realhost(struct Client *client)
 {
-	client->localClient->caps &= ~CLICAP_OPER_REALHOST;
-	if (client->localClient->caps & CLICAP_REALHOST && HasPrivilege(client, "auspex:hostname"))
+	ClearClientCap(client, CLICAP_OPER_REALHOST);
+	if (IsClientCapable(client, CLICAP_REALHOST) && HasPrivilege(client, "auspex:hostname"))
 	{
-		client->localClient->caps |= CLICAP_OPER_REALHOST;
+		client->localClient->client_caps |= CLICAP_OPER_REALHOST;
 	}
 }
 

--- a/extensions/example_module.c
+++ b/extensions/example_module.c
@@ -124,7 +124,7 @@ mapi_hfn_list_av1 test_hfnlist[] = {
  * to the cap (typically NULL). The last parameter is a pointer to an integer
  * for the CAP index (recommended).
  */
-unsigned int CAP_TESTCAP_SERVER, CAP_TESTCAP_CLIENT;
+uint64_t CAP_TESTCAP_SERVER, CAP_TESTCAP_CLIENT;
 mapi_cap_list_av2 test_cap_list[] = {
 	{ MAPI_CAP_SERVER, "TESTCAP", NULL, &CAP_TESTCAP_SERVER },
 	{ MAPI_CAP_CLIENT, "testcap", NULL, &CAP_TESTCAP_CLIENT },

--- a/extensions/identify_msg.c
+++ b/extensions/identify_msg.c
@@ -5,7 +5,7 @@
 static const char identify_msg_desc[] = "Provides the solanum.chat/identify-msg client capability";
 
 static void identmsg_outbound(void *);
-unsigned int CLICAP_IDENTIFY_MSG = 0;
+uint64_t CLICAP_IDENTIFY_MSG = 0;
 
 mapi_cap_list_av2 identmsg_cap_list[] = {
 	{ MAPI_CAP_CLIENT, "solanum.chat/identify-msg", NULL, &CLICAP_IDENTIFY_MSG },

--- a/extensions/invite_notify.c
+++ b/extensions/invite_notify.c
@@ -11,7 +11,7 @@ static const char inv_notify_desc[] = "Notifies channel on /invite and provides 
 
 static void hook_invite(void *);
 static void m_invited(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
-static unsigned int CAP_INVITE_NOTIFY;
+static uint64_t CAP_INVITE_NOTIFY;
 
 mapi_hfn_list_av1 inv_notify_hfnlist[] = {
 	{ "invite", hook_invite, HOOK_MONITOR },

--- a/extensions/m_remove.c
+++ b/extensions/m_remove.c
@@ -44,7 +44,7 @@ static const char description[] = "Provides the REMOVE command, an alternative t
 static void m_remove(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 static void remove_quote_part(void *);
 
-unsigned int CAP_REMOVE;
+uint64_t CAP_REMOVE;
 static char part_buf[REASONLEN + 1];
 
 struct Message remove_msgtab = {

--- a/extensions/tag_typing.c
+++ b/extensions/tag_typing.c
@@ -61,7 +61,7 @@ static void
 tag_typing_allow(void *data_)
 {
 	hook_data_message_tag *data = data_;
-	if (IsClient(data->client) && !IsCapable(data->client, CLICAP_MESSAGE_TAGS))
+	if (IsClient(data->client) && !IsClientCapable(data->client, CLICAP_MESSAGE_TAGS))
 		return;
 
 	if (!strcmp("+typing", data->key) && data->value != NULL && (!strcmp("active", data->value) || !strcmp("paused", data->value) || !strcmp("done", data->value))) {

--- a/include/capability.h
+++ b/include/capability.h
@@ -42,17 +42,17 @@ struct CapabilityEntry {
 };
 
 extern struct CapabilityEntry *capability_find(struct CapabilityIndex *idx, const char *cap);
-extern unsigned int capability_get(struct CapabilityIndex *idx, const char *cap, void **ownerdata);
-extern unsigned int capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata);
-extern unsigned int capability_put_anonymous(struct CapabilityIndex *idx);
+extern uint64_t capability_get(struct CapabilityIndex *idx, const char *cap, void **ownerdata);
+extern uint64_t capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata);
+extern uint64_t capability_put_anonymous(struct CapabilityIndex *idx);
 extern void capability_orphan(struct CapabilityIndex *idx, const char *cap);
 extern void capability_require(struct CapabilityIndex *idx, const char *cap);
 
 extern struct CapabilityIndex *capability_index_create(const char *name);
 extern void capability_index_destroy(struct CapabilityIndex *);
-extern const char *capability_index_list(struct CapabilityIndex *, unsigned int capability_mask);
-extern unsigned int capability_index_mask(struct CapabilityIndex *);
-extern unsigned int capability_index_get_required(struct CapabilityIndex *);
+extern const char *capability_index_list(struct CapabilityIndex *, uint64_t capability_mask);
+extern uint64_t capability_index_mask(struct CapabilityIndex *);
+extern uint64_t capability_index_get_required(struct CapabilityIndex *);
 extern void capability_index_stats(void (*cb)(const char *line, void *privdata), void *privdata);
 
 #endif

--- a/include/client.h
+++ b/include/client.h
@@ -87,7 +87,7 @@ struct Server
 	char by[NICKLEN];
 	rb_dlink_list servers;
 	rb_dlink_list users;
-	int caps;		/* capabilities bit-field */
+	uint64_t server_caps;		/* capabilities bit-field */
 	char *fullcaps;
 	struct scache_entry *nameinfo;
 };
@@ -218,7 +218,8 @@ struct LocalUser
 	char *fullcaps;
 	char *cipher_string;
 
-	int caps;		/* capabilities bit-field */
+	uint64_t client_caps;		/* capabilities bit-field */
+	uint64_t server_caps;
 	rb_fde_t *F;		/* >= 0, for local clients */
 
 	/* time challenge response is valid for */

--- a/include/hook.h
+++ b/include/hook.h
@@ -175,9 +175,9 @@ typedef struct
 typedef struct
 {
 	struct Client *client;
-	int oldcaps;
-	int add;
-	int del;
+	uint64_t oldcaps;
+	uint64_t add;
+	uint64_t del;
 } hook_data_cap_change;
 
 typedef struct
@@ -186,7 +186,7 @@ typedef struct
 	struct Client *source;
 	const char *key;
 	const char *value;
-	unsigned int capmask;
+	uint64_t capmask;
 	const struct MsgBuf *message;
 	int approved;
 } hook_data_message_tag;

--- a/include/modules.h
+++ b/include/modules.h
@@ -82,7 +82,7 @@ typedef struct
 	int cap_index;		/* Which cap index does this belong to? */
 	const char *cap_name;	/* Capability name */
 	void *cap_ownerdata;	/* Not used much but why not... */
-	unsigned int *cap_id;	/* May be set to non-NULL to store cap id */
+	uint64_t *cap_id;	/* May be set to non-NULL to store cap id */
 } mapi_cap_list_av2;
 
 struct mapi_mheader_av1

--- a/include/msgbuf.h
+++ b/include/msgbuf.h
@@ -58,13 +58,13 @@ struct MsgBuf {
 
 struct MsgBuf_str_data {
 	const struct MsgBuf *msgbuf;
-	unsigned int caps;
+	uint64_t caps;
 };
 
 #define MSGBUF_CACHE_SIZE 32
 
 struct MsgBuf_cache_entry {
-	unsigned int caps;
+	uint64_t caps;
 	bool is_remote;
 	buf_head_t linebuf;
 	struct MsgBuf_cache_entry *next;
@@ -74,7 +74,7 @@ struct MsgBuf_cache {
 	const struct MsgBuf *msgbuf;
 	char remote[DATALEN + 1];
 	char local[DATALEN + 1];
-	unsigned int overall_capmask;
+	uint64_t overall_capmask;
 
 	/* Fixed maximum size linked list, new entries are allocated at the end
 	 * of the array but are accessed through the "next" pointers.
@@ -109,7 +109,7 @@ void msgbuf_reconstruct_tail(struct MsgBuf *msgbuf, size_t n);
  * cmd may not be NULL.
  * returns 0 on success, 1 on error.
  */
-int msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, unsigned int capmask);
+int msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, uint64_t capmask);
 
 /*
  * unparse a MsgBuf header plus payload into a buffer.
@@ -117,18 +117,18 @@ int msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, unsign
  * cmd may not be NULL.
  * returns 0 on success, 1 on error.
  */
-int msgbuf_unparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, unsigned int capmask, const char *fmt, ...) AFP(5, 6);
-int msgbuf_vunparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, unsigned int capmask, const char *fmt, va_list va);
+int msgbuf_unparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, uint64_t capmask, const char *fmt, ...) AFP(5, 6);
+int msgbuf_vunparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, uint64_t capmask, const char *fmt, va_list va);
 
 int msgbuf_unparse_linebuf(char *buf, size_t buflen, void *data);
 int msgbuf_unparse_linebuf_tags(char *buf, size_t buflen, void *data);
-int msgbuf_unparse_prefix(char *buf, size_t *buflen, const struct MsgBuf *msgbuf, unsigned int capmask);
+int msgbuf_unparse_prefix(char *buf, size_t *buflen, const struct MsgBuf *msgbuf, uint64_t capmask);
 int msgbuf_unparse_para(char *buf, size_t buflen, const struct MsgBuf *msgbuf);
 
 const char *msgbuf_get_tag(const struct MsgBuf *buf, const char *name);
 
 void msgbuf_cache_init(struct MsgBuf_cache *cache, struct MsgBuf *msgbuf, const char *local_source, const char *remote_source);
-buf_head_t *msgbuf_cache_get(struct MsgBuf_cache *cache, unsigned int caps, bool is_remote);
+buf_head_t *msgbuf_cache_get(struct MsgBuf_cache *cache, uint64_t caps, bool is_remote);
 void msgbuf_cache_free(struct MsgBuf_cache *cache);
 
 static inline void
@@ -138,7 +138,7 @@ msgbuf_init(struct MsgBuf *msgbuf)
 }
 
 static inline void
-msgbuf_append_tag(struct MsgBuf *msgbuf, const char *key, const char *value, unsigned int capmask)
+msgbuf_append_tag(struct MsgBuf *msgbuf, const char *key, const char *value, uint64_t capmask)
 {
 	if (msgbuf->n_tags < MAXTAGS) {
 		msgbuf->tags[msgbuf->n_tags].key = key;

--- a/include/msgbuf.h
+++ b/include/msgbuf.h
@@ -38,7 +38,7 @@ enum parse_result
 struct MsgTag {
 	const char *key;		/* the key of the tag (must be set) */
 	const char *value;		/* the value of the tag or NULL */
-	unsigned int capmask;		/* the capability mask this tag belongs to (used only when sending) */
+	uint64_t capmask;		/* the capability mask this tag belongs to (used only when sending) */
 };
 
 struct MsgBuf {

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -133,9 +133,9 @@ extern struct remote_conf *make_remote_conf(void);
 extern void free_remote_conf(struct remote_conf *);
 
 extern void propagate_generic(struct Client *source_p, const char *command,
-		const char *target, int cap, const char *format, ...);
+		const char *target, uint64_t cap, const char *format, ...);
 extern void cluster_generic(struct Client *, const char *, int cltype,
-			int cap, const char *format, ...);
+			uint64_t cap, const char *format, ...);
 
 #define OPER_ENCRYPTED	0x00001
 #define OPER_NEEDSSL    0x80000

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -103,12 +103,14 @@ extern unsigned int CAP_STAG;			/* supports s2s tags and TAGMSG */
 /*
  * Capability macros.
  */
-#define IsClientCapable(x, cap)       (((x)->localClient->client_caps & (cap)) == cap)
-#define NotClientCapable(x, cap)	(((x)->localClient->client_caps & (cap)) == 0)
-#define ClearClientCap(x, cap)        ((x)->localClient->client_caps &= ~(cap))
-#define IsServerCapable(x, cap)       (((x)->localClient->server_caps & (cap)) == cap)
-#define NotServerCapable(x, cap)	(((x)->localClient->server_caps & (cap)) == 0)
-#define ClearServerCap(x, cap)        ((x)->localClient->server_caps &= ~(cap))
+#define IsClientCapable(x, cap)         (((x)->localClient->client_caps & (cap)) == cap)
+#define NotClientCapable(x, cap)        (((x)->localClient->client_caps & (cap)) == 0)
+#define SetClientCap(x, cap)            ((x)->localClient->client_caps |= (cap))
+#define ClearClientCap(x, cap)          ((x)->localClient->client_caps &= ~(cap))
+#define IsServerCapable(x, cap)         (((x)->localClient->server_caps & (cap)) == cap)
+#define NotServerCapable(x, cap)        (((x)->localClient->server_caps & (cap)) == 0)
+#define SetServerCap(x, cap)            ((x)->localClient->server_caps |= (cap))
+#define ClearServerCap(x, cap)          ((x)->localClient->server_caps &= ~(cap))
 
 /*
  * Globals

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -60,42 +60,42 @@ struct ClientCapability {
 };
 
 /* builtin client capabilities */
-extern unsigned int CLICAP_MULTI_PREFIX;
-extern unsigned int CLICAP_ACCOUNT_NOTIFY;
-extern unsigned int CLICAP_EXTENDED_JOIN;
-extern unsigned int CLICAP_AWAY_NOTIFY;
-extern unsigned int CLICAP_USERHOST_IN_NAMES;
-extern unsigned int CLICAP_CAP_NOTIFY;
-extern unsigned int CLICAP_CHGHOST;
-extern unsigned int CLICAP_ECHO_MESSAGE;
-extern unsigned int CLICAP_MESSAGE_TAGS;
-extern unsigned int CLICAP_BATCH;
+extern uint64_t CLICAP_MULTI_PREFIX;
+extern uint64_t CLICAP_ACCOUNT_NOTIFY;
+extern uint64_t CLICAP_EXTENDED_JOIN;
+extern uint64_t CLICAP_AWAY_NOTIFY;
+extern uint64_t CLICAP_USERHOST_IN_NAMES;
+extern uint64_t CLICAP_CAP_NOTIFY;
+extern uint64_t CLICAP_CHGHOST;
+extern uint64_t CLICAP_ECHO_MESSAGE;
+extern uint64_t CLICAP_MESSAGE_TAGS;
+extern uint64_t CLICAP_BATCH;
 
 /*
  * XXX: this is kind of ugly, but this allows us to have backwards
  * API-compatibility.
  */
-extern unsigned int CAP_CAP;			/* received a CAP to begin with */
-extern unsigned int CAP_QS;			/* Can handle quit storm removal */
-extern unsigned int CAP_EX;			/* Can do channel +e exemptions */
-extern unsigned int CAP_CHW;			/* Can do channel wall @# */
-extern unsigned int CAP_IE;			/* Can do invite exceptions */
-extern unsigned int CAP_KLN;			/* Can do KLINE message */
-extern unsigned int CAP_KNOCK;			/* supports KNOCK */
-extern unsigned int CAP_TB;			/* supports TBURST */
-extern unsigned int CAP_UNKLN;			/* supports remote unkline */
-extern unsigned int CAP_CLUSTER;		/* supports cluster stuff */
-extern unsigned int CAP_ENCAP;			/* supports ENCAP */
-extern unsigned int CAP_TS6;			/* supports TS6 or above */
-extern unsigned int CAP_SERVICE;		/* supports services */
-extern unsigned int CAP_RSFNC;			/* rserv FNC */
-extern unsigned int CAP_SAVE;			/* supports SAVE (nick collision FNC) */
-extern unsigned int CAP_EUID;			/* supports EUID (ext UID + nonencap CHGHOST) */
-extern unsigned int CAP_EOPMOD;			/* supports EOPMOD (ext +z + ext topic) */
-extern unsigned int CAP_BAN;			/* supports propagated bans */
-extern unsigned int CAP_MLOCK;			/* supports MLOCK messages */
-extern unsigned int CAP_EBMASK;			/* supports sending BMASK set by/at metadata */
-extern unsigned int CAP_STAG;			/* supports s2s tags and TAGMSG */
+extern uint64_t CAP_CAP;			/* received a CAP to begin with */
+extern uint64_t CAP_QS;			/* Can handle quit storm removal */
+extern uint64_t CAP_EX;			/* Can do channel +e exemptions */
+extern uint64_t CAP_CHW;			/* Can do channel wall @# */
+extern uint64_t CAP_IE;			/* Can do invite exceptions */
+extern uint64_t CAP_KLN;			/* Can do KLINE message */
+extern uint64_t CAP_KNOCK;			/* supports KNOCK */
+extern uint64_t CAP_TB;			/* supports TBURST */
+extern uint64_t CAP_UNKLN;			/* supports remote unkline */
+extern uint64_t CAP_CLUSTER;		/* supports cluster stuff */
+extern uint64_t CAP_ENCAP;			/* supports ENCAP */
+extern uint64_t CAP_TS6;			/* supports TS6 or above */
+extern uint64_t CAP_SERVICE;		/* supports services */
+extern uint64_t CAP_RSFNC;			/* rserv FNC */
+extern uint64_t CAP_SAVE;			/* supports SAVE (nick collision FNC) */
+extern uint64_t CAP_EUID;			/* supports EUID (ext UID + nonencap CHGHOST) */
+extern uint64_t CAP_EOPMOD;			/* supports EOPMOD (ext +z + ext topic) */
+extern uint64_t CAP_BAN;			/* supports propagated bans */
+extern uint64_t CAP_MLOCK;			/* supports MLOCK messages */
+extern uint64_t CAP_EBMASK;			/* supports sending BMASK set by/at metadata */
+extern uint64_t CAP_STAG;			/* supports s2s tags and TAGMSG */
 
 /* XXX: added for backwards compatibility. --nenolod */
 #define CAP_MASK	(capability_index_mask(serv_capindex) & ~(CAP_TS6 | CAP_CAP))
@@ -137,7 +137,7 @@ extern void init_builtin_capabs(void);
 extern int hunt_server(struct Client *client_pt,
 		       struct Client *source_pt,
 		       const char *command, int server, int parc, const char **parv);
-extern void send_capabilities(struct Client *, unsigned int);
+extern void send_capabilities(struct Client *, uint64_t);
 extern const char *show_capabilities(struct Client *client);
 extern void try_connections(void *unused);
 

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -103,9 +103,12 @@ extern unsigned int CAP_STAG;			/* supports s2s tags and TAGMSG */
 /*
  * Capability macros.
  */
-#define IsCapable(x, cap)       (((x)->localClient->caps & (cap)) == cap)
-#define NotCapable(x, cap)	(((x)->localClient->caps & (cap)) == 0)
-#define ClearCap(x, cap)        ((x)->localClient->caps &= ~(cap))
+#define IsClientCapable(x, cap)       (((x)->localClient->client_caps & (cap)) == cap)
+#define NotClientCapable(x, cap)	(((x)->localClient->client_caps & (cap)) == 0)
+#define ClearClientCap(x, cap)        ((x)->localClient->client_caps &= ~(cap))
+#define IsServerCapable(x, cap)       (((x)->localClient->server_caps & (cap)) == cap)
+#define NotServerCapable(x, cap)	(((x)->localClient->server_caps & (cap)) == 0)
+#define ClearServerCap(x, cap)        ((x)->localClient->server_caps &= ~(cap))
 
 /*
  * Globals

--- a/include/send.h
+++ b/include/send.h
@@ -48,26 +48,26 @@ extern void sendto_one_prefix(struct Client *target_p, struct Client *source_p,
 			      const char *command, const char *, ...) AFP(4, 5);
 extern void sendto_one_numeric(struct Client *target_p,
 			       int numeric, const char *, ...) AFP(3, 4);
-extern void sendto_one_tags(struct Client *target_p, int serv_cap, int serv_negcap,
+extern void sendto_one_tags(struct Client *target_p, uint64_t serv_cap, uint64_t serv_negcap,
 	size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(6, 7);
 
 extern void sendto_server(struct Client *one, struct Channel *chptr,
-			  unsigned long caps, unsigned long nocaps,
+			  uint64_t caps, uint64_t nocaps,
 			  const char *format, ...) AFP(5, 6);
 extern void sendto_server_tags(struct Client *one, struct Channel *chptr,
-			  unsigned long caps, unsigned long nocaps,
+			  uint64_t caps, uint64_t nocaps,
 			  size_t n_tags, const struct MsgTag tags[],
 			  const char *format, ...) AFP(7, 8);
 
 extern void sendto_channel_flags(struct Client *one, int type, struct Client *source_p,
 				 struct Channel *chptr, const char *, ...) AFP(5, 6);
 extern void sendto_channel_flags_tags(struct Client *one, int type, struct Client *source_p,
-				 struct Channel *chptr, int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+				 struct Channel *chptr, uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 				 size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(11, 12);
 extern void sendto_channel_opmod(struct Client *one, struct Client *source_p,
 				 struct Channel *chptr, const char *command, const char *text);
 extern void sendto_channel_opmod_tags(struct Client *one, struct Client *source_p,
-				 struct Channel *chptr, int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+				 struct Channel *chptr, uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 				 const char *command, const char *text, size_t n_tags, const struct MsgTag tags[]);
 
 extern void sendto_channel_local(struct Client *, int type, struct Channel *, const char *, ...) AFP(4, 5);
@@ -76,32 +76,32 @@ extern void sendto_channel_local_tags(struct Client *source_p, int type, const c
 	size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP (7, 8);
 extern void sendto_channel_local_butone(struct Client *, int type, struct Channel *, const char *, ...) AFP(4, 5);
 
-extern void sendto_channel_local_with_capability(struct Client *, int type, int caps, int negcaps,
+extern void sendto_channel_local_with_capability(struct Client *, int type, uint64_t caps, uint64_t negcaps,
 	struct Channel *, const char *, ...) AFP(6, 7);
-extern void sendto_channel_local_with_capability_tags(struct Client *, int type, int caps, int negcaps,
+extern void sendto_channel_local_with_capability_tags(struct Client *, int type, uint64_t caps, uint64_t negcaps,
 	struct Channel *, size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(8, 9);
-extern void sendto_channel_local_with_capability_butone(struct Client *, int type, int caps, int negcaps,
+extern void sendto_channel_local_with_capability_butone(struct Client *, int type, uint64_t caps, uint64_t negcaps,
 	struct Channel *, const char *, ...) AFP(6, 7);
-extern void sendto_channel_local_with_capability_butone_tags(struct Client *, int type, int caps, int negcaps,
+extern void sendto_channel_local_with_capability_butone_tags(struct Client *, int type, uint64_t caps, uint64_t negcaps,
 	struct Channel *, size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(8, 9);
 
-extern void sendto_common_channels_local(struct Client *, int caps, int negcaps, const char *, ...) AFP(4, 5);
-extern void sendto_common_channels_local_tags(struct Client *, int caps, int negcaps,
+extern void sendto_common_channels_local(struct Client *, uint64_t caps, uint64_t negcaps, const char *, ...) AFP(4, 5);
+extern void sendto_common_channels_local_tags(struct Client *, uint64_t caps, uint64_t negcaps,
 	size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(6, 7);
-extern void sendto_common_channels_local_butone(struct Client *, int caps, int negcaps, const char *, ...) AFP(4, 5);
-extern void sendto_common_channels_local_butone_tags(struct Client *, int caps, int negcaps,
+extern void sendto_common_channels_local_butone(struct Client *, uint64_t caps, uint64_t negcaps, const char *, ...) AFP(4, 5);
+extern void sendto_common_channels_local_butone_tags(struct Client *, uint64_t caps, uint64_t negcaps,
 	size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(6, 7);
 
 
 extern void sendto_match_butone(struct Client *one, struct Client *source_p,
 				const char *mask, int what, const char *, ...) AFP(5, 6);
 extern void sendto_match_butone_tags(struct Client *one, struct Client *source_p,
-				const char *mask, int what, int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+				const char *mask, int what, uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 				size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(11, 12);
 extern void sendto_match_servs(struct Client *source_p, const char *mask,
-				int cap, int negcap, const char *, ...) AFP(5, 6);
+				uint64_t cap, uint64_t negcap, const char *, ...) AFP(5, 6);
 extern void sendto_match_servs_tags(struct Client *source_p, const char *mask,
-				int cap, int negcap, size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(7, 8);
+				uint64_t cap, uint64_t negcap, size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(7, 8);
 
 extern void sendto_monitor(struct Client *, struct monitor *monptr, const char *, ...) AFP(3, 4);
 
@@ -110,8 +110,8 @@ extern void sendto_anywhere(struct Client *, struct Client *, const char *,
 extern void sendto_anywhere_echo(struct Client *, struct Client *, const char *,
 			    const char *, ...) AFP(4, 5);
 extern void sendto_anywhere_tags(struct Client *target_p, struct Client *source_p, const char *command,
-	int serv_cap, int serv_negcap, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...) AFP(8, 9);
-extern void sendto_local_clients_with_capability(int cap, const char *pattern, ...) AFP(2, 3);
+	uint64_t serv_cap, uint64_t serv_negcap, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...) AFP(8, 9);
+extern void sendto_local_clients_with_capability(uint64_t cap, const char *pattern, ...) AFP(2, 3);
 
 extern void sendto_realops_snomask(int, int, const char *, ...) AFP(3, 4);
 extern void sendto_realops_snomask_from(int, int, struct Client *, const char *, ...) AFP(4, 5);

--- a/include/stdinc.h
+++ b/include/stdinc.h
@@ -83,7 +83,7 @@ typedef bool _Bool;
 #endif
 
 
-#include <stdio.h>
+#include <stdint.h>
 #include <assert.h>
 #include <stdio.h>
 #include <time.h>

--- a/ircd/capability.c
+++ b/ircd/capability.c
@@ -35,7 +35,7 @@ capability_find(struct CapabilityIndex *idx, const char *cap)
 	return rb_dictionary_retrieve(idx->cap_dict, cap);
 }
 
-unsigned int
+uint64_t
 capability_get(struct CapabilityIndex *idx, const char *cap, void **ownerdata)
 {
 	struct CapabilityEntry *entry;
@@ -49,20 +49,20 @@ capability_get(struct CapabilityIndex *idx, const char *cap, void **ownerdata)
 	{
 		if (ownerdata != NULL)
 			*ownerdata = entry->ownerdata;
-		return (1 << entry->value);
+		return (1ull << entry->value);
 	}
 
 	return 0;
 }
 
-unsigned int
+uint64_t
 capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 {
 	struct CapabilityEntry *entry;
 
 	s_assert(idx != NULL);
 	if (!idx->highest_bit)
-		return 0xFFFFFFFF;
+		return 0xFFFFFFFFFFFFFFFFull;
 
 	if ((entry = rb_dictionary_retrieve(idx->cap_dict, cap)) != NULL)
 	{
@@ -72,7 +72,7 @@ capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 			s_assert(entry->ownerdata == NULL);
 			entry->ownerdata = ownerdata;
 		}
-		return (1 << entry->value);
+		return (1ull << entry->value);
 	}
 
 	entry = rb_malloc(sizeof(struct CapabilityEntry));
@@ -84,23 +84,23 @@ capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 	rb_dictionary_add(idx->cap_dict, entry->cap, entry);
 
 	idx->highest_bit++;
-	if (idx->highest_bit % (sizeof(unsigned int) * 8) == 0)
+	if (idx->highest_bit % (sizeof(uint64_t) * 8) == 0)
 		idx->highest_bit = 0;
 
-	return (1 << entry->value);
+	return (1ull << entry->value);
 }
 
-unsigned int
+uint64_t
 capability_put_anonymous(struct CapabilityIndex *idx)
 {
-	unsigned int value;
+	uint64_t value;
 
 	s_assert(idx != NULL);
 	if (!idx->highest_bit)
-		return 0xFFFFFFFF;
-	value = 1 << idx->highest_bit;
+		return 0xFFFFFFFFFFFFFFFFull;
+	value = 1ull << idx->highest_bit;
 	idx->highest_bit++;
-	if (idx->highest_bit % (sizeof(unsigned int) * 8) == 0)
+	if (idx->highest_bit % (sizeof(uint64_t) * 8) == 0)
 		idx->highest_bit = 0;
 	return value;
 }
@@ -170,7 +170,7 @@ capability_index_destroy(struct CapabilityIndex *idx)
 }
 
 const char *
-capability_index_list(struct CapabilityIndex *idx, unsigned int cap_mask)
+capability_index_list(struct CapabilityIndex *idx, uint64_t cap_mask)
 {
 	rb_dictionary_iter iter;
 	struct CapabilityEntry *entry;
@@ -184,7 +184,7 @@ capability_index_list(struct CapabilityIndex *idx, unsigned int cap_mask)
 
 	RB_DICTIONARY_FOREACH(entry, &iter, idx->cap_dict)
 	{
-		if ((1 << entry->value) & cap_mask)
+		if ((1ull << entry->value) & cap_mask)
 		{
 			tl = sprintf(t, "%s ", entry->cap);
 			t += tl;
@@ -197,37 +197,37 @@ capability_index_list(struct CapabilityIndex *idx, unsigned int cap_mask)
 	return buf;
 }
 
-unsigned int
+uint64_t
 capability_index_mask(struct CapabilityIndex *idx)
 {
 	rb_dictionary_iter iter;
 	struct CapabilityEntry *entry;
-	unsigned int mask = 0;
+	uint64_t mask = 0;
 
 	s_assert(idx != NULL);
 
 	RB_DICTIONARY_FOREACH(entry, &iter, idx->cap_dict)
 	{
 		if (!(entry->flags & CAP_ORPHANED))
-			mask |= (1 << entry->value);
+			mask |= (1ull << entry->value);
 	}
 
 	return mask;
 }
 
-unsigned int
+uint64_t
 capability_index_get_required(struct CapabilityIndex *idx)
 {
 	rb_dictionary_iter iter;
 	struct CapabilityEntry *entry;
-	unsigned int mask = 0;
+	uint64_t mask = 0;
 
 	s_assert(idx != NULL);
 
 	RB_DICTIONARY_FOREACH(entry, &iter, idx->cap_dict)
 	{
 		if (!(entry->flags & CAP_ORPHANED) && (entry->flags & CAP_REQUIRED))
-			mask |= (1 << entry->value);
+			mask |= (1ull << entry->value);
 	}
 
 	return mask;
@@ -255,7 +255,7 @@ capability_index_stats(void (*cb)(const char *line, void *privdata), void *privd
 		}
 
 		snprintf(buf, sizeof buf, "'%s': remaining bits - %u", idx->name,
-			    (unsigned int)((sizeof(unsigned int) * 8) - (idx->highest_bit - 1)));
+			    (unsigned int)((sizeof(uint64_t) * 8) - (idx->highest_bit - 1)));
 		cb(buf, privdata);
 	}
 

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -506,7 +506,7 @@ channel_member_names(struct Channel *chptr, struct Client *client_p, int show_eo
 	struct Client *target_p;
 	rb_dlink_node *ptr;
 	int is_member;
-	int stack = IsCapable(client_p, CLICAP_MULTI_PREFIX);
+	int stack = IsClientCapable(client_p, CLICAP_MULTI_PREFIX);
 
 	if(ShowChannel(client_p, chptr))
 	{
@@ -526,7 +526,7 @@ channel_member_names(struct Channel *chptr, struct Client *client_p, int show_eo
 			if(IsInvisible(target_p) && !is_member)
 				continue;
 
-			if (IsCapable(client_p, CLICAP_USERHOST_IN_NAMES))
+			if (IsClientCapable(client_p, CLICAP_USERHOST_IN_NAMES))
 			{
 				send_multiline_item(client_p, "%s%s!%s@%s",
 						find_channel_status(msptr, stack),

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -1206,9 +1206,7 @@ channel_modes(struct Channel *chptr, struct Client *client_p)
 	return final;
 }
 
-/* void send_cap_mode_changes(struct Client *client_p,
- *                        struct Client *source_p,
- *                        struct Channel *chptr, int cap, int nocap)
+/* void send_cap_mode_changes
  * Input: The client sending(client_p), the source client(source_p),
  *        the channel to send mode changes for(chptr)
  * Output: None.

--- a/ircd/msgbuf.c
+++ b/ircd/msgbuf.c
@@ -214,7 +214,7 @@ msgbuf_reconstruct_tail(struct MsgBuf *msgbuf, size_t n)
  * returns the length of the tags written
  */
 static size_t
-msgbuf_unparse_tags(char *buf, size_t buflen, const struct MsgBuf *msgbuf, unsigned int capmask)
+msgbuf_unparse_tags(char *buf, size_t buflen, const struct MsgBuf *msgbuf, uint64_t capmask)
 {
 	bool has_tags = false;
 	char *commit = buf;
@@ -346,7 +346,7 @@ msgbuf_unparse_linebuf_tags(char *buf, size_t buflen, void *data)
  * updates buflen to correctly allow remaining message data to be added
  */
 int
-msgbuf_unparse_prefix(char *buf, size_t *buflen, const struct MsgBuf *msgbuf, unsigned int capmask)
+msgbuf_unparse_prefix(char *buf, size_t *buflen, const struct MsgBuf *msgbuf, uint64_t capmask)
 {
 	size_t tags_buflen;
 	size_t used = 0;
@@ -423,7 +423,7 @@ msgbuf_unparse_para(char *buf, size_t buflen, const struct MsgBuf *msgbuf)
  * returns 0 on success, 1 on error.
  */
 int
-msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, unsigned int capmask)
+msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, uint64_t capmask)
 {
 	size_t buflen_copy = buflen;
 
@@ -440,7 +440,7 @@ msgbuf_unparse(char *buf, size_t buflen, const struct MsgBuf *msgbuf, unsigned i
  * returns 0 on success, 1 on error.
  */
 int
-msgbuf_vunparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, unsigned int capmask, const char *fmt, va_list va)
+msgbuf_vunparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, uint64_t capmask, const char *fmt, va_list va)
 {
 	size_t buflen_copy = buflen;
 	char *ws;
@@ -462,7 +462,7 @@ msgbuf_vunparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, unsigne
  * returns 0 on success, 1 on error.
  */
 int
-msgbuf_unparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, unsigned int capmask, const char *fmt, ...)
+msgbuf_unparse_fmt(char *buf, size_t buflen, const struct MsgBuf *head, uint64_t capmask, const char *fmt, ...)
 {
 	va_list va;
 	int res;
@@ -511,7 +511,7 @@ msgbuf_cache_init(struct MsgBuf_cache *cache, struct MsgBuf *msgbuf, const char 
 }
 
 buf_head_t*
-msgbuf_cache_get(struct MsgBuf_cache *cache, unsigned int caps, bool is_remote)
+msgbuf_cache_get(struct MsgBuf_cache *cache, uint64_t caps, bool is_remote)
 {
 	struct MsgBuf_cache_entry *entry = cache->head;
 	struct MsgBuf_cache_entry *prev = NULL;

--- a/ircd/s_newconf.c
+++ b/ircd/s_newconf.c
@@ -166,7 +166,7 @@ free_remote_conf(struct remote_conf *remote_p)
 
 void
 propagate_generic(struct Client *source_p, const char *command,
-		const char *target, int cap, const char *format, ...)
+		const char *target, uint64_t cap, const char *format, ...)
 {
 	char buffer[BUFSIZE];
 	va_list args;
@@ -185,7 +185,7 @@ propagate_generic(struct Client *source_p, const char *command,
 
 void
 cluster_generic(struct Client *source_p, const char *command,
-		int cltype, int cap, const char *format, ...)
+		int cltype, uint64_t cap, const char *format, ...)
 {
 	char buffer[BUFSIZE];
 	struct remote_conf *shared_p;

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -67,39 +67,39 @@ static char buf[BUFSIZE];
 struct CapabilityIndex *serv_capindex = NULL;
 struct CapabilityIndex *cli_capindex = NULL;
 
-unsigned int CAP_CAP;
-unsigned int CAP_QS;
-unsigned int CAP_EX;
-unsigned int CAP_CHW;
-unsigned int CAP_IE;
-unsigned int CAP_KLN;
-unsigned int CAP_KNOCK;
-unsigned int CAP_TB;
-unsigned int CAP_UNKLN;
-unsigned int CAP_CLUSTER;
-unsigned int CAP_ENCAP;
-unsigned int CAP_TS6;
-unsigned int CAP_SERVICE;
-unsigned int CAP_RSFNC;
-unsigned int CAP_RSFNCF;
-unsigned int CAP_SAVE;
-unsigned int CAP_EUID;
-unsigned int CAP_EOPMOD;
-unsigned int CAP_BAN;
-unsigned int CAP_MLOCK;
-unsigned int CAP_EBMASK;
-unsigned int CAP_STAG;
+uint64_t CAP_CAP;
+uint64_t CAP_QS;
+uint64_t CAP_EX;
+uint64_t CAP_CHW;
+uint64_t CAP_IE;
+uint64_t CAP_KLN;
+uint64_t CAP_KNOCK;
+uint64_t CAP_TB;
+uint64_t CAP_UNKLN;
+uint64_t CAP_CLUSTER;
+uint64_t CAP_ENCAP;
+uint64_t CAP_TS6;
+uint64_t CAP_SERVICE;
+uint64_t CAP_RSFNC;
+uint64_t CAP_RSFNCF;
+uint64_t CAP_SAVE;
+uint64_t CAP_EUID;
+uint64_t CAP_EOPMOD;
+uint64_t CAP_BAN;
+uint64_t CAP_MLOCK;
+uint64_t CAP_EBMASK;
+uint64_t CAP_STAG;
 
-unsigned int CLICAP_MULTI_PREFIX;
-unsigned int CLICAP_ACCOUNT_NOTIFY;
-unsigned int CLICAP_EXTENDED_JOIN;
-unsigned int CLICAP_AWAY_NOTIFY;
-unsigned int CLICAP_USERHOST_IN_NAMES;
-unsigned int CLICAP_CAP_NOTIFY;
-unsigned int CLICAP_CHGHOST;
-unsigned int CLICAP_ECHO_MESSAGE;
-unsigned int CLICAP_MESSAGE_TAGS;
-unsigned int CLICAP_BATCH;
+uint64_t CLICAP_MULTI_PREFIX;
+uint64_t CLICAP_ACCOUNT_NOTIFY;
+uint64_t CLICAP_EXTENDED_JOIN;
+uint64_t CLICAP_AWAY_NOTIFY;
+uint64_t CLICAP_USERHOST_IN_NAMES;
+uint64_t CLICAP_CAP_NOTIFY;
+uint64_t CLICAP_CHGHOST;
+uint64_t CLICAP_ECHO_MESSAGE;
+uint64_t CLICAP_MESSAGE_TAGS;
+uint64_t CLICAP_BATCH;
 
 /*
  * initialize our builtin capability table. --nenolod
@@ -467,7 +467,7 @@ check_server(const char *name, struct Client *client_p)
  * side effects	- send the CAPAB line to a server  -orabidoo
  */
 void
-send_capabilities(struct Client *client_p, unsigned int cap_can_send)
+send_capabilities(struct Client *client_p, uint64_t cap_can_send)
 {
 	sendto_one(client_p, "CAPAB :%s", capability_index_list(serv_capindex, cap_can_send));
 }

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -453,7 +453,7 @@ check_server(const char *name, struct Client *client_p)
 
 	/* clear TB if they support but we dont want it */
 	if(!ServerConfTb(server_p))
-		ClearCap(client_p, CAP_TB);
+		ClearServerCap(client_p, CAP_TB);
 
 	return 0;
 }
@@ -523,7 +523,7 @@ burst_modes_TS6(struct Client *client_p, struct Channel *chptr,
 
 	send_multiline_init(client_p, " ", ":%s %s %ld %s %c :",
 			me.id,
-			IsCapable(client_p, CAP_EBMASK) ? "EBMASK" : "BMASK",
+			IsServerCapable(client_p, CAP_EBMASK) ? "EBMASK" : "BMASK",
 			(long)chptr->channelts,
 			chptr->chname,
 			flag);
@@ -537,7 +537,7 @@ burst_modes_TS6(struct Client *client_p, struct Channel *chptr,
 		else
 			strcpy(buf, banptr->banstr);
 
-		if IsCapable(client_p, CAP_EBMASK)
+		if (IsServerCapable(client_p, CAP_EBMASK))
 			send_multiline_item(client_p, "%s %ld %s",
 				buf,
 				(long)banptr->when,
@@ -592,7 +592,7 @@ burst_TS6(struct Client *client_p)
 			ubuf[1] = '\0';
 		}
 
-		if(IsCapable(client_p, CAP_EUID))
+		if (IsServerCapable(client_p, CAP_EUID))
 			sendto_one(client_p, ":%s EUID %s %d %ld %s %s %s %s %s %s %s :%s",
 				   target_p->servptr->id, target_p->name,
 				   target_p->hopcount + 1,
@@ -616,7 +616,7 @@ burst_TS6(struct Client *client_p)
 			sendto_one(client_p, ":%s ENCAP * CERTFP :%s",
 					use_id(target_p), target_p->certfp);
 
-		if(!IsCapable(client_p, CAP_EUID))
+		if (!IsServerCapable(client_p, CAP_EUID))
 		{
 			if(IsDynSpoof(target_p))
 				sendto_one(client_p, ":%s ENCAP * REALHOST %s",
@@ -696,25 +696,25 @@ burst_TS6(struct Client *client_p)
 		if(rb_dlink_list_length(&chptr->banlist) > 0)
 			burst_modes_TS6(client_p, chptr, &chptr->banlist, 'b');
 
-		if(IsCapable(client_p, CAP_EX) &&
+		if (IsServerCapable(client_p, CAP_EX) &&
 		   rb_dlink_list_length(&chptr->exceptlist) > 0)
 			burst_modes_TS6(client_p, chptr, &chptr->exceptlist, 'e');
 
-		if(IsCapable(client_p, CAP_IE) &&
+		if (IsServerCapable(client_p, CAP_IE) &&
 		   rb_dlink_list_length(&chptr->invexlist) > 0)
 			burst_modes_TS6(client_p, chptr, &chptr->invexlist, 'I');
 
 		if(rb_dlink_list_length(&chptr->quietlist) > 0)
 			burst_modes_TS6(client_p, chptr, &chptr->quietlist, 'q');
 
-		if(IsCapable(client_p, CAP_TB) && chptr->topic != NULL)
+		if (IsServerCapable(client_p, CAP_TB) && chptr->topic != NULL)
 			sendto_one(client_p, ":%s TB %s %ld %s%s:%s",
 				   me.id, chptr->chname, (long) chptr->topic_time,
 				   ConfigChannel.burst_topicwho ? chptr->topic_info : "",
 				   ConfigChannel.burst_topicwho ? " " : "",
 				   chptr->topic);
 
-		if(IsCapable(client_p, CAP_MLOCK))
+		if (IsServerCapable(client_p, CAP_MLOCK))
 			sendto_one(client_p, ":%s MLOCK %ld %s :%s",
 				   me.id, (long) chptr->channelts, chptr->chname,
 				   EmptyString(chptr->mode_lock) ? "" : chptr->mode_lock);
@@ -747,11 +747,11 @@ show_capabilities(struct Client *target_p)
 	if(IsSSL(target_p))
 		rb_strlcat(msgbuf, " SSL", sizeof(msgbuf));
 
-	if(!IsServer(target_p) || !target_p->serv->caps)	/* short circuit if no caps */
+	if(!IsServer(target_p) || !target_p->serv->server_caps)	/* short circuit if no caps */
 		return msgbuf + 1;
 
 	rb_strlcat(msgbuf, " ", sizeof(msgbuf));
-	rb_strlcat(msgbuf, capability_index_list(serv_capindex, target_p->serv->caps), sizeof(msgbuf));
+	rb_strlcat(msgbuf, capability_index_list(serv_capindex, target_p->serv->server_caps), sizeof(msgbuf));
 
 	return msgbuf + 1;
 }
@@ -838,7 +838,7 @@ server_estab(struct Client *client_p)
 	make_server(client_p);
 	SetServer(client_p);
 
-	client_p->serv->caps = client_p->localClient->caps;
+	client_p->serv->server_caps = client_p->localClient->server_caps;
 
 	if(client_p->localClient->fullcaps)
 	{
@@ -957,7 +957,7 @@ server_estab(struct Client *client_p)
 					target_p->serv->fullcaps);
 	}
 
-	if(IsCapable(client_p, CAP_BAN))
+	if (IsServerCapable(client_p, CAP_BAN))
 		burst_ban(client_p);
 
 	burst_TS6(client_p);

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -40,7 +40,7 @@
 #include "monitor.h"
 #include "msgbuf.h"
 
-#define CLIENT_CAP_MASK(x)	((x)->from->localClient->client_caps | (((x)->from->localClient->server_caps & CAP_STAG) ? (uint64_t)-1 : 0))
+#define CLIENT_CAP_MASK(x)	((x)->from->localClient->client_caps | (IsServerCapable((x)->from, CAP_STAG) ? UINT64_MAX : 0))
 
 static void send_queued_write(rb_fde_t *F, void *data);
 

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -40,8 +40,7 @@
 #include "monitor.h"
 #include "msgbuf.h"
 
-#define CLIENT_CAP_MASK(x)	(MyClient((x)) ? (x)->localClient->caps : \
-		((x)->from == &me || ((x)->from && (x)->from->localClient->caps & CAP_STAG)) ? (unsigned)-1 : 0)
+#define CLIENT_CAP_MASK(x)	((x)->from->localClient->client_caps | (((x)->from->localClient->server_caps & CAP_STAG) ? (uint64_t)-1 : 0))
 
 static void send_queued_write(rb_fde_t *F, void *data);
 
@@ -439,7 +438,7 @@ sendto_one_numeric(struct Client *target_p, int numeric, const char *pattern, ..
  * side effects -
  */
 void
-sendto_one_tags(struct Client *target_p, int serv_cap, int serv_negcap,
+sendto_one_tags(struct Client *target_p, uint64_t serv_cap, uint64_t serv_negcap,
 	size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -451,7 +450,7 @@ sendto_one_tags(struct Client *target_p, int serv_cap, int serv_negcap,
 	if (IsIOError(dest_p))
 		return;
 
-	if (!IsCapable(dest_p, serv_cap) || !NotCapable(dest_p, serv_negcap))
+	if (!IsServerCapable(dest_p, serv_cap) || !NotServerCapable(dest_p, serv_negcap))
 		return;
 
 	va_start(args, pattern);
@@ -477,7 +476,7 @@ sendto_one_tags(struct Client *target_p, int serv_cap, int serv_negcap,
  *                support ALL capabs in 'caps', and NO capabs in 'nocaps'.
  */
 static void
-sendto_server_internal(struct Client *one, struct Channel *chptr, unsigned long caps, unsigned long nocaps,
+sendto_server_internal(struct Client *one, struct Channel *chptr, uint64_t caps, uint64_t nocaps,
 	const char *format, va_list *args, size_t n_tags, const struct MsgTag tags[])
 {
 	struct Client *target_p;
@@ -509,14 +508,14 @@ sendto_server_internal(struct Client *one, struct Channel *chptr, unsigned long 
 			continue;
 
 		/* check we have required capabs */
-		if (!IsCapable(target_p, caps))
+		if (!IsServerCapable(target_p, caps))
 			continue;
 
 		/* check we don't have any forbidden capabs */
-		if (!NotCapable(target_p, nocaps))
+		if (!NotServerCapable(target_p, nocaps))
 			continue;
 
-		send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, IsCapable(target_p, CAP_STAG) ? (unsigned)-1 : 0, false));
+		send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
 	}
 
 	msgbuf_cache_free(&msgbuf_cache);
@@ -540,8 +539,8 @@ sendto_server_internal(struct Client *one, struct Channel *chptr, unsigned long 
  * -davidt
  */
 void
-sendto_server(struct Client *one, struct Channel *chptr, unsigned long caps,
-	      unsigned long nocaps, const char *format, ...)
+sendto_server(struct Client *one, struct Channel *chptr, uint64_t caps,
+	      uint64_t nocaps, const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -564,8 +563,8 @@ sendto_server(struct Client *one, struct Channel *chptr, unsigned long caps,
  *                support ALL capabs in 'caps', and NO capabs in 'nocaps'.
  */
 void
-sendto_server_tags(struct Client *one, struct Channel *chptr, unsigned long caps,
-		  unsigned long nocaps, size_t n_tags, const struct MsgTag tags[], const char *format, ...)
+sendto_server_tags(struct Client *one, struct Channel *chptr, uint64_t caps,
+		  uint64_t nocaps, size_t n_tags, const struct MsgTag tags[], const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -589,7 +588,7 @@ sendto_server_tags(struct Client *one, struct Channel *chptr, unsigned long caps
  */
 static void
 sendto_channel_flags_internal(struct Client *one, int type, struct Client *source_p, struct Channel *chptr,
-		     int cli_cap, int cli_negcap, const char *priv, int serv_cap, int serv_negcap,
+		     uint64_t cli_cap, uint64_t cli_negcap, const char *priv, uint64_t serv_cap, uint64_t serv_negcap,
 		     const rb_strf_t *strings, size_t n_tags, const struct MsgTag tags[])
 {
 	char buf[DATALEN + 1];
@@ -633,10 +632,10 @@ sendto_channel_flags_internal(struct Client *one, int type, struct Client *sourc
 			/* if we've got a specific type, target must support
 			 * CHW.. --fl
 			 */
-			if(type && NotCapable(target_p->from, CAP_CHW))
+			if(type && NotServerCapable(target_p->from, CAP_CHW))
 				continue;
 
-			if (!IsCapable(target_p->from, serv_cap) || !NotCapable(target_p->from, serv_negcap))
+			if (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap))
 				continue;
 
 			if (target_p->from->serial != current_serial)
@@ -645,14 +644,14 @@ sendto_channel_flags_internal(struct Client *one, int type, struct Client *sourc
 				target_p->from->serial = current_serial;
 			}
 		}
-		else if (IsCapable(target_p, cli_cap) && NotCapable(target_p, cli_negcap) && (priv == NULL || HasPrivilege(target_p, priv)))
+		else if (IsClientCapable(target_p, cli_cap) && NotClientCapable(target_p, cli_negcap) && (priv == NULL || HasPrivilege(target_p, priv)))
 		{
 			send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
 		}
 	}
 
 	/* source client may not be on the channel, send echo separately */
-	if (MyClient(source_p) && IsCapable(source_p, CLICAP_ECHO_MESSAGE))
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
 	{
 		target_p = one == NULL ? source_p : one;
 
@@ -688,7 +687,7 @@ sendto_channel_flags(struct Client *one, int type, struct Client *source_p,
  */
 void
 sendto_channel_flags_tags(struct Client *one, int type, struct Client *source_p,
-			 struct Channel *chptr, int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+			 struct Channel *chptr, uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 			 size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -707,7 +706,7 @@ sendto_channel_flags_tags(struct Client *one, int type, struct Client *source_p,
  */
 static void
 sendto_channel_opmod_internal(struct Client *one, struct Client *source_p, struct Channel *chptr,
-	int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+	uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 	const char *command, const char *text, size_t n_tags, const struct MsgTag tags[])
 {
 	char buf[DATALEN + 1];
@@ -768,12 +767,12 @@ sendto_channel_opmod_internal(struct Client *one, struct Client *source_p, struc
 
 		if (!MyClient(target_p))
 		{
-			if (!IsCapable(target_p->from, serv_cap) || !NotCapable(target_p->from, serv_negcap))
+			if (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap))
 				continue;
 
 			if(target_p->from->serial != current_serial)
 			{
-				if (IsCapable(target_p->from, CAP_EOPMOD))
+				if (IsServerCapable(target_p->from, CAP_EOPMOD))
 					send_linebuf(target_p->from, msgbuf_cache_get(&msgbuf_cache_eopmod, CLIENT_CAP_MASK(target_p), true));
 				else if (chptr->mode.mode & MODE_MODERATED)
 					send_linebuf(target_p->from, msgbuf_cache_get(&msgbuf_cache_statusmsg, CLIENT_CAP_MASK(target_p), true));
@@ -781,13 +780,13 @@ sendto_channel_opmod_internal(struct Client *one, struct Client *source_p, struc
 					send_linebuf(target_p->from, msgbuf_cache_get(&msgbuf_cache_old, CLIENT_CAP_MASK(target_p), true));
 				target_p->from->serial = current_serial;
 			}
-		} else if (IsCapable(target_p, cli_cap) && NotCapable(target_p, cli_negcap)) {
+		} else if (IsClientCapable(target_p, cli_cap) && NotClientCapable(target_p, cli_negcap)) {
 			send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache_statusmsg, CLIENT_CAP_MASK(target_p), false));
 		}
 	}
 
 	/* source client may not be on the channel, send echo separately */
-	if (MyClient(source_p) && IsCapable(source_p, CLICAP_ECHO_MESSAGE))
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
 	{
 		target_p = one;
 
@@ -820,7 +819,7 @@ sendto_channel_opmod(struct Client *one, struct Client *source_p,
  */
 void
 sendto_channel_opmod_tags(struct Client *one, struct Client *source_p, struct Channel *chptr,
-	int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+	uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 	const char *command, const char *text, size_t n_tags, const struct MsgTag tags[])
 {
 	sendto_channel_opmod_internal(one, source_p, chptr, cli_cap, cli_negcap, serv_cap, serv_negcap, command, text, n_tags, tags);
@@ -834,7 +833,7 @@ sendto_channel_opmod_tags(struct Client *one, struct Client *source_p, struct Ch
  */
 static void
 sendto_channel_local_internal(struct Client *one, int type, struct Client *source_p, struct Channel *chptr,
-	int caps, int negcaps, const char *priv, const char *pattern, va_list *args, size_t n_tags, const struct MsgTag tags[])
+	uint64_t caps, uint64_t negcaps, const char *priv, const char *pattern, va_list *args, size_t n_tags, const struct MsgTag tags[])
 {
 	char buf[DATALEN + 1];
 	struct membership *msptr;
@@ -865,7 +864,7 @@ sendto_channel_local_internal(struct Client *one, int type, struct Client *sourc
 		if (type && (msptr->flags & type) == 0)
 			continue;
 
-		if (!IsCapable(target_p, caps) || !NotCapable(target_p, negcaps))
+		if (!IsClientCapable(target_p, caps) || !NotClientCapable(target_p, negcaps))
 			continue;
 
 		if (priv != NULL && !HasPrivilege(target_p, priv))
@@ -933,7 +932,7 @@ sendto_channel_local_tags(struct Client *source_p, int type, const char *priv, s
  * side effects -
  */
 void
-sendto_channel_local_with_capability(struct Client *source_p, int type, int caps, int negcaps, struct Channel *chptr, const char *pattern, ...)
+sendto_channel_local_with_capability(struct Client *source_p, int type, uint64_t caps, uint64_t negcaps, struct Channel *chptr, const char *pattern, ...)
 {
 	va_list args;
 
@@ -949,7 +948,7 @@ sendto_channel_local_with_capability(struct Client *source_p, int type, int caps
  * side effects -
  */
 void
-sendto_channel_local_with_capability_tags(struct Client *source_p, int type, int caps, int negcaps,
+sendto_channel_local_with_capability_tags(struct Client *source_p, int type, uint64_t caps, uint64_t negcaps,
 	struct Channel *chptr, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -967,7 +966,7 @@ sendto_channel_local_with_capability_tags(struct Client *source_p, int type, int
  */
 void
 sendto_channel_local_with_capability_butone(struct Client *one, int type,
-	int caps, int negcaps, struct Channel *chptr, const char *pattern, ...)
+	uint64_t caps, uint64_t negcaps, struct Channel *chptr, const char *pattern, ...)
 {
 	va_list args;
 
@@ -985,7 +984,7 @@ sendto_channel_local_with_capability_butone(struct Client *one, int type,
  */
 void
 sendto_channel_local_with_capability_butone_tags(struct Client *one, int type,
-	int caps, int negcaps, struct Channel *chptr, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
+	uint64_t caps, uint64_t negcaps, struct Channel *chptr, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
 
@@ -1019,7 +1018,7 @@ sendto_channel_local_butone(struct Client *one, int type, struct Channel *chptr,
  * side effects - Sends a message to all people on local server who are in the same channel with user
  */
 static void
-sendto_common_channels_local_internal(struct Client *one, struct Client *user, int caps, int negcaps,
+sendto_common_channels_local_internal(struct Client *one, struct Client *user, uint64_t caps, uint64_t negcaps,
 	const char *pattern, va_list *args, size_t n_tags, const struct MsgTag tags[])
 {
 	rb_dlink_node *ptr;
@@ -1058,8 +1057,8 @@ sendto_common_channels_local_internal(struct Client *one, struct Client *user, i
 
 			if(IsIOError(target_p) ||
 			   target_p->serial == current_serial ||
-			   !IsCapable(target_p, caps) ||
-			   !NotCapable(target_p, negcaps))
+			   !IsClientCapable(target_p, caps) ||
+			   !NotClientCapable(target_p, negcaps))
 				continue;
 
 			target_p->serial = current_serial;
@@ -1070,7 +1069,7 @@ sendto_common_channels_local_internal(struct Client *one, struct Client *user, i
 	/* this can happen when the user isn't in any channels, but we still
 	 * need to send them the data, ie a nick change
 	 */
-	if (MyConnect(user) && (user->serial != current_serial) && IsCapable(user, caps) && NotCapable(user, negcaps))
+	if (MyConnect(user) && (user->serial != current_serial) && IsClientCapable(user, caps) && NotClientCapable(user, negcaps))
 	{
 		send_linebuf(user, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(user), false));
 	}
@@ -1091,7 +1090,7 @@ sendto_common_channels_local_internal(struct Client *one, struct Client *user, i
  *		  used by m_nick.c and exit_one_client.
  */
 void
-sendto_common_channels_local(struct Client *user, int caps, int negcaps, const char *pattern, ...)
+sendto_common_channels_local(struct Client *user, uint64_t caps, uint64_t negcaps, const char *pattern, ...)
 {
 	va_list args;
 
@@ -1114,7 +1113,7 @@ sendto_common_channels_local(struct Client *user, int caps, int negcaps, const c
  *		  used by m_nick.c and exit_one_client.
  */
 void
-sendto_common_channels_local_tags(struct Client *user, int caps, int negcaps,
+sendto_common_channels_local_tags(struct Client *user, uint64_t caps, uint64_t negcaps,
 	size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -1136,7 +1135,7 @@ sendto_common_channels_local_tags(struct Client *user, int caps, int negcaps,
  * 		  in same channel with user, except for user itself.
  */
 void
-sendto_common_channels_local_butone(struct Client *user, int caps, int negcaps, const char *pattern, ...)
+sendto_common_channels_local_butone(struct Client *user, uint64_t caps, uint64_t negcaps, const char *pattern, ...)
 {
 	va_list args;
 
@@ -1158,7 +1157,7 @@ sendto_common_channels_local_butone(struct Client *user, int caps, int negcaps, 
  * 		  in same channel with user, except for user itself.
  */
 void
-sendto_common_channels_local_butone_tags(struct Client *user, int caps, int negcaps,
+sendto_common_channels_local_butone_tags(struct Client *user, uint64_t caps, uint64_t negcaps,
 	size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -1176,7 +1175,7 @@ sendto_common_channels_local_butone_tags(struct Client *user, int caps, int negc
  */
 static void
 sendto_match_internal(struct Client *one, struct Client *source_p, const char *mask, int what,
-	int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+	uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 	const char *pattern, va_list *args, size_t n_tags, const struct MsgTag tags[])
 {
 	struct Client *target_p;
@@ -1201,7 +1200,7 @@ sendto_match_internal(struct Client *one, struct Client *source_p, const char *m
 		{
 			target_p = ptr->data;
 
-			if (match(mask, target_p->host) && IsCapable(target_p, cli_cap) && NotCapable(target_p, cli_negcap))
+			if (match(mask, target_p->host) && IsClientCapable(target_p, cli_cap) && NotClientCapable(target_p, cli_negcap))
 				send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
 		}
 	}
@@ -1212,7 +1211,7 @@ sendto_match_internal(struct Client *one, struct Client *source_p, const char *m
 		{
 			target_p = ptr->data;
 
-			if (IsCapable(target_p, cli_cap) && NotCapable(target_p, cli_negcap))
+			if (IsClientCapable(target_p, cli_cap) && NotClientCapable(target_p, cli_negcap))
 				send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
 		}
 	}
@@ -1224,7 +1223,7 @@ sendto_match_internal(struct Client *one, struct Client *source_p, const char *m
 		if (target_p == one)
 			continue;
 
-		if (!IsCapable(target_p->from, serv_cap) || !NotCapable(target_p->from, serv_negcap))
+		if (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap))
 			continue;
 
 		send_linebuf(target_p->from, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), true));
@@ -1257,7 +1256,7 @@ sendto_match_butone(struct Client *one, struct Client *source_p,
  */
 void
 sendto_match_butone_tags(struct Client *one, struct Client *source_p,
-			const char *mask, int what, int cli_cap, int cli_negcap, int serv_cap, int serv_negcap,
+			const char *mask, int what, uint64_t cli_cap, uint64_t cli_negcap, uint64_t serv_cap, uint64_t serv_negcap,
 			size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -1273,7 +1272,7 @@ sendto_match_butone_tags(struct Client *one, struct Client *source_p,
  * side effects - message is sent to matching servers with caps.
  */
 static void
-sendto_match_servs_internal(struct Client *source_p, const char *mask, int cap, int negcap,
+sendto_match_servs_internal(struct Client *source_p, const char *mask, uint64_t cap, uint64_t negcap,
 	const char *pattern, va_list *args, size_t n_tags, const struct MsgTag tags[])
 {
 	rb_dlink_node *ptr;
@@ -1312,10 +1311,10 @@ sendto_match_servs_internal(struct Client *source_p, const char *mask, int cap, 
 			 */
 			target_p->from->serial = current_serial;
 
-			if (cap && !IsCapable(target_p->from, cap))
+			if (cap && !IsServerCapable(target_p->from, cap))
 				continue;
 
-			if (negcap && !NotCapable(target_p->from, negcap))
+			if (negcap && !NotServerCapable(target_p->from, negcap))
 				continue;
 
 			send_linebuf(target_p->from, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), true));
@@ -1332,7 +1331,7 @@ sendto_match_servs_internal(struct Client *source_p, const char *mask, int cap, 
  * side effects - message is sent to matching servers with caps.
  */
 void
-sendto_match_servs(struct Client *source_p, const char *mask, int cap, int negcap, const char *pattern, ...)
+sendto_match_servs(struct Client *source_p, const char *mask, uint64_t cap, uint64_t negcap, const char *pattern, ...)
 {
 	va_list args;
 	va_start(args, pattern);
@@ -1347,7 +1346,7 @@ sendto_match_servs(struct Client *source_p, const char *mask, int cap, int negca
  * side effects - message is sent to matching servers with caps.
  */
 void
-sendto_match_servs_tags(struct Client *source_p, const char *mask, int cap, int negcap,
+sendto_match_servs_tags(struct Client *source_p, const char *mask, uint64_t cap, uint64_t negcap,
 	size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
@@ -1363,7 +1362,7 @@ sendto_match_servs_tags(struct Client *source_p, const char *mask, int cap, int 
  * side effects - message is sent to matching local clients with caps.
  */
 void
-sendto_local_clients_with_capability(int cap, const char *pattern, ...)
+sendto_local_clients_with_capability(uint64_t cap, const char *pattern, ...)
 {
 	va_list args;
 	rb_dlink_node *ptr;
@@ -1384,7 +1383,7 @@ sendto_local_clients_with_capability(int cap, const char *pattern, ...)
 	{
 		target_p = ptr->data;
 
-		if (IsIOError(target_p) || !IsCapable(target_p, cap))
+		if (IsIOError(target_p) || !IsClientCapable(target_p, cap))
 			continue;
 
 		send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
@@ -1440,7 +1439,7 @@ sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *patt
 static void
 sendto_anywhere_internal(struct Client *dest_p, struct Client *target_p,
 		struct Client *source_p, const char *command,
-		int serv_cap, int serv_negcap,
+		uint64_t serv_cap, uint64_t serv_negcap,
 		const char *pattern, va_list *args,
 		size_t n_tags, const struct MsgTag tags[])
 {
@@ -1449,7 +1448,7 @@ sendto_anywhere_internal(struct Client *dest_p, struct Client *target_p,
 	int used;
 	rb_strf_t strings = { .format = pattern, .format_args = args, .next = NULL };
 
-	if (!MyClient(dest_p) && (!IsCapable(target_p->from, serv_cap) || !NotCapable(target_p->from, serv_negcap)))
+	if (!MyClient(dest_p) && (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap)))
 		return;
 
 	if (MyClient(dest_p))
@@ -1509,7 +1508,7 @@ sendto_anywhere_echo(struct Client *target_p, struct Client *source_p,
  */
 void
 sendto_anywhere_tags(struct Client *target_p, struct Client *source_p, const char *command,
-	int serv_cap, int serv_negcap, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
+	uint64_t serv_cap, uint64_t serv_negcap, size_t n_tags, const struct MsgTag tags[], const char *pattern, ...)
 {
 	va_list args;
 

--- a/modules/cap_account_tag.c
+++ b/modules/cap_account_tag.c
@@ -38,7 +38,7 @@ static const char cap_account_tag_desc[] =
 	"Provides the account-tag client capability";
 
 static void cap_account_tag_process(void *);
-unsigned int CLICAP_ACCOUNT_TAG = 0;
+uint64_t CLICAP_ACCOUNT_TAG = 0;
 
 mapi_hfn_list_av1 cap_account_tag_hfnlist[] = {
 	{ "outbound_msgbuf", cap_account_tag_process },

--- a/modules/cap_server_time.c
+++ b/modules/cap_server_time.c
@@ -40,7 +40,7 @@ static const char cap_server_time_desc[] =
 
 static void cap_server_time_incoming(void *);
 static void cap_server_time_process(void *);
-unsigned int CLICAP_SERVER_TIME = 0;
+uint64_t CLICAP_SERVER_TIME = 0;
 
 mapi_hfn_list_av1 cap_server_time_hfnlist[] = {
 	{ "message_tag", cap_server_time_incoming },

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -76,7 +76,7 @@ static void echo_msg(struct Client *, struct Client *, enum message_type, const 
 static void expire_tgchange(void *unused);
 static struct ev_entry *expire_tgchange_event;
 
-static unsigned int CAP_ECHO;
+static uint64_t CAP_ECHO;
 
 struct entity
 {

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -204,7 +204,7 @@ m_notice(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 static void
 m_tagmsg(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[]) {
-	if (MyClient(source_p) && !IsCapable(source_p, CLICAP_MESSAGE_TAGS))
+	if (MyClient(source_p) && !IsClientCapable(source_p, CLICAP_MESSAGE_TAGS))
 		return;
 
 	m_message(MESSAGE_TYPE_TAGMSG, msgbuf_p, client_p, source_p, parc, parv);
@@ -832,7 +832,7 @@ echo_msg(struct Client *source_p, struct Client *target_p,
 
 	if (MyClient(target_p))
 	{
-		if (!IsCapable(target_p, CLICAP_ECHO_MESSAGE))
+		if (!IsClientCapable(target_p, CLICAP_ECHO_MESSAGE))
 			return;
 
 		sendto_one_tags(target_p, NOCAPS, NOCAPS,
@@ -844,10 +844,7 @@ echo_msg(struct Client *source_p, struct Client *target_p,
 		return;
 	}
 
-	if (!(target_p->from->serv->caps & CAP_ECHO))
-		return;
-
-	sendto_one_tags(target_p, NOCAPS, NOCAPS,
+	sendto_one_tags(target_p, CAP_ECHO, NOCAPS,
 		msgbuf_p->n_tags, msgbuf_p->tags, ":%s ECHO %c %s :%s",
 		use_id(source_p),
 		shortname[msgtype],
@@ -944,7 +941,7 @@ msg_client(enum message_type msgtype,
 			return;
 		}
 
-		if (msgtype == MESSAGE_TYPE_TAGMSG && IsCapable(target_p, CLICAP_MESSAGE_TAGS))
+		if (msgtype == MESSAGE_TYPE_TAGMSG && IsClientCapable(target_p, CLICAP_MESSAGE_TAGS))
 		{
 			add_reply_target(target_p, source_p);
 			sendto_anywhere_tags(target_p, source_p, cmdname[msgtype],
@@ -968,7 +965,7 @@ msg_client(enum message_type msgtype,
 			text);
 
 		/* if the remote doesn't support ECHO, generate a local echo-message instead */
-		if (!(target_p->from->serv->caps & CAP_ECHO))
+		if (!IsServerCapable(target_p->from, CAP_ECHO))
 			echo_msg(target_p, source_p, msgtype, text, msgbuf_p);
 	}
 }

--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -1152,7 +1152,7 @@ can_save(struct Client *target_p)
 	serv_p = IsServer(target_p) ? target_p : target_p->servptr;
 	while (serv_p != NULL && serv_p != &me)
 	{
-		if (!(serv_p->serv->caps & CAP_SAVE))
+		if (!(serv_p->serv->server_caps & CAP_SAVE))
 			return false;
 		serv_p = serv_p->servptr;
 	}
@@ -1163,7 +1163,7 @@ static void
 save_user(struct Client *client_p, struct Client *source_p,
 		struct Client *target_p)
 {
-	if (!MyConnect(target_p) && (!has_id(target_p) || !IsCapable(target_p->from, CAP_SAVE)))
+	if (!MyConnect(target_p) && (!has_id(target_p) || !IsServerCapable(target_p->from, CAP_SAVE)))
 	{
 		/* This shouldn't happen */
 		/* Note we only need SAVE support in this direction */

--- a/modules/core/m_server.c
+++ b/modules/core/m_server.c
@@ -231,7 +231,7 @@ mr_server(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	}
 
 	/* require TS6 for direct links */
-	if(!IsCapable(client_p, CAP_TS6))
+	if (!IsServerCapable(client_p, CAP_TS6))
 	{
 		sendto_realops_snomask(SNO_GENERAL, L_NETWIDE,
 					"Link %s dropped, TS6 protocol is required", name);
@@ -241,10 +241,10 @@ mr_server(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 
 	/* check to ensure any "required" caps are set. --nenolod */
 	required_mask = capability_index_get_required(serv_capindex);
-	if (!IsCapable(client_p, required_mask))
+	if (!IsServerCapable(client_p, required_mask))
 	{
 		missing = capability_index_list(serv_capindex, required_mask &
-				~client_p->localClient->caps);
+				~client_p->localClient->server_caps);
 		sendto_realops_snomask(SNO_GENERAL, L_NETWIDE,
 					"Link %s dropped, required CAPABs [%s] are missing",
 					name, missing);

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -59,7 +59,7 @@ mapi_clist_av1 cap_clist[] = { &cap_msgtab, NULL };
 
 DECLARE_MODULE_AV2(cap, NULL, NULL, cap_clist, NULL, NULL, NULL, NULL, cap_desc);
 
-#define IsCapableEntry(c, e)		IsCapable(c, 1 << (e)->value)
+#define IsCapableEntry(c, e)		IsClientCapable(c, 1ull << (e)->value)
 #define HasCapabilityFlag(c, f)		(c->ownerdata != NULL && (((struct ClientCapability *)c->ownerdata)->flags & (f)) == f)
 
 static inline int
@@ -235,7 +235,7 @@ static void
 cap_ack(struct Client *source_p, const char *arg)
 {
 	struct CapabilityEntry *cap;
-	int capadd = 0, capdel = 0;
+	uint64_t capadd = 0, capdel = 0;
 	int finished = 0, negate;
 
 	if(EmptyString(arg))
@@ -260,8 +260,8 @@ cap_ack(struct Client *source_p, const char *arg)
 			capadd |= (1 << cap->value);
 	}
 
-	source_p->localClient->caps |= capadd;
-	source_p->localClient->caps &= ~capdel;
+	source_p->localClient->client_caps |= capadd;
+	source_p->localClient->client_caps &= ~capdel;
 }
 
 static void
@@ -283,7 +283,7 @@ cap_list(struct Client *source_p, const char *arg)
 {
 	/* list of what theyre currently using */
 	clicap_generate(source_p, "LIST",
-			source_p->localClient->caps ? source_p->localClient->caps : -1);
+			source_p->localClient->client_caps ? source_p->localClient->client_caps : -1);
 }
 
 static void
@@ -300,7 +300,7 @@ cap_ls(struct Client *source_p, const char *arg)
 
 	if (caps_version >= 302) {
 		source_p->flags |= FLAGS_CLICAP_DATA;
-		source_p->localClient->caps |= CLICAP_CAP_NOTIFY;
+		source_p->localClient->client_caps |= CLICAP_CAP_NOTIFY;
 	}
 
 	/* list of what we support */
@@ -312,7 +312,7 @@ cap_req(struct Client *source_p, const char *arg)
 {
 	char ack_buf[DATALEN+1];
 	struct CapabilityEntry *cap;
-	int capadd = 0, capdel = 0;
+	uint64_t capadd = 0, capdel = 0;
 	int finished = 0, negate;
 	int ret;
 	hook_data_cap_change hdata;
@@ -344,7 +344,7 @@ cap_req(struct Client *source_p, const char *arg)
 				break;
 			}
 
-			capdel |= (1 << cap->value);
+			capdel |= (1ull << cap->value);
 		}
 		else
 		{
@@ -354,7 +354,7 @@ cap_req(struct Client *source_p, const char *arg)
 				break;
 			}
 
-			capadd |= (1 << cap->value);
+			capadd |= (1ull << cap->value);
 		}
 
 	}
@@ -369,12 +369,12 @@ cap_req(struct Client *source_p, const char *arg)
 	sendto_one(source_p, "%s", ack_buf);
 
 	hdata.client = source_p;
-	hdata.oldcaps = source_p->localClient->caps;
+	hdata.oldcaps = source_p->localClient->client_caps;
 	hdata.add = capadd;
 	hdata.del = capdel;
 
-	source_p->localClient->caps |= capadd;
-	source_p->localClient->caps &= ~capdel;
+	source_p->localClient->client_caps |= capadd;
+	source_p->localClient->client_caps &= ~capdel;
 
 	call_hook(h_cap_change, &hdata);
 }
@@ -402,6 +402,12 @@ static void
 m_cap(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
 	struct clicap_cmd *cmd;
+
+	if (strlen(client_p->id) == 3 || (source_p->preClient && !EmptyString(source_p->preClient->id)))
+	{
+		exit_client(client_p, client_p, client_p, "Mixing client and server protocol");
+		return;
+	}
 
 	if(!(cmd = bsearch(parv[1], clicap_cmdlist,
 				sizeof(clicap_cmdlist) / sizeof(struct clicap_cmd),

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -260,8 +260,8 @@ cap_ack(struct Client *source_p, const char *arg)
 			capadd |= (1 << cap->value);
 	}
 
-	source_p->localClient->client_caps |= capadd;
-	source_p->localClient->client_caps &= ~capdel;
+	SetClientCap(source_p, capadd);
+	ClearClientCap(source_p, capdel);
 }
 
 static void
@@ -300,7 +300,7 @@ cap_ls(struct Client *source_p, const char *arg)
 
 	if (caps_version >= 302) {
 		source_p->flags |= FLAGS_CLICAP_DATA;
-		source_p->localClient->client_caps |= CLICAP_CAP_NOTIFY;
+		SetClientCap(source_p, CLICAP_CAP_NOTIFY);
 	}
 
 	/* list of what we support */
@@ -373,8 +373,8 @@ cap_req(struct Client *source_p, const char *arg)
 	hdata.add = capadd;
 	hdata.del = capdel;
 
-	source_p->localClient->client_caps |= capadd;
-	source_p->localClient->client_caps &= ~capdel;
+	SetClientCap(source_p, capadd);
+	ClearClientCap(source_p, capdel);
 
 	call_hook(h_cap_change, &hdata);
 }

--- a/modules/m_capab.c
+++ b/modules/m_capab.c
@@ -68,13 +68,13 @@ mr_capab(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		return;
 
 	/* CAP_TS6 is set in PASS, so is valid.. */
-	if((client_p->localClient->caps & ~CAP_TS6) != 0)
+	if((client_p->localClient->server_caps & ~CAP_TS6) != 0)
 	{
 		exit_client(client_p, client_p, client_p, "CAPAB received twice");
 		return;
 	}
 	else
-		client_p->localClient->caps |= CAP_CAP;
+		client_p->localClient->server_caps |= CAP_CAP;
 
 	rb_free(client_p->localClient->fullcaps);
 	client_p->localClient->fullcaps = rb_strdup(parv[1]);
@@ -83,7 +83,7 @@ mr_capab(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	{
 		char *t = LOCAL_COPY(parv[i]);
 		for (s = rb_strtok_r(t, " ", &p); s; s = rb_strtok_r(NULL, " ", &p))
-			client_p->localClient->caps |= capability_get(serv_capindex, s, NULL);
+			client_p->localClient->server_caps |= capability_get(serv_capindex, s, NULL);
 	}
 }
 
@@ -101,12 +101,12 @@ me_gcap(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	/* already had GCAPAB?! */
 	if(!EmptyString(source_p->serv->fullcaps))
 	{
-		source_p->serv->caps = 0;
+		source_p->serv->server_caps = 0;
 		rb_free(source_p->serv->fullcaps);
 	}
 
 	source_p->serv->fullcaps = rb_strdup(parv[1]);
 
 	for (s = rb_strtok_r(t, " ", &p); s; s = rb_strtok_r(NULL, " ", &p))
-		source_p->serv->caps |= capability_get(serv_capindex, s, NULL);
+		source_p->serv->server_caps |= capability_get(serv_capindex, s, NULL);
 }

--- a/modules/m_capab.c
+++ b/modules/m_capab.c
@@ -74,7 +74,7 @@ mr_capab(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		return;
 	}
 	else
-		client_p->localClient->server_caps |= CAP_CAP;
+		SetServerCap(client_p, CAP_CAP);
 
 	rb_free(client_p->localClient->fullcaps);
 	client_p->localClient->fullcaps = rb_strdup(parv[1]);
@@ -83,7 +83,7 @@ mr_capab(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	{
 		char *t = LOCAL_COPY(parv[i]);
 		for (s = rb_strtok_r(t, " ", &p); s; s = rb_strtok_r(NULL, " ", &p))
-			client_p->localClient->server_caps |= capability_get(serv_capindex, s, NULL);
+			SetServerCap(client_p, capability_get(serv_capindex, s, NULL));
 	}
 }
 
@@ -108,5 +108,5 @@ me_gcap(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	source_p->serv->fullcaps = rb_strdup(parv[1]);
 
 	for (s = rb_strtok_r(t, " ", &p); s; s = rb_strtok_r(NULL, " ", &p))
-		source_p->serv->server_caps |= capability_get(serv_capindex, s, NULL);
+		SetServerCap(source_p, capability_get(serv_capindex, s, NULL));
 }

--- a/modules/m_capab.c
+++ b/modules/m_capab.c
@@ -108,5 +108,5 @@ me_gcap(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	source_p->serv->fullcaps = rb_strdup(parv[1]);
 
 	for (s = rb_strtok_r(t, " ", &p); s; s = rb_strtok_r(NULL, " ", &p))
-		SetServerCap(source_p, capability_get(serv_capindex, s, NULL));
+		source_p->serv->server_caps |= capability_get(serv_capindex, s, NULL);
 }

--- a/modules/m_names.c
+++ b/modules/m_names.c
@@ -170,7 +170,7 @@ names_global(struct Client *source_p)
 		if(dont_show)
 			continue;
 
-		if (IsCapable(source_p, CLICAP_USERHOST_IN_NAMES))
+		if (IsClientCapable(source_p, CLICAP_USERHOST_IN_NAMES))
 		{
 			send_multiline_item(source_p, "%s!%s@%s",
 					target_p->name,

--- a/modules/m_pass.c
+++ b/modules/m_pass.c
@@ -103,7 +103,7 @@ mr_pass(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			   IsIdChar(parv[4][2]) && parv[4][3] == '\0' &&
 			   EmptyString(client_p->preClient->id))
 			{
-				client_p->localClient->server_caps |= CAP_TS6;
+				SetServerCap(client_p, CAP_TS6);
 				rb_strlcpy(client_p->preClient->id, parv[4], sizeof(client_p->preClient->id));
 			}
 		}

--- a/modules/m_pass.c
+++ b/modules/m_pass.c
@@ -103,7 +103,7 @@ mr_pass(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			   IsIdChar(parv[4][2]) && parv[4][3] == '\0' &&
 			   EmptyString(client_p->preClient->id))
 			{
-				client_p->localClient->caps |= CAP_TS6;
+				client_p->localClient->server_caps |= CAP_TS6;
 				rb_strlcpy(client_p->preClient->id, parv[4], sizeof(client_p->preClient->id));
 			}
 		}

--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -52,7 +52,7 @@ static void me_mechlist(struct MsgBuf *, struct Client *, struct Client *, int, 
 static void abort_sasl(void *);
 static void abort_sasl_exit(void *);
 
-static unsigned int CLICAP_SASL = 0;
+static uint64_t CLICAP_SASL = 0;
 static char mechlist_buf[BUFSIZE];
 
 struct Message authenticate_msgtab = {

--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -109,7 +109,7 @@ m_authenticate(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *
 	struct Client *saslserv_p = NULL;
 
 	/* They really should use CAP for their own sake. */
-	if(!IsCapable(source_p, CLICAP_SASL))
+	if (!IsClientCapable(source_p, CLICAP_SASL))
 		return;
 
 	if(source_p->localClient->sasl_next_retry > rb_current_time())

--- a/modules/m_starttls.c
+++ b/modules/m_starttls.c
@@ -43,7 +43,7 @@ struct Message starttls_msgtab = {
 
 mapi_clist_av1 starttls_clist[] = { &starttls_msgtab, NULL };
 
-unsigned int CLICAP_TLS = 0;
+uint64_t CLICAP_TLS = 0;
 
 static bool
 tls_visible(struct Client *ignored)

--- a/modules/m_who.c
+++ b/modules/m_who.c
@@ -498,7 +498,7 @@ do_who(struct Client *source_p, struct Client *target_p, struct membership *mspt
 	const char *q;
 
 	sprintf(status, "%c%s%s",
-		   target_p->user->away ? 'G' : 'H', SeesOper(target_p, source_p) ? "*" : "", msptr ? find_channel_status(msptr, fmt->fields || IsCapable(source_p, CLICAP_MULTI_PREFIX)) : "");
+		   target_p->user->away ? 'G' : 'H', SeesOper(target_p, source_p) ? "*" : "", msptr ? find_channel_status(msptr, fmt->fields || IsClientCapable(source_p, CLICAP_MULTI_PREFIX)) : "");
 
 	if (fmt->fields == 0)
 		sendto_one(source_p, form_str(RPL_WHOREPLY), me.name,

--- a/tests/sasl_abort1.c
+++ b/tests/sasl_abort1.c
@@ -52,7 +52,7 @@ static void common_sasl_test(bool aborted)
 	strcpy(server->id, TEST_SERVER_ID);
 	strcpy(remote->id, TEST_REMOTE_ID);
 	add_to_id_hash(remote->id, remote);
-	server->localClient->caps = CAP_ENCAP | CAP_TS6;
+	server->localClient->server_caps = CAP_ENCAP | CAP_TS6;
 	remote->umodes |= UMODE_SERVICE;
 
 	client_util_parse(user, "CAP LS 302" CRLF);

--- a/tests/sasl_abort1.c
+++ b/tests/sasl_abort1.c
@@ -52,7 +52,7 @@ static void common_sasl_test(bool aborted)
 	strcpy(server->id, TEST_SERVER_ID);
 	strcpy(remote->id, TEST_REMOTE_ID);
 	add_to_id_hash(remote->id, remote);
-	server->localClient->server_caps = CAP_ENCAP | CAP_TS6;
+	SetServerCap(server, CAP_ENCAP | CAP_TS6);
 	remote->umodes |= UMODE_SERVICE;
 
 	client_util_parse(user, "CAP LS 302" CRLF);

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -87,14 +87,6 @@ static void standard_init(void)
 	server3 = make_remote_server_name(&me, TEST_SERVER3_NAME);
 	remote3 = make_remote_person_nick(server3, TEST_REMOTE3_NICK);
 
-	// Expose potential bugs in overlapping capabilities
-	server->localClient->caps |= CAP_ACCOUNT_TAG;
-	server->localClient->caps |= CAP_SERVER_TIME;
-	server2->localClient->caps |= CAP_ACCOUNT_TAG;
-	server2->localClient->caps |= CAP_SERVER_TIME;
-	server3->localClient->caps |= CAP_ACCOUNT_TAG;
-	server3->localClient->caps |= CAP_SERVER_TIME;
-
 	local_chan_o = make_local_person_nick("LChanOp");
 	local_chan_ov = make_local_person_nick("LChanOpVoice");
 	local_chan_v = make_local_person_nick("LChanVoice");
@@ -167,13 +159,13 @@ static void standard_ids(void)
 
 static void standard_server_caps(unsigned int add, unsigned int remove)
 {
-	server->localClient->caps |= add;
-	server2->localClient->caps |= add;
-	server3->localClient->caps |= add;
+	server->localClient->server_caps |= add;
+	server2->localClient->server_caps |= add;
+	server3->localClient->server_caps |= add;
 
-	server->localClient->caps &= ~remove;
-	server2->localClient->caps &= ~remove;
-	server3->localClient->caps &= ~remove;
+	server->localClient->server_caps &= ~remove;
+	server2->localClient->server_caps &= ~remove;
+	server3->localClient->server_caps &= ~remove;
 }
 
 static void standard_free(void)
@@ -223,10 +215,10 @@ static void sendto_one1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_one(local_chan_o, "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_o, MSG);
@@ -297,10 +289,10 @@ static void sendto_one_prefix1__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_one_prefix(user, &me, "TEST", ":Hello %s!", "World");
 	is_client_sendq(":" TEST_ME_NAME " TEST " TEST_NICK " :Hello World!" CRLF, user, MSG);
@@ -399,10 +391,10 @@ static void sendto_one_notice1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_one_notice(local_chan_o, ":Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " :" TEST_ME_NAME " NOTICE LChanOp :Hello World!" CRLF, local_chan_o, MSG);
@@ -466,10 +458,10 @@ static void sendto_one_numeric1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_one_numeric(local_chan_o, 1, "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " :" TEST_ME_NAME " 001 LChanOp Hello World!" CRLF, local_chan_o, MSG);
@@ -735,10 +727,10 @@ static void sendto_channel_flags__local__all_members__tags(void)
 	standard_init();
 
 	strcpy(local_chan_p->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_flags(local_chan_p, ALL_MEMBERS, local_chan_p, channel, "TEST #placeholder :Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -770,10 +762,10 @@ static void sendto_channel_flags__remote__all_members__tags(void)
 	standard_init();
 
 	strcpy(remote_chan_p->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_flags(server, ALL_MEMBERS, remote_chan_p, channel, "TEST #placeholder :Hello %s!", "World");
 	is_client_sendq("@account=test :RChanPeon" TEST_ID_SUFFIX " TEST #placeholder :Hello World!" CRLF, local_chan_o, "On channel; " MSG);
@@ -1285,9 +1277,9 @@ static void sendto_channel_opmod__local__tags(void)
 	standard_init();
 
 	strcpy(local_chan_p->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -1321,10 +1313,10 @@ static void sendto_channel_opmod__local__tags(void)
 	// Moderated channel
 	channel->mode.mode |= MODE_MODERATED;
 
-	local_chan_o->localClient->caps &= ~CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps &= ~CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_ov->localClient->caps &= ~CAP_SERVER_TIME;
+	local_chan_o->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps &= ~CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_ov->localClient->client_caps &= ~CAP_SERVER_TIME;
 
 	sendto_channel_opmod(local_chan_p, local_chan_p, channel, "TEST", "Hello World!");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1470,9 +1462,9 @@ static void sendto_channel_opmod__remote__tags(void)
 	standard_init();
 
 	strcpy(remote2_chan_d->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -1502,10 +1494,10 @@ static void sendto_channel_opmod__remote__tags(void)
 	// Moderated channel
 	channel->mode.mode |= MODE_MODERATED;
 
-	local_chan_o->localClient->caps &= ~CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps &= ~CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_ov->localClient->caps &= ~CAP_SERVER_TIME;
+	local_chan_o->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps &= ~CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_ov->localClient->client_caps &= ~CAP_SERVER_TIME;
 
 	sendto_channel_opmod(server2, remote2_chan_d, channel, "TEST", "Hello World!");
 	is_client_sendq(":R2ChanDeaf" TEST_ID_SUFFIX " TEST " TEST_CHANNEL " :Hello World!" CRLF, local_chan_o, "On channel; " MSG);
@@ -1619,10 +1611,10 @@ static void sendto_channel_local1__tags(void)
 	standard_init();
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_local(user, ALL_MEMBERS, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1685,8 +1677,8 @@ static void sendto_channel_local1__tags(void)
 	add_user_to_channel(lchannel, oper1, CHFL_PEON);
 	add_user_to_channel(lchannel, oper2, CHFL_PEON);
 
-	oper1->localClient->caps |= CAP_ACCOUNT_TAG;
-	oper2->localClient->caps |= CAP_SERVER_TIME;
+	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	oper2->localClient->client_caps |= CAP_SERVER_TIME;
 
 	sendto_channel_local(user, ALL_MEMBERS, lchannel, "Hello %s!", "World");
 	is_client_sendq("Hello World!" CRLF, user, "On channel; " MSG);
@@ -1704,8 +1696,8 @@ static void sendto_channel_local1__tags(void)
 	is_client_sendq_empty(server2, MSG);
 	is_client_sendq_empty(server3, MSG);
 
-	oper1->localClient->caps &= ~CAP_ACCOUNT_TAG;
-	oper2->localClient->caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
+	oper2->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_local(user, ALL_MEMBERS, lchannel, "Hello %s!", "World");
 	is_client_sendq("Hello World!" CRLF, user, "On channel; " MSG);
@@ -1730,8 +1722,8 @@ static void sendto_channel_local_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1860,14 +1852,14 @@ static void sendto_channel_local_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1996,8 +1988,8 @@ static void sendto_channel_local_with_capability_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2096,15 +2088,15 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2304,10 +2296,10 @@ static void sendto_channel_local_butone1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_channel_local_butone(NULL, ALL_MEMBERS, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2406,8 +2398,8 @@ static void sendto_common_channels_local1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2472,7 +2464,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
+	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2511,15 +2503,15 @@ static void sendto_common_channels_local1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2554,7 +2546,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_SERVER_TIME;
+	local_no_chan->localClient->client_caps |= CAP_SERVER_TIME;
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2586,8 +2578,8 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
-	local_no_chan->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_no_chan->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2619,7 +2611,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps &= ~CAP_SERVER_TIME;
+	local_no_chan->localClient->client_caps &= ~CAP_SERVER_TIME;
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2658,8 +2650,8 @@ static void sendto_common_channels_local_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2724,7 +2716,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
+	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2763,15 +2755,15 @@ static void sendto_common_channels_local_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2806,7 +2798,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_SERVER_TIME;
+	local_no_chan->localClient->client_caps |= CAP_SERVER_TIME;
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2838,8 +2830,8 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
-	local_no_chan->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_no_chan->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2871,7 +2863,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps &= ~CAP_SERVER_TIME;
+	local_no_chan->localClient->client_caps &= ~CAP_SERVER_TIME;
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -3012,10 +3004,10 @@ static void sendto_match_butone__host__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3219,10 +3211,10 @@ static void sendto_match_butone__server__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3324,8 +3316,8 @@ static void sendto_local_clients_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
@@ -3344,8 +3336,8 @@ static void sendto_local_clients_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
 
 	strcpy(user->user->suser, "test");
 	strcpy(local_chan_o->user->suser, "test_o");
@@ -3353,10 +3345,10 @@ static void sendto_local_clients_with_capability1__tags(void)
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
 	strcpy(local_chan_d->user->suser, "test_d");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
@@ -3403,10 +3395,10 @@ static void sendto_monitor1__tags(void)
 	standard_init();
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	monptr = find_monitor(TEST_NICK, 1);
 	rb_dlinkAddAlloc(local_chan_o, &monptr->users);
@@ -3496,10 +3488,10 @@ static void sendto_anywhere1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3608,10 +3600,10 @@ static void sendto_anywhere_echo1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	sendto_anywhere_echo(local_chan_o, local_chan_o, "TEST", "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test_o :LChanOp" TEST_ID_SUFFIX " TEST LChanOp Hello World!" CRLF, local_chan_o, MSG);
@@ -3722,10 +3714,10 @@ static void sendto_match_servs1(void)
 {
 	standard_init();
 
-	server->localClient->caps = CAP_ENCAP;
-	server2->localClient->caps = CAP_ENCAP;
-	server2->localClient->caps |= CAP_KNOCK;
-	server3->localClient->caps = CAP_BAN;
+	server->localClient->server_caps = CAP_ENCAP;
+	server2->localClient->server_caps = CAP_ENCAP;
+	server2->localClient->server_caps |= CAP_KNOCK;
+	server3->localClient->server_caps = CAP_BAN;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3865,13 +3857,13 @@ static void sendto_match_servs1__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	user->localClient->caps |= CAP_ACCOUNT_TAG;
-	user->localClient->caps |= CAP_SERVER_TIME;
+	user->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	user->localClient->client_caps |= CAP_SERVER_TIME;
 
-	server->localClient->caps = CAP_ENCAP;
-	server2->localClient->caps = CAP_ENCAP;
-	server2->localClient->caps |= CAP_KNOCK;
-	server3->localClient->caps = CAP_BAN;
+	server->localClient->server_caps = CAP_ENCAP;
+	server2->localClient->server_caps = CAP_ENCAP;
+	server2->localClient->server_caps |= CAP_KNOCK;
+	server3->localClient->server_caps = CAP_BAN;
 
 	// This function does not support TS5...
 	standard_ids();
@@ -4027,8 +4019,8 @@ static void sendto_realops_snomask1(void)
 	oper3->user->privset = privilegeset_get("admin");
 	oper4->user->privset = privilegeset_get("admin");
 
-	server->localClient->caps = CAP_ENCAP | CAP_TS6;
-	server2->localClient->caps = 0;
+	server->localClient->server_caps = CAP_ENCAP | CAP_TS6;
+	server2->localClient->server_caps = 0;
 
 	ConfigFileEntry.global_snotices = 0;
 	remote_rehash_oper_p = NULL;
@@ -4236,10 +4228,10 @@ static void sendto_realops_snomask1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->caps |= CAP_SERVER_TIME;
-	oper2->localClient->caps |= CAP_SERVER_TIME;
-	oper3->localClient->caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_SERVER_TIME;
+	oper2->localClient->client_caps |= CAP_SERVER_TIME;
+	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4254,8 +4246,8 @@ static void sendto_realops_snomask1__tags(void)
 	oper3->user->privset = privilegeset_get("admin");
 	oper4->user->privset = privilegeset_get("admin");
 
-	server->localClient->caps = CAP_ENCAP | CAP_TS6;
-	server2->localClient->caps = 0;
+	server->localClient->server_caps = CAP_ENCAP | CAP_TS6;
+	server2->localClient->server_caps = 0;
 
 	ConfigFileEntry.global_snotices = 0;
 	remote_rehash_oper_p = NULL;
@@ -4571,10 +4563,10 @@ static void sendto_realops_snomask_from1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->caps |= CAP_SERVER_TIME;
-	oper2->localClient->caps |= CAP_SERVER_TIME;
-	oper3->localClient->caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_SERVER_TIME;
+	oper2->localClient->client_caps |= CAP_SERVER_TIME;
+	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4748,10 +4740,10 @@ static void sendto_wallops_flags1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->caps |= CAP_SERVER_TIME;
-	oper2->localClient->caps |= CAP_SERVER_TIME;
-	oper3->localClient->caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_SERVER_TIME;
+	oper2->localClient->client_caps |= CAP_SERVER_TIME;
+	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4868,10 +4860,10 @@ static void sendto_wallops_flags2__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->caps |= CAP_SERVER_TIME;
-	oper2->localClient->caps |= CAP_SERVER_TIME;
-	oper3->localClient->caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	oper1->localClient->client_caps |= CAP_SERVER_TIME;
+	oper2->localClient->client_caps |= CAP_SERVER_TIME;
+	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -47,9 +47,9 @@ int rb_gettimeofday(struct timeval *tv, void *tz)
 	return 0;
 }
 
-unsigned int CAP_ACCOUNT_TAG;
-unsigned int CAP_SERVER_TIME;
-unsigned int CAP_MULTI_PREFIX;
+uint64_t CAP_ACCOUNT_TAG;
+uint64_t CAP_SERVER_TIME;
+uint64_t CAP_MULTI_PREFIX;
 
 static struct Client *user;
 static struct Client *server;

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -157,15 +157,15 @@ static void standard_ids(void)
 	strcpy(remote2_chan_d->id, TEST_SERVER2_ID "90205");
 }
 
-static void standard_server_caps(unsigned int add, unsigned int remove)
+static void standard_server_caps(uint64_t add, uint64_t remove)
 {
-	server->localClient->server_caps |= add;
-	server2->localClient->server_caps |= add;
-	server3->localClient->server_caps |= add;
+	SetServerCap(server, add);
+	SetServerCap(server2, add);
+	SetServerCap(server3, add);
 
-	server->localClient->server_caps &= ~remove;
-	server2->localClient->server_caps &= ~remove;
-	server3->localClient->server_caps &= ~remove;
+	ClearServerCap(server, remove);
+	ClearServerCap(server2, remove);
+	ClearServerCap(server3, remove);
 }
 
 static void standard_free(void)
@@ -215,10 +215,10 @@ static void sendto_one1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_one(local_chan_o, "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_o, MSG);
@@ -289,10 +289,10 @@ static void sendto_one_prefix1__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_one_prefix(user, &me, "TEST", ":Hello %s!", "World");
 	is_client_sendq(":" TEST_ME_NAME " TEST " TEST_NICK " :Hello World!" CRLF, user, MSG);
@@ -391,10 +391,10 @@ static void sendto_one_notice1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_one_notice(local_chan_o, ":Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " :" TEST_ME_NAME " NOTICE LChanOp :Hello World!" CRLF, local_chan_o, MSG);
@@ -458,10 +458,10 @@ static void sendto_one_numeric1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_one_numeric(local_chan_o, 1, "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " :" TEST_ME_NAME " 001 LChanOp Hello World!" CRLF, local_chan_o, MSG);
@@ -727,10 +727,10 @@ static void sendto_channel_flags__local__all_members__tags(void)
 	standard_init();
 
 	strcpy(local_chan_p->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_flags(local_chan_p, ALL_MEMBERS, local_chan_p, channel, "TEST #placeholder :Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -762,10 +762,10 @@ static void sendto_channel_flags__remote__all_members__tags(void)
 	standard_init();
 
 	strcpy(remote_chan_p->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_flags(server, ALL_MEMBERS, remote_chan_p, channel, "TEST #placeholder :Hello %s!", "World");
 	is_client_sendq("@account=test :RChanPeon" TEST_ID_SUFFIX " TEST #placeholder :Hello World!" CRLF, local_chan_o, "On channel; " MSG);
@@ -1277,9 +1277,9 @@ static void sendto_channel_opmod__local__tags(void)
 	standard_init();
 
 	strcpy(local_chan_p->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
 
 	// This function does not support TS5...
 	standard_ids();
@@ -1313,10 +1313,10 @@ static void sendto_channel_opmod__local__tags(void)
 	// Moderated channel
 	channel->mode.mode |= MODE_MODERATED;
 
-	local_chan_o->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps &= ~CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_ov->localClient->client_caps &= ~CAP_SERVER_TIME;
+	ClearClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	ClearClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_ACCOUNT_TAG);
+	ClearClientCap(local_chan_ov, CAP_SERVER_TIME);
 
 	sendto_channel_opmod(local_chan_p, local_chan_p, channel, "TEST", "Hello World!");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1462,9 +1462,9 @@ static void sendto_channel_opmod__remote__tags(void)
 	standard_init();
 
 	strcpy(remote2_chan_d->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
 
 	// This function does not support TS5...
 	standard_ids();
@@ -1494,10 +1494,10 @@ static void sendto_channel_opmod__remote__tags(void)
 	// Moderated channel
 	channel->mode.mode |= MODE_MODERATED;
 
-	local_chan_o->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps &= ~CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_ov->localClient->client_caps &= ~CAP_SERVER_TIME;
+	ClearClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	ClearClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_ACCOUNT_TAG);
+	ClearClientCap(local_chan_ov, CAP_SERVER_TIME);
 
 	sendto_channel_opmod(server2, remote2_chan_d, channel, "TEST", "Hello World!");
 	is_client_sendq(":R2ChanDeaf" TEST_ID_SUFFIX " TEST " TEST_CHANNEL " :Hello World!" CRLF, local_chan_o, "On channel; " MSG);
@@ -1611,10 +1611,10 @@ static void sendto_channel_local1__tags(void)
 	standard_init();
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_local(user, ALL_MEMBERS, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1677,8 +1677,8 @@ static void sendto_channel_local1__tags(void)
 	add_user_to_channel(lchannel, oper1, CHFL_PEON);
 	add_user_to_channel(lchannel, oper2, CHFL_PEON);
 
-	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	oper2->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper2, CAP_SERVER_TIME);
 
 	sendto_channel_local(user, ALL_MEMBERS, lchannel, "Hello %s!", "World");
 	is_client_sendq("Hello World!" CRLF, user, "On channel; " MSG);
@@ -1696,8 +1696,8 @@ static void sendto_channel_local1__tags(void)
 	is_client_sendq_empty(server2, MSG);
 	is_client_sendq_empty(server3, MSG);
 
-	oper1->localClient->client_caps &= ~CAP_ACCOUNT_TAG;
-	oper2->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	ClearClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper2, CAP_ACCOUNT_TAG);
 
 	sendto_channel_local(user, ALL_MEMBERS, lchannel, "Hello %s!", "World");
 	is_client_sendq("Hello World!" CRLF, user, "On channel; " MSG);
@@ -1722,8 +1722,8 @@ static void sendto_channel_local_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1852,14 +1852,14 @@ static void sendto_channel_local_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -1988,8 +1988,8 @@ static void sendto_channel_local_with_capability_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2088,15 +2088,15 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2296,10 +2296,10 @@ static void sendto_channel_local_butone1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_channel_local_butone(NULL, ALL_MEMBERS, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
@@ -2398,8 +2398,8 @@ static void sendto_common_channels_local1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2464,7 +2464,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_no_chan, CAP_MULTI_PREFIX);
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2503,15 +2503,15 @@ static void sendto_common_channels_local1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2546,7 +2546,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(local_no_chan, CAP_SERVER_TIME);
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2578,8 +2578,8 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_no_chan->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_no_chan, CAP_MULTI_PREFIX);
+	SetClientCap(local_no_chan, CAP_ACCOUNT_TAG);
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2611,7 +2611,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps &= ~CAP_SERVER_TIME;
+	ClearClientCap(local_no_chan, CAP_SERVER_TIME);
 
 	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2650,8 +2650,8 @@ static void sendto_common_channels_local_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2716,7 +2716,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_no_chan, CAP_MULTI_PREFIX);
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2755,15 +2755,15 @@ static void sendto_common_channels_local_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2798,7 +2798,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(local_no_chan, CAP_SERVER_TIME);
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2830,8 +2830,8 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_no_chan->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_no_chan, CAP_MULTI_PREFIX);
+	SetClientCap(local_no_chan, CAP_ACCOUNT_TAG);
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -2863,7 +2863,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->client_caps &= ~CAP_SERVER_TIME;
+	ClearClientCap(local_no_chan, CAP_SERVER_TIME);
 
 	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
@@ -3004,10 +3004,10 @@ static void sendto_match_butone__host__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3211,10 +3211,10 @@ static void sendto_match_butone__server__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3316,8 +3316,8 @@ static void sendto_local_clients_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
@@ -3336,8 +3336,8 @@ static void sendto_local_clients_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->client_caps |= CAP_MULTI_PREFIX;
-	local_chan_v->localClient->client_caps |= CAP_MULTI_PREFIX;
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
 
 	strcpy(user->user->suser, "test");
 	strcpy(local_chan_o->user->suser, "test_o");
@@ -3345,10 +3345,10 @@ static void sendto_local_clients_with_capability1__tags(void)
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
 	strcpy(local_chan_d->user->suser, "test_d");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
@@ -3395,10 +3395,10 @@ static void sendto_monitor1__tags(void)
 	standard_init();
 
 	strcpy(user->user->suser, "test");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	monptr = find_monitor(TEST_NICK, 1);
 	rb_dlinkAddAlloc(local_chan_o, &monptr->users);
@@ -3488,10 +3488,10 @@ static void sendto_anywhere1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	// This function does not support TS5...
 	standard_ids();
@@ -3600,10 +3600,10 @@ static void sendto_anywhere_echo1__tags(void)
 	strcpy(local_chan_ov->user->suser, "test_ov");
 	strcpy(local_chan_v->user->suser, "test_v");
 	strcpy(local_chan_p->user->suser, "test_p");
-	local_chan_o->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	local_chan_o->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_ov->localClient->client_caps |= CAP_SERVER_TIME;
-	local_chan_v->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(local_chan_o, CAP_ACCOUNT_TAG);
+	SetClientCap(local_chan_o, CAP_SERVER_TIME);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
 
 	sendto_anywhere_echo(local_chan_o, local_chan_o, "TEST", "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test_o :LChanOp" TEST_ID_SUFFIX " TEST LChanOp Hello World!" CRLF, local_chan_o, MSG);
@@ -3715,8 +3715,7 @@ static void sendto_match_servs1(void)
 	standard_init();
 
 	server->localClient->server_caps = CAP_ENCAP;
-	server2->localClient->server_caps = CAP_ENCAP;
-	server2->localClient->server_caps |= CAP_KNOCK;
+	server2->localClient->server_caps = CAP_ENCAP | CAP_KNOCK;
 	server3->localClient->server_caps = CAP_BAN;
 
 	// This function does not support TS5...
@@ -3857,12 +3856,11 @@ static void sendto_match_servs1__tags(void)
 
 	strcpy(user->user->suser, "test");
 	strcpy(remote->user->suser, "rtest");
-	user->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	user->localClient->client_caps |= CAP_SERVER_TIME;
+	SetClientCap(user, CAP_ACCOUNT_TAG);
+	SetClientCap(user, CAP_SERVER_TIME);
 
 	server->localClient->server_caps = CAP_ENCAP;
-	server2->localClient->server_caps = CAP_ENCAP;
-	server2->localClient->server_caps |= CAP_KNOCK;
+	server2->localClient->server_caps = CAP_ENCAP | CAP_KNOCK;
 	server3->localClient->server_caps = CAP_BAN;
 
 	// This function does not support TS5...
@@ -4228,10 +4226,10 @@ static void sendto_realops_snomask1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->client_caps |= CAP_SERVER_TIME;
-	oper2->localClient->client_caps |= CAP_SERVER_TIME;
-	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper1, CAP_SERVER_TIME);
+	SetClientCap(oper2, CAP_SERVER_TIME);
+	SetClientCap(oper3, CAP_ACCOUNT_TAG);
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4563,10 +4561,10 @@ static void sendto_realops_snomask_from1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->client_caps |= CAP_SERVER_TIME;
-	oper2->localClient->client_caps |= CAP_SERVER_TIME;
-	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper1, CAP_SERVER_TIME);
+	SetClientCap(oper2, CAP_SERVER_TIME);
+	SetClientCap(oper3, CAP_ACCOUNT_TAG);
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4740,10 +4738,10 @@ static void sendto_wallops_flags1__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->client_caps |= CAP_SERVER_TIME;
-	oper2->localClient->client_caps |= CAP_SERVER_TIME;
-	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper1, CAP_SERVER_TIME);
+	SetClientCap(oper2, CAP_SERVER_TIME);
+	SetClientCap(oper3, CAP_ACCOUNT_TAG);
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);
@@ -4860,10 +4858,10 @@ static void sendto_wallops_flags2__tags(void)
 	strcpy(oper3->user->suser, "test3");
 	strcpy(oper4->user->suser, "test4");
 
-	oper1->localClient->client_caps |= CAP_ACCOUNT_TAG;
-	oper1->localClient->client_caps |= CAP_SERVER_TIME;
-	oper2->localClient->client_caps |= CAP_SERVER_TIME;
-	oper3->localClient->client_caps |= CAP_ACCOUNT_TAG;
+	SetClientCap(oper1, CAP_ACCOUNT_TAG);
+	SetClientCap(oper1, CAP_SERVER_TIME);
+	SetClientCap(oper2, CAP_SERVER_TIME);
+	SetClientCap(oper3, CAP_ACCOUNT_TAG);
 
 	make_local_person_oper(oper1);
 	make_local_person_oper(oper2);


### PR DESCRIPTION
Instead of overloading the same field in a LocalUser, have separate fields for client caps vs server caps. While only one of these will ever be nonzero, it reduces error by making it explicit which set of caps is being checked. IsCapable and friends have been split as well, to IsClientCapable and IsServerCapable. Finally, both fields have been updated to uint64_t (server caps were approaching the current limit) and all APIs that reference caps updated to uint64_t as well (no more signed/unsigned mismatches).

Fixes #498 