### PR TITLE
Update to C17 and remove SOFT_ASSERT

### DIFF
--- a/authd/dns.c
+++ b/authd/dns.c
@@ -107,7 +107,8 @@ lookup_hostname(const char *ip, DNSCB callback, void *data)
 void
 cancel_query(struct dns_query *query)
 {
-	query->callback = query->data = NULL;
+	query->callback = NULL;
+	query->data = NULL;
 }
 
 /* Callback from gethost_byname_type */
@@ -240,6 +241,7 @@ handle_resolve_dns(int parc, char *parv[])
 	{
 	case '6':
 		aftype = AF_INET6;
+		// fallthrough
 	case '4':
 		if(!lookup_ip(record, aftype, submit_dns_answer, id))
 			submit_dns_answer(NULL, false, qtype, NULL);

--- a/bandb/bantool.c
+++ b/bandb/bantool.c
@@ -228,10 +228,17 @@ main(int argc, char *argv[])
 		fprintf(stdout, "* Allowing duplicate bans...\n");
 
 	/* checking for our files to import or export */
-	for(i = 0; i < LAST_BANDB_TYPE; i++)
+	for (i = 0; i < LAST_BANDB_TYPE; i++)
 	{
-		if (snprintf(conf, sizeof(conf), "%s/%s.conf%s",
-			    etc, bandb_table[i], bandb_suffix[i]) >= sizeof(conf)) {
+		int written = snprintf(conf, sizeof(conf), "%s/%s.conf%s",
+			etc, bandb_table[i], bandb_suffix[i]);
+		if (written < 0)
+		{
+			fprintf(stderr, "* Error: Failed to generate config filename\n");
+			exit(EXIT_FAILURE);
+		}
+
+		if ((unsigned int)written >= sizeof(conf)) {
 			fprintf(stderr, "* Error: Config filename too long\n");
 			exit(EXIT_FAILURE);
 		}

--- a/configure.ac
+++ b/configure.ac
@@ -10,10 +10,12 @@ AC_LANG(C)
 AC_USE_SYSTEM_EXTENSIONS
 AC_GNU_SOURCE
 
-AC_PROG_CC_C99
+AC_PROG_CC
 
-if test x"$ac_cv_prog_cc_c99" = "xno"; then
-	AC_ERROR([solanum requires a C99 capable compiler])
+dnl meson uses C17 but autoconf doesn't support that in AC_PROG_CC
+dnl GCC backported all C17 fixes to C11 anyway, so it's fine to just check for that here
+if test x"$ac_prog_cc_stdc" = "xc89" -o x"$ac_prog_cc_stdc" = "xc99"; then
+	AC_ERROR([solanum requires a C11 capable compiler])
 fi
 
 AC_PREFIX_DEFAULT($HOME/ircd)
@@ -34,8 +36,10 @@ LTDL_INIT
 build_ltdl=$with_included_ltdl
 AM_CONDITIONAL([BUILD_LTDL], [test x"$build_ltdl" = x"yes"])
 
+IRC_CFLAGS="$IRC_CFLAGS -std=gnu11 -D_GNU_SOURCE"
+
 if test "$ac_cv_c_compiler_gnu" = yes; then
-	IRC_CFLAGS="$IRC_CFLAGS -O0 -Wall"
+	IRC_CFLAGS="$IRC_CFLAGS -O0 -Wall -Wextra -pedantic -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length -Wno-overlength-strings"
 fi
 
 dnl If we support -g, use it!
@@ -460,13 +464,10 @@ dnl Debug-related options
 dnl =====================
 
 AC_ARG_ENABLE(assert,
-AC_HELP_STRING([--enable-assert],[Enable assert(). Choose between soft(warnings) and hard(aborts the daemon)]),
+AC_HELP_STRING([--enable-assert],[Enable assert().]),
 [assert=$enableval], [assert=no])
 
 if test "$assert" = no; then
-	AC_DEFINE(NDEBUG, 1, [Define this to disable debugging support.])
-elif test "$assert" = soft; then
-	AC_DEFINE(SOFT_ASSERT, 1, [Define this to enable soft asserts.])
 	AC_DEFINE(NDEBUG, 1, [Define this to disable debugging support.])
 elif test "$assert" = yes; then
 	assert="hard"

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -146,7 +146,7 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	if (parc >= 6)
 	{
 		const char *s;
-		for (s = parv[5]; s != NULL; (s = strchr(s, ' ')) && s++)
+		for (s = parv[5]; s != NULL; (void)((s = strchr(s, ' ')) && s++))
 		{
 			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == ' ' || s[6] == '\0'))
 				secure = 1;

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -147,7 +147,7 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	if (parc >= 6)
 	{
 		const char *s;
-		for (s = parv[5]; s != NULL; (s = strchr(s, ' ')) && s++)
+		for (s = parv[5]; s != NULL; (void)((s = strchr(s, ' ')) && s++))
 		{
 			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == ' ' || s[6] == '\0'))
 				secure = 1;

--- a/extensions/tag_message_id.c
+++ b/extensions/tag_message_id.c
@@ -144,7 +144,7 @@ generate_msgid(char *buf, size_t len, struct Client *source_p, const char *targe
 	 */
 	char *encoded = NULL;
 	if (target != NULL)
-		encoded = rb_base64_encode(target, strlen(target));
+		encoded = (char *)rb_base64_encode((const unsigned char *)target, strlen(target));
 
 	snprintf(buf, len, "1%010d%03d%06d%s%s",
 		(unsigned)prev_ts, prev_ms, ctr, source_p->id, encoded == NULL ? "" : encoded);

--- a/extensions/tag_reply.c
+++ b/extensions/tag_reply.c
@@ -125,7 +125,9 @@ tag_reply_allow(void *data_)
 		{
 			/* the target must match the channel name in the reply tag */
 			int chlen;
-			char *chname = rb_base64_decode(data->value + MSGID_LEN_MIN, idlen - MSGID_LEN_MIN, &chlen);
+			unsigned char *chname = rb_base64_decode(
+				(const unsigned char *)data->value + MSGID_LEN_MIN,
+				idlen - MSGID_LEN_MIN, &chlen);
 			if (chname == NULL)
 				return;
 

--- a/include/channel.h
+++ b/include/channel.h
@@ -233,7 +233,7 @@ int iter_comm_channels_step(rb_dlink_node *pos1, rb_dlink_node *pos2,
 #define ITER_COMM_CHANNELS(pos1, pos2, head1, head2, ms1, ms2, chptr) \
 		for ((pos1) = (head1), (pos2) = (head2); \
 			iter_comm_channels_step((pos1), (pos2), &(ms1), &(ms2), &(chptr)); \
-			(ms1) && ((pos1) = (pos1)->next), (ms2) && ((pos2) = (pos2)->next))
+			(void)((ms1) && ((pos1) = (pos1)->next)), (void)((ms2) && ((pos2) = (pos2)->next)))
 
 
 extern rb_dlink_list global_channel_list;

--- a/include/ircd.h
+++ b/include/ircd.h
@@ -100,7 +100,6 @@ extern int testing_conf;
 extern struct ev_entry *check_splitmode_ev;
 
 extern bool ircd_ssl_ok;
-extern bool ircd_zlib_ok;
 extern int maxconnections;
 
 void ircd_shutdown(const char *reason) __attribute__((noreturn));

--- a/include/ircd.h
+++ b/include/ircd.h
@@ -100,7 +100,6 @@ extern int testing_conf;
 extern struct ev_entry *check_splitmode_ev;
 
 extern bool ircd_ssl_ok;
-extern bool ircd_zlib_ok;
 extern int maxconnections;
 
 void ircd_shutdown(const char *reason) __noreturn;

--- a/include/s_assert.h
+++ b/include/s_assert.h
@@ -32,33 +32,16 @@
 #include "send.h"
 #include "snomask.h"
 
-#ifdef __GNUC__
 #define ss_assert(expr)	(								\
 			((expr)) || (							\
 				ilog(L_MAIN,						\
 				"file: %s line: %d (%s): Assertion failed: (%s)",	\
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr), 0) || (\
+				__FILE__, __LINE__, __func__, #expr), 0) || (\
 				sendto_realops_snomask(SNO_GENERAL, L_ALL,		\
 				"file: %s line: %d (%s): Assertion failed: (%s)",	\
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr), 0)	\
+				__FILE__, __LINE__, __func__, #expr), 0)	\
 			)
-#else
-#define ss_assert(expr)	(								\
-			((expr)) || (							\
-				ilog(L_MAIN,						\
-				"file: %s line: %d: Assertion failed: (%s)",		\
-				__FILE__, __LINE__, #expr), 0) || (			\
-				sendto_realops_snomask(SNO_GENERAL, L_ALL,		\
-				"file: %s line: %d: Assertion failed: (%s)"		\
-				__FILE__, __LINE__, #expr), 0)				\
-			)
-#endif
 
-/* evaluates to true if assertion fails */
-#ifdef SOFT_ASSERT
-#define s_assert(expr)	(!ss_assert(expr))
-#else
-#define s_assert(expr)	(assert(ss_assert(expr)), 0)
-#endif
+#define s_assert(expr)	assert(ss_assert(expr))
 
 #endif /* INCLUDED_s_assert_h */

--- a/include/s_user.h
+++ b/include/s_user.h
@@ -47,7 +47,7 @@ extern void introduce_client(struct Client *client_p, struct Client *source_p,
 extern void change_nick_user_host(struct Client *target_p, const char *nick, const char *user,
 				  const char *host, int newts, const char *format, ...);
 
-extern int user_modes[256];
+extern unsigned int user_modes[256];
 extern unsigned int find_umode_slot(void);
 extern void construct_umodebuf(void);
 

--- a/ircd/batch.c
+++ b/ircd/batch.c
@@ -121,13 +121,13 @@ allocate_batch_message(struct MsgBuf *msg)
 	char *c;
 	struct BatchMessage *copy = rb_malloc(sizeof(struct BatchMessage));
 
-	for (int i = 0; i < msg->n_tags; i++)
+	for (size_t i = 0; i < msg->n_tags; i++)
 	{
 		len += strlen(msg->tags[i].key) + 1;
 		len += strlen(msg->tags[i].value) + 1;
 	}
 
-	for (int i = 0; i < msg->n_para; i++)
+	for (size_t i = 0; i < msg->n_para; i++)
 	{
 		len += strlen(msg->para[i]) + 1;
 	}
@@ -147,7 +147,7 @@ allocate_batch_message(struct MsgBuf *msg)
 
 	copy->msg.n_tags = msg->n_tags;
 	copy->msg.tagslen = msg->tagslen;
-	for (int i = 0; i < msg->n_tags; i++)
+	for (size_t i = 0; i < msg->n_tags; i++)
 	{
 		strcpy(c, msg->tags[i].key);
 		copy->msg.tags[i].key = c;
@@ -159,7 +159,7 @@ allocate_batch_message(struct MsgBuf *msg)
 	}
 
 	copy->msg.n_para = msg->n_para;
-	for (int i = 0; i < msg->n_para; i++)
+	for (size_t i = 0; i < msg->n_para; i++)
 	{
 		strcpy(c, msg->para[i]);
 		copy->msg.para[i] = c;

--- a/ircd/batch.c
+++ b/ircd/batch.c
@@ -120,7 +120,7 @@ allocate_batch_message(struct MsgBuf *msg)
 	char *c;
 	struct BatchMessage *copy = rb_malloc(sizeof(struct BatchMessage));
 
-	for (int i = 0; i < msg->n_tags; i++)
+	for (size_t i = 0; i < msg->n_tags; i++)
 	{
 		if (msg->tags[i].key == NULL)
 			continue;
@@ -130,7 +130,7 @@ allocate_batch_message(struct MsgBuf *msg)
 			len += strlen(msg->tags[i].value) + 1;
 	}
 
-	for (int i = 0; i < msg->n_para; i++)
+	for (size_t i = 0; i < msg->n_para; i++)
 	{
 		len += strlen(msg->para[i]) + 1;
 	}
@@ -150,7 +150,7 @@ allocate_batch_message(struct MsgBuf *msg)
 
 	copy->msg.n_tags = msg->n_tags;
 	copy->msg.tagslen = msg->tagslen;
-	for (int i = 0, j = 0; i < msg->n_tags; i++)
+	for (size_t i = 0, j = 0; i < msg->n_tags; i++)
 	{
 		if (msg->tags[i].key == NULL)
 		{
@@ -174,7 +174,7 @@ allocate_batch_message(struct MsgBuf *msg)
 	}
 
 	copy->msg.n_para = msg->n_para;
-	for (int i = 0; i < msg->n_para; i++)
+	for (size_t i = 0; i < msg->n_para; i++)
 	{
 		strcpy(c, msg->para[i]);
 		copy->msg.para[i] = c;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -1354,7 +1354,7 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 
 	mbuf = modebuf;
 
-	for (ml = parv[0]; *ml != 0 && ms - modesets < ARRAY_SIZE(modesets); ml++)
+	for (ml = parv[0]; *ml != 0 && (size_t)(ms - modesets) < ARRAY_SIZE(modesets); ml++)
 	{
 		c = *ml;
 		switch (c)

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -904,7 +904,7 @@ chm_ban(struct Client *source_p, struct Channel *chptr,
 			return;
 
 		if (forward)
-			forward[-1]= '$';
+			*(forward - 1) = '$';
 
 		mode_changes[mode_count].letter = c;
 		mode_changes[mode_count].dir = MODE_ADD;
@@ -1354,7 +1354,7 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 
 	mbuf = modebuf;
 
-	for (ml = parv[0]; *ml != 0 && ms - modesets < ARRAY_SIZE(modesets); ml++)
+	for (ml = parv[0]; *ml != 0 && (size_t)(ms - modesets) < ARRAY_SIZE(modesets); ml++)
 	{
 		c = *ml;
 		switch (c)

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1976,24 +1976,9 @@ free_user(struct User *user, struct Client *client_p)
 		/*
 		 * sanity check
 		 */
-		if(user->refcnt < 0 || user->invited.head || user->channel.head)
-		{
-			sendto_realops_snomask(SNO_GENERAL, L_ALL,
-					     "* %p user (%s!%s@%s) %p %p %p %lu %d *",
-					     client_p,
-					     client_p ? client_p->
-					     name : "<noname>",
-					     client_p->username,
-					     client_p->host,
-					     user,
-					     user->invited.head,
-					     user->channel.head,
-					     rb_dlink_list_length(&user->channel),
-					     user->refcnt);
-			s_assert(!user->refcnt);
-			s_assert(!user->invited.head);
-			s_assert(!user->channel.head);
-		}
+		s_assert(!user->refcnt);
+		s_assert(!user->invited.head);
+		s_assert(!user->channel.head);
 
 		rb_bh_free(user_heap, user);
 	}

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1983,24 +1983,9 @@ free_user(struct User *user, struct Client *client_p)
 		/*
 		 * sanity check
 		 */
-		if(user->refcnt < 0 || user->invited.head || user->channel.head)
-		{
-			sendto_realops_snomask(SNO_GENERAL, L_ALL,
-					     "* %p user (%s!%s@%s) %p %p %p %lu %d *",
-					     client_p,
-					     client_p ? client_p->
-					     name : "<noname>",
-					     client_p->username,
-					     client_p->host,
-					     user,
-					     user->invited.head,
-					     user->channel.head,
-					     rb_dlink_list_length(&user->channel),
-					     user->refcnt);
-			s_assert(!user->refcnt);
-			s_assert(!user->invited.head);
-			s_assert(!user->channel.head);
-		}
+		s_assert(!user->refcnt);
+		s_assert(!user->invited.head);
+		s_assert(!user->channel.head);
 
 		rb_bh_free(user_heap, user);
 	}

--- a/ircd/client_tags.c
+++ b/ircd/client_tags.c
@@ -33,8 +33,8 @@
 #include "client_tags.h"
 
 static struct client_tag_support supported_client_tags[MAX_CLIENT_TAGS];
-static int num_client_tags = 0;
-static int max_client_tags = MAX_CLIENT_TAGS;
+static unsigned int num_client_tags = 0;
+static unsigned int max_client_tags = MAX_CLIENT_TAGS;
 
 int
 add_client_tag(const char *name)
@@ -51,7 +51,7 @@ add_client_tag(const char *name)
 void
 remove_client_tag(const char *name)
 {
-	for (int index = 0; index < num_client_tags; index++)
+	for (unsigned int index = 0; index < num_client_tags; index++)
 	{
 		if (!strcmp(supported_client_tags[index].name, name)) {
 			if (index < num_client_tags - 1)
@@ -68,7 +68,7 @@ format_client_tags(char *dst, size_t dst_sz, const char *individual_fmt, const c
 	size_t start = 0;
 	size_t join_len = strlen(join_sep);
 	*dst = 0;
-	for (size_t index = 0; index < num_client_tags; index++) {
+	for (unsigned int index = 0; index < num_client_tags; index++) {
 		if (start >= dst_sz)
 			break;
 

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -103,7 +103,6 @@ bool kline_queued = false;
 bool server_state_foreground = false;
 bool opers_see_all_users = false;
 bool ircd_ssl_ok = false;
-bool ircd_zlib_ok = true;
 
 int testing_conf = 0;
 time_t startup_time;

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -104,7 +104,6 @@ bool kline_queued = false;
 bool server_state_foreground = false;
 bool opers_see_all_users = false;
 bool ircd_ssl_ok = false;
-bool ircd_zlib_ok = true;
 
 int testing_conf = 0;
 time_t startup_time;

--- a/ircd/listener.c
+++ b/ircd/listener.c
@@ -43,7 +43,7 @@
 #include "s_assert.h"
 #include "logger.h"
 
-static rb_dlink_list listener_list = {};
+static rb_dlink_list listener_list;
 static int accept_precallback(rb_fde_t *F, struct sockaddr *addr, rb_socklen_t addrlen, void *data);
 static void accept_callback(rb_fde_t *F, int status, struct sockaddr *addr, rb_socklen_t addrlen, void *data);
 static SSL_OPEN_CB accept_sslcallback;
@@ -230,7 +230,7 @@ find_listener(struct rb_sockaddr_storage *addr, int sctp)
 		if (listener->sctp != sctp)
 			continue;
 
-		for (int i = 0; i < ARRAY_SIZE(listener->addr); i++) {
+		for (size_t i = 0; i < ARRAY_SIZE(listener->addr); i++) {
 			if (GET_SS_FAMILY(&addr[i]) != GET_SS_FAMILY(&listener->addr[i]))
 				goto next;
 

--- a/ircd/match.c
+++ b/ircd/match.c
@@ -92,7 +92,7 @@ int match(const char *mask, const char *name)
 					  for (n_tmp = n; *n && irctolower(*n) != irctolower(*m); n++);
 				  }
 			  }
-			  /* and fall through */
+			  // fallthrough
 		  default:
 			  if (!*n)
 				  return (*m != '\0' ? 0 : 1);
@@ -198,7 +198,7 @@ int mask_match(const char *mask_, const char *name)
 					  for (n_tmp = n; *n && irctolower(*n) != irctolower(*m); n++);
 				  }
 			  }
-			  /* and fall through */
+			  // fallthrough
 		  default:
 			  if (!*n)
 				  return (*m != '\0' ? 0 : 1);
@@ -624,8 +624,8 @@ int ircncmp(const void *s1, const void *s2, int n)
 void matchset_for_client(struct Client *who, struct matchset *m)
 {
 	bool hide_ip = IsIPSpoof(who) || (!ConfigChannel.ip_bans_through_vhost && IsDynSpoof(who));
-	unsigned hostn = 0;
-	unsigned ipn = 0;
+	unsigned int hostn = 0;
+	unsigned int ipn = 0;
 
 	struct sockaddr_in ip4;
 
@@ -659,11 +659,11 @@ void matchset_for_client(struct Client *who, struct matchset *m)
 		ipn++;
 	}
 
-	for (int i = hostn; i < ARRAY_SIZE(m->host); i++)
+	for (size_t i = hostn; i < ARRAY_SIZE(m->host); i++)
 	{
 		m->host[i][0] = '\0';
 	}
-	for (int i = ipn; i < ARRAY_SIZE(m->ip); i++)
+	for (size_t i = ipn; i < ARRAY_SIZE(m->ip); i++)
 	{
 		m->ip[i][0] = '\0';
 	}
@@ -678,14 +678,14 @@ bool client_matches_mask(struct Client *who, const char *mask)
 
 bool matches_mask(const struct matchset *m, const char *mask)
 {
-	for (int i = 0; i < ARRAY_SIZE(m->host); i++)
+	for (size_t i = 0; i < ARRAY_SIZE(m->host); i++)
 	{
 		if (m->host[i][0] == '\0')
 			break;
 		if (match(mask, m->host[i]))
 			return true;
 	}
-	for (int i = 0; i < ARRAY_SIZE(m->ip); i++)
+	for (size_t i = 0; i < ARRAY_SIZE(m->ip); i++)
 	{
 		if (m->ip[i][0] == '\0')
 			break;

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -883,7 +883,7 @@ static char *listener_address[2];
 static int
 conf_begin_listen(struct TopConf *tc)
 {
-	for (int i = 0; i < ARRAY_SIZE(listener_address); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(listener_address); i++) {
 		rb_free(listener_address[i]);
 		listener_address[i] = NULL;
 	}
@@ -894,7 +894,7 @@ conf_begin_listen(struct TopConf *tc)
 static int
 conf_end_listen(struct TopConf *tc)
 {
-	for (int i = 0; i < ARRAY_SIZE(listener_address); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(listener_address); i++) {
 		rb_free(listener_address[i]);
 		listener_address[i] = NULL;
 	}

--- a/ircd/packet.c
+++ b/ircd/packet.c
@@ -310,7 +310,7 @@ read_packet(rb_fde_t * F, void *data)
 
 		/* Check to make sure we're not flooding */
 		if(!IsAnyServer(client_p) &&
-		   (rb_linebuf_alloclen(&client_p->localClient->buf_recvq) + client_p->localClient->pending_batch_lines > ConfigFileEntry.client_flood_max_lines))
+		   (rb_linebuf_alloclen(&client_p->localClient->buf_recvq) + (int)client_p->localClient->pending_batch_lines > ConfigFileEntry.client_flood_max_lines))
 		{
 			if(!(ConfigFileEntry.no_oper_flood && IsOperGeneral(client_p)))
 			{

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -515,11 +515,9 @@ do_numeric(int numeric, struct Client *client_p, struct Client *source_p, struct
 	if(parc > 1)
 	{
 		char *t = buffer;	/* Current position within the buffer */
-		int i;
-		int tl;		/* current length of presently being built string in t */
-		for (i = 2; i < (parc - 1); i++)
+		for (size_t i = 2; i < (parc - 1); i++)
 		{
-			tl = sprintf(t, " %s", parv[i]);
+			int tl = sprintf(t, " %s", parv[i]);
 			t += tl;
 		}
 		sprintf(t, " :%s", parv[parc - 1]);

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -518,11 +518,9 @@ do_numeric(int numeric, struct Client *client_p, struct Client *source_p, struct
 	if(parc > 1)
 	{
 		char *t = buffer;	/* Current position within the buffer */
-		int i;
-		int tl;		/* current length of presently being built string in t */
-		for (i = 2; i < (parc - 1); i++)
+		for (size_t i = 2; i < (parc - 1); i++)
 		{
-			tl = sprintf(t, " %s", parv[i]);
+			int tl = sprintf(t, " %s", parv[i]);
 			t += tl;
 		}
 		sprintf(t, " :%s", parv[parc - 1]);

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -592,8 +592,7 @@ attach_conf(struct Client *client_p, struct ConfItem *aconf)
 	if(IsIllegal(aconf))
 		return (NOT_AUTHORISED);
 
-	if(s_assert(ClassPtr(aconf)))
-		return (NOT_AUTHORISED);
+	s_assert(ClassPtr(aconf));
 
 	if(!add_ip_limit(client_p, aconf))
 		return (TOO_MANY_LOCAL);

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -589,8 +589,7 @@ attach_conf(struct Client *client_p, struct ConfItem *aconf)
 	if(IsIllegal(aconf))
 		return (NOT_AUTHORISED);
 
-	if(s_assert(ClassPtr(aconf)))
-		return (NOT_AUTHORISED);
+	s_assert(ClassPtr(aconf));
 
 	if(!add_ip_limit(client_p, aconf))
 		return (TOO_MANY_LOCAL);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1008,7 +1008,7 @@ serv_connect(struct server_conf *server_p, struct Client *by)
 	if(server_p == NULL)
 		return 0;
 
-	for (int i = 0; i < ARRAY_SIZE(sa_connect); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(sa_connect); i++) {
 		SET_SS_FAMILY(&sa_connect[i], AF_UNSPEC);
 		SET_SS_FAMILY(&sa_bind[i], AF_UNSPEC);
 	}
@@ -1158,7 +1158,7 @@ serv_connect(struct server_conf *server_p, struct Client *by)
 	SetConnecting(client_p);
 	rb_dlinkAddTail(client_p, &client_p->node, &global_client_list);
 
-	for (int i = 0; i < ARRAY_SIZE(sa_connect); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(sa_connect); i++) {
 		if (GET_SS_FAMILY(&sa_bind[i]) == AF_UNSPEC) {
 			if (GET_SS_FAMILY(&sa_connect[i]) == GET_SS_FAMILY(&ServerInfo.bind4))
 				sa_bind[i] = ServerInfo.bind4;

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1021,7 +1021,7 @@ serv_connect(struct server_conf *server_p, struct Client *by)
 	if(server_p == NULL)
 		return 0;
 
-	for (int i = 0; i < ARRAY_SIZE(sa_connect); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(sa_connect); i++) {
 		SET_SS_FAMILY(&sa_connect[i], AF_UNSPEC);
 		SET_SS_FAMILY(&sa_bind[i], AF_UNSPEC);
 	}
@@ -1171,7 +1171,7 @@ serv_connect(struct server_conf *server_p, struct Client *by)
 	SetConnecting(client_p);
 	rb_dlinkAddTail(client_p, &client_p->node, &global_client_list);
 
-	for (int i = 0; i < ARRAY_SIZE(sa_connect); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(sa_connect); i++) {
 		if (GET_SS_FAMILY(&sa_bind[i]) == AF_UNSPEC) {
 			if (GET_SS_FAMILY(&sa_connect[i]) == GET_SS_FAMILY(&ServerInfo.bind4))
 				sa_bind[i] = ServerInfo.bind4;

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -58,7 +58,7 @@ void user_welcome(struct Client *source_p);
 char umodebuf[128];
 
 static int orphaned_umodes = 0;
-int user_modes[256] = {
+unsigned int user_modes[256] = {
 	/* 0x00 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x0F */
 	/* 0x10 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x1F */
 	/* 0x20 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x2F */
@@ -1567,7 +1567,7 @@ construct_umodebuf(void)
 {
 	int i;
 	char *ptr = umodebuf;
-	static int prev_user_modes[128];
+	static unsigned int prev_user_modes[128];
 
 	*ptr = '\0';
 

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -222,27 +222,6 @@ send_queued_write(rb_fde_t *F, void *data)
  * side effects - the linebuf object is cleared, then populated
  */
 static void
-linebuf_put_tags(buf_head_t *linebuf, const struct MsgBuf *msgbuf, const struct Client *target_p, rb_strf_t *message)
-{
-	struct MsgBuf_str_data msgbuf_str_data = { .msgbuf = msgbuf, .caps = CLIENT_CAP_MASK(target_p) };
-	rb_strf_t strings = { .func = msgbuf_unparse_linebuf_tags, .func_args = &msgbuf_str_data, .length = TAGSLEN + 1, .next = message };
-
-	message->length = DATALEN + 1;
-	rb_linebuf_put(linebuf, &strings);
-}
-
-static void
-linebuf_put_tagsf(buf_head_t *linebuf, const struct MsgBuf *msgbuf, const struct Client *target_p, const rb_strf_t *message, const char *format, ...)
-{
-	va_list va;
-	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
-
-	va_start(va, format);
-	linebuf_put_tags(linebuf, msgbuf, target_p, &strings);
-	va_end(va);
-}
-
-static void
 linebuf_put_msg(buf_head_t *linebuf, rb_strf_t *message)
 {
 	message->length = DATALEN + 1;
@@ -1451,9 +1430,12 @@ sendto_anywhere_internal(struct Client *dest_p, struct Client *target_p,
 	if (!MyClient(dest_p) && (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap)))
 		return;
 
-	if (MyClient(dest_p))
-		used = snprintf(buf, sizeof(buf), IsPerson(source_p) ? ":%1$s!%4$s@%5$s %2$s %3$s " : ":%1$s %2$s %3$s ",
-			source_p->name, command, target_p->name, source_p->username, source_p->host);
+	if (MyClient(dest_p) && IsPerson(source_p))
+		used = snprintf(buf, sizeof(buf), ":%s!%s@%s %s %s ",
+			source_p->name, source_p->username, source_p->host, command, target_p->name);
+	else if (MyClient(dest_p))
+		used = snprintf(buf, sizeof(buf), ":%s %s %s ",
+			source_p->name, command, target_p->name);
 	else
 		used = snprintf(buf, sizeof(buf), ":%s %s %s ",
 			get_id(source_p, target_p), command, get_id(target_p, target_p));
@@ -1744,13 +1726,13 @@ kill_client_serv_butone(struct Client *one, struct Client *target_p, const char 
 
 static struct Client *multiline_stashed_target_p;
 static char multiline_prefix[DATALEN+1]; /* allow for null termination */
-static int multiline_prefix_len;
+static size_t multiline_prefix_len;
 static char multiline_separator[2];
-static int multiline_separator_len;
+static size_t multiline_separator_len;
 static char *multiline_item_start;
 static char *multiline_cur;
-static int multiline_cur_len;
-static int multiline_remote_pad;
+static size_t multiline_cur_len;
+static size_t multiline_remote_pad;
 
 bool
 send_multiline_init(struct Client *target_p, const char *separator, const char *format, ...)
@@ -1886,7 +1868,7 @@ send_multiline_fini(struct Client *target_p, const char *format, ...)
 		final_len = vsnprintf(final, sizeof final, format, args);
 		va_end(args);
 
-		if (final_len <= 0 || final_len > multiline_prefix_len)
+		if (final_len <= 0 || (unsigned int)final_len > multiline_prefix_len)
 		{
 			s_assert(false && "Multiline: failure preparing final prefix!");
 			multiline_stashed_target_p = NULL;

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -222,27 +222,6 @@ send_queued_write(rb_fde_t *F, void *data)
  * side effects - the linebuf object is cleared, then populated
  */
 static void
-linebuf_put_tags(buf_head_t *linebuf, const struct MsgBuf *msgbuf, const struct Client *target_p, rb_strf_t *message)
-{
-	struct MsgBuf_str_data msgbuf_str_data = { .msgbuf = msgbuf, .caps = CLIENT_CAP_MASK(target_p) };
-	rb_strf_t strings = { .func = msgbuf_unparse_linebuf_tags, .func_args = &msgbuf_str_data, .length = TAGSLEN + 1, .next = message };
-
-	message->length = DATALEN + 1;
-	rb_linebuf_put(linebuf, &strings);
-}
-
-static void
-linebuf_put_tagsf(buf_head_t *linebuf, const struct MsgBuf *msgbuf, const struct Client *target_p, const rb_strf_t *message, const char *format, ...)
-{
-	va_list va;
-	rb_strf_t strings = { .format = format, .format_args = &va, .next = message };
-
-	va_start(va, format);
-	linebuf_put_tags(linebuf, msgbuf, target_p, &strings);
-	va_end(va);
-}
-
-static void
 linebuf_put_msg(buf_head_t *linebuf, rb_strf_t *message)
 {
 	message->length = DATALEN + 1;
@@ -1515,9 +1494,12 @@ sendto_anywhere_internal(struct Client *dest_p, struct Client *target_p,
 	if (!MyClient(dest_p) && (!IsServerCapable(target_p->from, serv_cap) || !NotServerCapable(target_p->from, serv_negcap)))
 		return;
 
-	if (MyClient(dest_p))
-		used = snprintf(buf, sizeof(buf), IsPerson(source_p) ? ":%1$s!%4$s@%5$s %2$s %3$s " : ":%1$s %2$s %3$s ",
-			source_p->name, command, target_p->name, source_p->username, source_p->host);
+	if (MyClient(dest_p) && IsPerson(source_p))
+		used = snprintf(buf, sizeof(buf), ":%s!%s@%s %s %s ",
+			source_p->name, source_p->username, source_p->host, command, target_p->name);
+	else if (MyClient(dest_p))
+		used = snprintf(buf, sizeof(buf), ":%s %s %s ",
+			source_p->name, command, target_p->name);
 	else
 		used = snprintf(buf, sizeof(buf), ":%s %s %s ",
 			get_id(source_p, target_p), command, get_id(target_p, target_p));
@@ -1818,13 +1800,13 @@ kill_client_serv_butone(struct Client *one, struct Client *target_p, const char 
 
 static struct Client *multiline_stashed_target_p;
 static char multiline_prefix[DATALEN+1]; /* allow for null termination */
-static int multiline_prefix_len;
+static size_t multiline_prefix_len;
 static char multiline_separator[2];
-static int multiline_separator_len;
+static size_t multiline_separator_len;
 static char *multiline_item_start;
 static char *multiline_cur;
-static int multiline_cur_len;
-static int multiline_remote_pad;
+static size_t multiline_cur_len;
+static size_t multiline_remote_pad;
 
 bool
 send_multiline_init(struct Client *target_p, const char *separator, const char *format, ...)
@@ -1960,7 +1942,7 @@ send_multiline_fini(struct Client *target_p, const char *format, ...)
 		final_len = vsnprintf(final, sizeof final, format, args);
 		va_end(args);
 
-		if (final_len <= 0 || final_len > multiline_prefix_len)
+		if (final_len <= 0 || (unsigned int)final_len > multiline_prefix_len)
 		{
 			s_assert(false && "Multiline: failure preparing final prefix!");
 			multiline_stashed_target_p = NULL;

--- a/ircd/sslproc.c
+++ b/ircd/sslproc.c
@@ -529,7 +529,6 @@ ssl_process_cmd_recv(ssl_ctl_t * ctl)
 			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s", cannot_setup_ssl);
 			break;
 		case 'U':
-			ircd_zlib_ok = 0;
 			ircd_ssl_ok = false;
 			ilog(L_MAIN, "%s", no_ssl_or_zlib);
 			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s", no_ssl_or_zlib);
@@ -540,8 +539,9 @@ ssl_process_cmd_recv(ssl_ctl_t * ctl)
 			if (len > sizeof(ctl->version) - 1)
 				len = sizeof(ctl->version) - 1;
 			strncpy(ctl->version, &ctl_buf->buf[1], len);
+			break;
 		case 'z':
-			ircd_zlib_ok = 0;
+			/* no longer used, previously indicated no support for zlib */
 			break;
 		default:
 			ilog(L_MAIN, "Received invalid command from ssld: %s", ctl_buf->buf);

--- a/librb/include/rb_lib.h
+++ b/librb/include/rb_lib.h
@@ -77,28 +77,14 @@ char *alloca();
 #endif
 
 
-#ifdef __GNUC__
 #define slrb_assert(expr)	(							\
 			rb_likely((expr)) || (						\
 				rb_lib_log( 						\
 				"file: %s line: %d (%s): Assertion failed: (%s)",	\
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr), 0) 	\
+				__FILE__, __LINE__, __func__, #expr), 0) 	\
 			)
-#else
-#define slrb_assert(expr)	(							\
-			rb_likely((expr)) || (						\
-				rb_lib_log( 						\
-				"file: %s line: %d: Assertion failed: (%s)",		\
-				__FILE__, __LINE__, #expr), 0) 				\
-			)
-#endif
 
-/* evaluates to true if assertion fails */
-#ifdef SOFT_ASSERT
-#define lrb_assert(expr) 	(!slrb_assert(expr))
-#else
-#define lrb_assert(expr)	(assert(slrb_assert(expr)), 0)
-#endif
+#define lrb_assert(expr)	assert(slrb_assert(expr))
 
 #ifdef RB_SOCKADDR_HAS_SA_LEN
 #define ss_len sa_len

--- a/librb/include/rb_lib.h
+++ b/librb/include/rb_lib.h
@@ -66,28 +66,11 @@ void *alloca(size_t);
 #endif
 
 
-#ifdef __GNUC__
-#  define slrb_assert(expr)	(							\
-			rb_likely((expr)) || (						\
-				rb_lib_log( 						\
-				"file: %s line: %d (%s): Assertion failed: (%s)",	\
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr), 0) 	\
-			)
-#else
-#  define slrb_assert(expr)	(							\
-			rb_likely((expr)) || (						\
-				rb_lib_log( 						\
-				"file: %s line: %d: Assertion failed: (%s)",		\
-				__FILE__, __LINE__, #expr), 0) 				\
-			)
-#endif
+#define slrb_assert(expr)	(rb_likely((expr)) || (rb_lib_log(	\
+	"file: %s line: %d (%s): Assertion failed: (%s)",	\
+	__FILE__, __LINE__, __func__, #expr), 0))
 
-/* evaluates to true if assertion fails */
-#ifdef SOFT_ASSERT
-#  define lrb_assert(expr) 	(!slrb_assert(expr))
-#else
-#  define lrb_assert(expr)	(assert(slrb_assert(expr)), 0)
-#endif
+#define lrb_assert(expr)	assert(slrb_assert(expr))
 
 #ifdef RB_SOCKADDR_HAS_SA_LEN
 #  define ss_len sa_len
@@ -162,7 +145,7 @@ void rb_sleep(unsigned int seconds, unsigned int useconds);
 char *rb_crypt(const char *, const char *);
 
 unsigned char *rb_base64_encode(const unsigned char *str, int length);
-unsigned char *rb_base64_decode(const unsigned char *str, int length, int *ret);
+unsigned char *rb_base64_decode(const unsigned char *str, size_t length, int *ret);
 int rb_kill(pid_t, int);
 char *rb_strerror(int);
 

--- a/librb/src/rawbuf.c
+++ b/librb/src/rawbuf.c
@@ -269,8 +269,8 @@ rb_rawbuf_get(rawbuf_head_t * rb, void *data, int len)
 int
 rb_rawbuf_length(rawbuf_head_t * rb)
 {
-	if (rb_dlink_list_length(&rb->list) == 0 && lrb_assert(rb->len == 0))
-		rb->len = 0;
+	if (rb_dlink_list_length(&rb->list) == 0)
+		lrb_assert(rb->len == 0);
 	return rb->len;
 }
 

--- a/librb/src/rb_lib.c
+++ b/librb/src/rb_lib.c
@@ -324,7 +324,7 @@ rb_base64_encode(const unsigned char *str, int length)
 }
 
 unsigned char *
-rb_base64_decode(const unsigned char *str, int length, int *ret)
+rb_base64_decode(const unsigned char *str, size_t length, int *ret)
 {
 	const unsigned char *current = str;
 	int ch, i = 0, j = 0, k;

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('solanum', 'c',
   version: '1.0-dev',
-  default_options: ['c_std=c99', 'warning_level=0'],
+  default_options: ['c_std=gnu17', 'warning_level=0'],
   meson_version: '>=0.62.0', # dependency('dl')
   license: 'GPLv2'
 )
@@ -218,7 +218,12 @@ endif
 conf_data.set_quoted('LT_MODULE_EXT', '.so')
 
 
-c_args = []
+c_args = [
+  '-Wno-unused-parameter',
+  '-Wno-missing-field-initializers',
+  '-Wno-format-zero-length',
+  '-Wno-overlength-strings',
+]
 link_args = []
 
 if get_option('profile')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('solanum', 'c',
   version: '1.0-dev',
-  default_options: ['c_std=c99', 'warning_level=0'],
+  default_options: ['c_std=gnu17', 'warning_level=3'],
   meson_version: '>=0.62.0', # dependency('dl')
   license: 'GPLv2'
 )
@@ -206,7 +206,12 @@ endif
 conf_data.set_quoted('LT_MODULE_EXT', '.so')
 
 
-c_args = []
+c_args = [
+  '-Wno-unused-parameter',
+  '-Wno-missing-field-initializers',
+  '-Wno-format-zero-length',
+  '-Wno-overlength-strings',
+]
 link_args = []
 
 if get_option('profile')

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -243,7 +243,7 @@ m_message(enum message_type msgtype, struct MsgBuf *msgbuf_p,
 	if (msgtype == MESSAGE_TYPE_TAGMSG)
 	{
 		bool found_client_tag = false;
-		for (int i = 0; i < msgbuf_p->n_tags; i++)
+		for (size_t i = 0; i < msgbuf_p->n_tags; i++)
 		{
 			if (*msgbuf_p->tags[i].key == '+')
 			{

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -253,7 +253,7 @@ m_message(enum message_type msgtype, struct MsgBuf *msgbuf_p,
 	if (msgtype == MESSAGE_TYPE_TAGMSG)
 	{
 		bool found_client_tag = false;
-		for (int i = 0; i < msgbuf_p->n_tags; i++)
+		for (size_t i = 0; i < msgbuf_p->n_tags; i++)
 		{
 			if (*msgbuf_p->tags[i].key == '+')
 			{

--- a/modules/core/m_mode.c
+++ b/modules/core/m_mode.c
@@ -415,7 +415,7 @@ do_bmask(bool extended, struct MsgBuf *msgbuf_p, struct Client *client_p, struct
 			}
 
 			if (forward != NULL)
-				forward[-1] = '$';
+				*(forward - 1) = '$';
 
 			*output_ptr++ = parv[3][0];
 			arglen = sprintf(param_ptr, "%s ", mask);

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -150,7 +150,7 @@ clicap_find(const char *data, int *negate, int *finished)
  * Outputs: None
  */
 static void
-clicap_generate(struct Client *source_p, const char *subcmd, int flags)
+clicap_generate(struct Client *source_p, const char *subcmd, uint64_t flags)
 {
 	const char *str_cont = "* :";
 	const char *str_final = ":";
@@ -166,7 +166,7 @@ clicap_generate(struct Client *source_p, const char *subcmd, int flags)
 			(source_p->flags & FLAGS_CLICAP_DATA) ? str_cont : str_final);
 
 	/* shortcut, nothing to do */
-	if (flags == -1 || !multiline_ret) {
+	if (flags == UINT64_MAX || !multiline_ret) {
 		sendto_one(source_p, ":%s CAP %s %s %s",
 				me.name,
 				EmptyString(source_p->name) ? "*" : source_p->name,
@@ -283,7 +283,7 @@ cap_list(struct Client *source_p, const char *arg)
 {
 	/* list of what theyre currently using */
 	clicap_generate(source_p, "LIST",
-			source_p->localClient->client_caps ? source_p->localClient->client_caps : -1);
+			source_p->localClient->client_caps ? source_p->localClient->client_caps : UINT64_MAX);
 }
 
 static void

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -285,10 +285,9 @@ cap_end(struct Client *source_p, const char *arg)
 static void
 cap_list(struct Client *source_p, const char *arg)
 {
-	/* list of what theyre currently using */
+	/* list of what they're currently using */
 	begin_local_response_batch();
-	clicap_generate(source_p, "LIST",
-			source_p->localClient->client_caps ? source_p->localClient->client_caps : -1);
+	clicap_generate(source_p, "LIST", source_p->localClient->client_caps ? 1 : -1);
 }
 
 static void

--- a/tests/chmode1.c
+++ b/tests/chmode1.c
@@ -25,7 +25,7 @@
 #include "ircd_util.h"
 #include "tap/basic.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 static struct Channel *channel;
 static struct Client *client;

--- a/tests/client_util.c
+++ b/tests/client_util.c
@@ -30,7 +30,7 @@
 #include "parse.h"
 #include "listener.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 static struct Listener fake_listener = {
 	.name = "fake",

--- a/tests/hostmask1.c
+++ b/tests/hostmask1.c
@@ -28,7 +28,7 @@
 #include "client.h"
 #include "hostmask.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 

--- a/tests/ircd_util.c
+++ b/tests/ircd_util.c
@@ -29,7 +29,7 @@
 #include "client.h"
 #include "modules.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 extern int solanum_main(int argc, const char *argv[]);
 

--- a/tests/labeled_response1.c
+++ b/tests/labeled_response1.c
@@ -34,7 +34,7 @@
 #include "s_newconf.h"
 #include "s_user.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 #define LONG_VALUE_50 "12345678901234567890123456789012345678901234567890"
 #define LONG_VALUE_100 LONG_VALUE_50 LONG_VALUE_50
 #define LONG_VALUE_200 LONG_VALUE_100 LONG_VALUE_100

--- a/tests/match1.c
+++ b/tests/match1.c
@@ -26,7 +26,7 @@
 #include "client.h"
 #include "match.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 

--- a/tests/misc.c
+++ b/tests/misc.c
@@ -6,7 +6,7 @@
 
 #include "s_newconf.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 #define MINUTE (60)
 #define HOUR (MINUTE * 60)

--- a/tests/msgbuf_parse1.c
+++ b/tests/msgbuf_parse1.c
@@ -28,7 +28,7 @@
 #include "msgbuf.h"
 #include "client.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 static char tmp[10240];

--- a/tests/msgbuf_unparse1.c
+++ b/tests/msgbuf_unparse1.c
@@ -28,7 +28,7 @@
 #include "msgbuf.h"
 #include "client.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 static const char text[] =
@@ -247,7 +247,7 @@ static void no_tags(void)
 {
 	const struct MsgBuf msgbuf = {
 		.n_tags = 0,
-		.tags = {},
+		.tags = { { 0 } },
 
 		.cmd = "PRIVMSG",
 		.origin = "origin",

--- a/tests/privilege1.c
+++ b/tests/privilege1.c
@@ -26,7 +26,7 @@
 #include "client.h"
 #include "privilege.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 void privilegeset_add_privs(struct PrivilegeSet *dst, const char *privs);
 

--- a/tests/rb_dictionary1.c
+++ b/tests/rb_dictionary1.c
@@ -27,7 +27,7 @@
 #include "ircd_defs.h"
 #include "client.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 #define MKTEXT(n) &text[sizeof(text) - ((n) + 1)]
 
@@ -38,15 +38,6 @@ static void replace1(void)
 
 	ok(original != NULL, MSG);
 	is_string("data1", original->data, MSG);
-
-#ifdef SOFT_ASSERT
-	rb_dictionary_element *replacement = rb_dictionary_add(dict, "test", "data2");
-
-	ok(replacement != NULL, MSG);
-	ok(original == replacement, MSG);
-
-	is_string("data2", original->data, MSG);
-#endif
 }
 
 int main(int argc, char *argv[])

--- a/tests/rb_snprintf_append1.c
+++ b/tests/rb_snprintf_append1.c
@@ -28,7 +28,7 @@
 #include "client.h"
 #include "rb_lib.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 

--- a/tests/rb_snprintf_try_append1.c
+++ b/tests/rb_snprintf_try_append1.c
@@ -28,7 +28,7 @@
 #include "client.h"
 #include "rb_lib.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 

--- a/tests/sasl_abort1.c
+++ b/tests/sasl_abort1.c
@@ -17,7 +17,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
  *  USA
  */
-#define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdio.h>
@@ -34,7 +33,7 @@
 #include "s_newconf.h"
 #include "hash.h"
 
-#define MSG "%s:%d (%s; aborted=%d)", __FILE__, __LINE__, __FUNCTION__, aborted
+#define MSG "%s:%d (%s; aborted=%d)", __FILE__, __LINE__, __func__, aborted
 
 static void common_sasl_test(bool aborted)
 {

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -31,7 +31,7 @@
 #include "monitor.h"
 #include "s_conf.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 // What time is it?
 #define ADVENTURE_TIME "2017-07-14T02:40:00.000Z"

--- a/tests/send_multiline1.c
+++ b/tests/send_multiline1.c
@@ -31,7 +31,7 @@
 #include "s_conf.h"
 #include "hash.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 static void sendto_multiline_basic(void)
 {

--- a/tests/serv_connect1.c
+++ b/tests/serv_connect1.c
@@ -17,13 +17,13 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
  *  USA
  */
-#define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/socket.h>
 #include "tap/basic.h"
 
 #include "ircd_util.h"
@@ -36,13 +36,13 @@
 
 #include "rb_lib.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 static rb_fde_t *last_F = NULL;
 static CNCB *last_connect_callback = NULL;
 static void *last_connect_data = NULL;
 
-int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+int connect(int sockfd, __CONST_SOCKADDR_ARG addr, socklen_t addrlen)
 {
 	printf("# connect(%d, ...)\n", sockfd);
 	errno = EINPROGRESS;
@@ -51,13 +51,14 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 
 void rb_connect_tcp(rb_fde_t *F, struct sockaddr *dest, struct sockaddr *clocal, CNCB *callback, void *data, int timeout)
 {
-	printf("# rb_connect_tcp(%p, ...)\n", F);
+	printf("# rb_connect_tcp(%p, ...)\n", (void *)F);
 
 	last_F = F;
 	last_connect_callback = callback;
 	last_connect_data = data;
 
-	void *(*func)(rb_fde_t *, struct sockaddr *, struct sockaddr *, CNCB *, void *, int) = dlsym(RTLD_NEXT, "rb_connect_tcp");
+	void *(*func)(rb_fde_t *, struct sockaddr *, struct sockaddr *, CNCB *, void *, int);
+	*(void **)(&func) = dlsym(RTLD_NEXT, "rb_connect_tcp");
 	func(F, dest, clocal, callback, data, timeout);
 }
 

--- a/tests/substitution1.c
+++ b/tests/substitution1.c
@@ -28,7 +28,7 @@
 #include "client.h"
 #include "substitution.h"
 
-#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __func__
 
 struct Client me;
 static const char text[] =


### PR DESCRIPTION
The overall goal of this branch is to fix all compiler warnings so that the meson build can run with -Wall -Wextra -pedantic -Werror and compile cleanly (corresponds to --warnlevel 3 --werror in meson flags). I did need to turn off warnings about unused parameters in meson.build as part of this because [[maybe_unused]] and/or unnamed function parameters in definitions is a C23 feature which is unfortunately still a bit *too* new of a C standard for GCC as shipped by supported OSes. Other categories of warnings were disabled because they are fully-conformant standard C but GCC just doesn't like them: missing field initializers (standard C will zero-init any missing fields which is what we want in every case we're doing this), empty format strings (needed in a small handful of cases), and "overlong strings" in test code.

C17 is supported by GCC shipped by all modern OSes (Debian 12+, Ubuntu 24.02+, and Alma/Rocky 9+), and buys us some neat features like anonymous structs/unions that later changes may use. Specifically, meson was changed to use the gnu17 variant since we make use of a handful of GNU extensions (and unconditionally define _GNU_SOURCE). Using gnu17 instead of c17 shuts up some pedantic warnings about strict compliance to the C99 standard which are not possible to shut up in a standards-compliant way until C23.

SOFT_ASSERT support was removed because it was not supported by the meson build system anyway, and cleaning up that code resolved some warnings about unused values due to the comma operator in the case it was not defined. As was discussed on IRC, if a soft assertion fails the ircd would almost certainly core in short order anyway due to the violation of preconditions.