### PR TITLE
Implementation of labeled-response

### DIFF
--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -1093,19 +1093,28 @@ Hook functions can manipulate the message tags that would be sent by modifying
 the passed-in data. This hook is only called once per outbound message,
 regardless of how many clients the message will be sent to.
 
-Hook data: `hook_data *`
+Hook data: `hook_data_outbound_msgbuf *`
 
 Fields:
 
-- client (`struct Client *`): The client sending the message
-- arg1 (`struct MsgBuf *`): The message buffer being sent
-- arg2 (`void *`): Unused (always `NULL`)
+- source (`struct Client *`): The client sending the message
+- msgbuf (`struct MsgBuf *`): The message buffer being sent
+- target (`struct Client *`): The single client receiving the message or `NULL`
+- chptr (`struct Channel *`): The channel receiving the message or `NULL`
+- source_sees_message (`bool`): Whether the client sending the message will also receive it
 
-Hook functions can inspect `arg1` and modify it. Any modifications such as the
+Hook functions can inspect `msgbuf` and modify it. Any modifications such as the
 addition or removal of message tags will be sent to the targets of the
 message. To add message tags, call msgbuf_append_tag. To remove tags, set the
 tag's `capmask` to 0. Changing other aspects of the MsgBuf such as the origin
 or parameter array is not recommended and may not function as expected.
+
+The target field will be non-`NULL` when the message is being sent to a single
+client and will be `NULL` for messages sent to channels or that are broadcast
+to potentially many clients. The chptr field will be non-`NULL` when the
+message is being sent to a single channel and will be `NULL` for messages not
+sent to channels or that are sent to everyone in multiple channels. Both
+fields will be `NULL` for broadcast-type messages.
 
 The following send functions currently do not call this hook:
 

--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -11,8 +11,8 @@ module or define a new hook in a module, see `extensions/example_module.c`.
 | Module     | Hook name                      | Description                                               |
 |------------|--------------------------------|-----------------------------------------------------------|
 | Core       | after_client_exit              | A user has left the server                                |
-| Core       | burst_client                   | A user was sent to a remote server during a netjoin       |
 | Core       | burst_channel                  | A channel was sent to a remote server during a netjoin    |
+| Core       | burst_client                   | A user was sent to a remote server during a netjoin       |
 | Core       | burst_finished                 | We finished bursting users/channels during a netjoin      |
 | Core       | can_join                       | A local user is about to join a channel                   |
 | Core       | can_kick                       | A user is about to be kicked from a channel               |
@@ -28,6 +28,7 @@ module or define a new hook in a module, see `extensions/example_module.c`.
 | Core       | new_local_user                 | A user connected locally, before introducing to network   |
 | Core       | new_remote_user                | A remote user was introduced, before propagating onward   |
 | Core       | outbound_msgbuf                | A message is about to be sent to one or more targets      |
+| Core       | parse_end                      | We have finished processing an incoming message           |
 | Core       | priv_change                    | An oper's privset changed                                 |
 | Core       | privmsg_channel                | A message or PART is about to be sent to a channel        |
 | Core       | privmsg_user                   | A message is about to be sent to a user                   |
@@ -1110,6 +1111,19 @@ The following send functions currently do not call this hook:
 
 - kill_client
 - kill_client_serv_butone
+
+### parse_end
+
+This hook is called after we have processed an incoming message, including
+sending all relevant responses.
+
+Hook data: always `NULL`
+
+The global state variables `incoming_client` and `incoming_message` are still
+defined at the time this hook is executed. If sending messages from this hook,
+ensure that you choose a priority lower than `HOOK_HIGHEST`; any messages sent
+from hook functions with `HOOK_HIGHEST` or `HOOK_MONITOR` will not have proper
+context for labeled-response.
 
 ### priv_change
 

--- a/extensions/cap_oper.c
+++ b/extensions/cap_oper.c
@@ -66,20 +66,20 @@ cap_oper_oper_visible(struct Client *client)
 static void
 cap_oper_outbound_msgbuf(void *data_)
 {
-	hook_data *data = data_;
-	struct MsgBuf *msgbuf = data->arg1;
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
 
-	if (data->client == NULL || !IsPerson(data->client))
+	if (data->source == NULL || !IsPerson(data->source))
 		return;
 
-	if (IsOper(data->client))
+	if (IsOper(data->source))
 	{
 		/* send all oper data to auspex */
-		msgbuf_append_tag(msgbuf, "solanum.chat/oper", data->client->user->opername, CLICAP_OPER_AUSPEX);
-		if (HasPrivilege(data->client, "oper:hidden") || ConfigFileEntry.hide_opers)
+		msgbuf_append_tag(msgbuf, "solanum.chat/oper", data->source->user->opername, CLICAP_OPER_AUSPEX);
+		if (HasPrivilege(data->source, "oper:hidden") || ConfigFileEntry.hide_opers)
 			/* these people aren't allowed to see hidden opers */
 			return;
-		msgbuf_append_tag(msgbuf, "solanum.chat/oper", data->client->user->opername, CLICAP_OPER_JUSTOPER);
+		msgbuf_append_tag(msgbuf, "solanum.chat/oper", data->source->user->opername, CLICAP_OPER_JUSTOPER);
 		msgbuf_append_tag(msgbuf, "solanum.chat/oper", NULL, CLICAP_OPER_NORMAL);
 	}
 }

--- a/extensions/cap_realhost.c
+++ b/extensions/cap_realhost.c
@@ -61,20 +61,20 @@ cap_oper_realhost_visible(struct Client *client)
 static void
 cap_realhost_outbound_msgbuf(void *data_)
 {
-	hook_data *data = data_;
-	struct MsgBuf *msgbuf = data->arg1;
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
 
-	if (data->client == NULL || !IsPerson(data->client))
+	if (data->source == NULL || !IsPerson(data->source))
 		return;
 
-	if (!IsIPSpoof(data->client) && !EmptyString(data->client->sockhost) && strcmp(data->client->sockhost, "0"))
+	if (!IsIPSpoof(data->source) && !EmptyString(data->source->sockhost) && strcmp(data->source->sockhost, "0"))
 	{
-		msgbuf_append_tag(msgbuf, "solanum.chat/ip", data->client->sockhost,
-				IsDynSpoof(data->client) ? CLICAP_OPER_REALHOST : CLICAP_REALHOST);
+		msgbuf_append_tag(msgbuf, "solanum.chat/ip", data->source->sockhost,
+				IsDynSpoof(data->source) ? CLICAP_OPER_REALHOST : CLICAP_REALHOST);
 	}
 
-	if (!EmptyString(data->client->orighost))
-		msgbuf_append_tag(msgbuf, "solanum.chat/realhost", data->client->orighost, CLICAP_OPER_REALHOST);
+	if (!EmptyString(data->source->orighost))
+		msgbuf_append_tag(msgbuf, "solanum.chat/realhost", data->source->orighost, CLICAP_OPER_REALHOST);
 }
 
 static inline void

--- a/extensions/identify_msg.c
+++ b/extensions/identify_msg.c
@@ -19,10 +19,10 @@ static mapi_hfn_list_av1 identmsg_hfnlist[] = {
 
 static void identmsg_outbound(void *data_)
 {
-	hook_data *data = data_;
-	struct MsgBuf *msgbuf = data->arg1;
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
 
-	if (IsIdentified(data->client))
+	if (IsIdentified(data->source))
 		msgbuf_append_tag(msgbuf, "solanum.chat/identified", NULL, CLICAP_IDENTIFY_MSG);
 }
 

--- a/extensions/m_echotags.c
+++ b/extensions/m_echotags.c
@@ -2,6 +2,7 @@
 #include "modules.h"
 #include "client.h"
 #include "ircd.h"
+#include "response.h"
 #include "send.h"
 
 static void m_echotags(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[]);
@@ -20,6 +21,7 @@ DECLARE_MODULE_AV2(echotags, NULL, NULL, echotags_clist, NULL, NULL, NULL, NULL,
 static void
 m_echotags(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
+	begin_local_response_batch();
 	sendto_one_notice(source_p, ":*** You sent %zu tags.", msgbuf_p->n_tags);
 
 	for (size_t i = 0; i < msgbuf_p->n_tags; i++)

--- a/extensions/m_findforwards.c
+++ b/extensions/m_findforwards.c
@@ -33,6 +33,7 @@
 #include "modules.h"
 #include "packet.h"
 #include "messages.h"
+#include "response.h"
 
 static const char findfowards_desc[] = "Allows operators to find forwards to a given channel";
 
@@ -87,6 +88,7 @@ m_findforwards(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *
 			last_used = rb_current_time();
 	}
 
+	begin_local_response_batch();
 	send_multiline_init(source_p, " ", ":%s NOTICE %s :Forwards for %s: ",
 			me.name,
 			source_p->name,

--- a/extensions/m_ojoin.c
+++ b/extensions/m_ojoin.c
@@ -34,6 +34,7 @@
 #include "parse.h"
 #include "modules.h"
 #include "messages.h"
+#include "response.h"
 
 static const char ojoin_desc[] = "Allow admins to forcibly join channels with the OJOIN command";
 
@@ -86,6 +87,8 @@ mo_ojoin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	if(move_me == 1)
 		parv[1]--;
+
+	begin_local_response_batch();
 
 	sendto_wallops_flags(UMODE_WALLOP, &me,
 			     "OJOIN called for %s by %s!%s@%s",

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -52,6 +52,7 @@
 #include "hash.h"
 #include "s_conf.h"
 #include "reject.h"
+#include "response.h"
 
 static const char webirc_desc[] = "Adds support for the WebIRC system";
 
@@ -155,6 +156,7 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 
 	if (secure && !IsSecure(source_p))
 	{
+		begin_local_response_batch();
 		sendto_one(source_p, "NOTICE * :CGI:IRC is not connected securely; marking you as insecure");
 		secure = 0;
 	}

--- a/help/opers/notice
+++ b/help/opers/notice
@@ -16,7 +16,7 @@ $$servermask - Send a message to a server or set of
 $#hostmask   - Send a message to users matching the
                hostmask specified.
 
-These two are operator only.
+These two require Oper Priv: oper:mass_notice
 
 The nick can be extended to fit into the following
 syntax:
@@ -24,12 +24,4 @@ syntax:
 username@servername
 
 This syntax is used to securely send a message to a
-service or a bot.
-
-An extension of this is the syntax to send to all opers
-on a server.
-
-opers@servername
-
-In Hybrid 7, all opers on a server will see a message that
-looks like a modified WALLOPS
+network service.

--- a/help/opers/privmsg
+++ b/help/opers/privmsg
@@ -24,12 +24,4 @@ syntax:
 username@servername
 
 This syntax is used to securely send a message to a
-service or a bot.
-
-An extension of this is the syntax to send to all opers
-on a server.
-
-opers@servername
-
-In Hybrid 7, all opers on a server will see a message that
-looks like a modified WALLOPS
+network service.

--- a/include/batch.h
+++ b/include/batch.h
@@ -36,6 +36,8 @@
  * The child_allowed field is ignored and never called if this is set. */
 #define BATCH_FLAG_ALLOW_ALL 0x02
 
+struct ResponseInfo;
+
 struct Batch
 {
 	/* server-generated batch ID (15 random characters + trailing null byte) */
@@ -58,6 +60,8 @@ struct Batch
 	unsigned int len;
 	/* A linked list of struct BatchMessage * for each message inside of the batch */
 	rb_dlink_list messages;
+	/* labeled-response context for this batch */
+	struct ResponseInfo *response_info;
 };
 
 struct BatchMessage

--- a/include/client.h
+++ b/include/client.h
@@ -279,6 +279,7 @@ struct LocalUser
 
 	uint32_t pending_batch_lines;	/* number of lines held in pending client-initiated batches */
 	rb_dlink_list pending_batches;	/* batches this client started but did not finish */
+	rb_dlink_list pending_remote_responses; /* labeled-response replies we're awaiting from remote servers */
 };
 
 #define AUTHC_F_DEFERRED 0x01
@@ -308,12 +309,21 @@ struct PreClient
 	char id[IDLEN]; /* UID/SID, unique on the network (unverified) */
 };
 
+struct ResponseInfo;
+
 struct ListClient
 {
-	char *chname, *mask, *nomask;
-	unsigned int users_min, users_max;
-	time_t created_min, created_max, topic_min, topic_max;
+	char *chname;
+	char *mask;
+	char *nomask;
+	unsigned int users_min;
+	unsigned int users_max;
+	time_t created_min;
+	time_t created_max;
+	time_t topic_min;
+	time_t topic_max;
 	int operspy;
+	struct ResponseInfo *response_info;
 };
 
 /*

--- a/include/hook.h
+++ b/include/hook.h
@@ -64,6 +64,7 @@ extern int h_priv_change;
 extern int h_cap_change;
 extern int h_message_tag;
 extern int h_message_handler;
+extern int h_parse_end;
 
 void init_hook(void);
 int register_hook(const char *name);

--- a/include/hook.h
+++ b/include/hook.h
@@ -202,6 +202,15 @@ enum message_type {
 
 typedef struct
 {
+	struct Client *source;
+	struct MsgBuf *msgbuf;
+	struct Client *target;
+	struct Channel *chptr;
+	bool source_sees_message;
+} hook_data_outbound_msgbuf;
+
+typedef struct
+{
 	enum message_type msgtype;
 	struct Client *source_p;
 	struct Channel *chptr;

--- a/include/response.h
+++ b/include/response.h
@@ -42,6 +42,8 @@ struct ResponseInfo
 	bool sent;
 	/* while this is >0, outgoing messages will not be tagged with label/batch even if they otherwise would */
 	int skip_tags;
+	/* for remote batches, the server mask dictating which servers we are expecting responses from */
+	char mask[HOSTLEN + 1];
 };
 
 /* state of an outgoing labeled-response */
@@ -57,9 +59,11 @@ void begin_local_response_batch(void);
 
 /* send a labeled-response BATCH to the incoming client for replies that will be generated at least partially
  * by remote servers. server_count must be the number of servers expected to send responses back.
- * If a batch is already opened, adds server_count to the number of servers we're expecting responses from.
+ * mask must be a string (potentially containing * and ? wildcards) that matches servers we need responses from.
+ * If a local batch is already opened, transforms it into a remote batch.
+ * Calling on an existing remote batch is an error.
  */
-void begin_remote_response_batch(int server_count);
+void begin_remote_response_batch(int server_count, const char *mask);
 
 /* Get details for a labeled-response batch with the specified batch ID */
 struct ResponseInfo *get_remote_response_batch(const char *batch);

--- a/include/response.h
+++ b/include/response.h
@@ -1,0 +1,75 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * response.h: header for labeled-response support
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef INCLUDED_response_h
+#define INCLUDED_response_h
+
+struct Client;
+
+struct ResponseInfo
+{
+	/* local client to reach source_p by */
+	struct Client *client_p;
+	/* client to send the labeled-response to */
+	struct Client *source_p;
+	/* client-specified label; empty string if none specified or source_p is remote */
+	char label[65];
+	/* the batch id of the response batch; empty string if not batched */
+	char batch[20];
+	/* number of remote servers we are expecting to receive responses from */
+	int remote_response;
+	/* if remote_response is nonzero, time that we stop waiting for a remote response and close the batch */
+	time_t expires;
+	/* whether a response has already been sent to the local client */
+	bool sent;
+	/* while this is >0, outgoing messages will not be tagged with label/batch even if they otherwise would */
+	int skip_tags;
+};
+
+/* state of an outgoing labeled-response */
+extern struct ResponseInfo *outgoing_response_info;
+
+/* initialize labeled-response memory */
+void init_response(void);
+
+/* send a labeled-response BATCH to the incoming client for replies that will be generated entirely locally.
+ * No-op if a batch is already opened.
+ */
+void begin_local_response_batch(void);
+
+/* send a labeled-response BATCH to the incoming client for replies that will be generated at least partially
+ * by remote servers. server_count must be the number of servers expected to send responses back.
+ * If a batch is already opened, adds server_count to the number of servers we're expecting responses from.
+ */
+void begin_remote_response_batch(int server_count);
+
+/* Get details for a labeled-response batch with the specified batch ID */
+struct ResponseInfo *get_remote_response_batch(const char *batch);
+
+/* Free memory and clean up references to a pending labeled-response batch */
+void free_response_batch(struct ResponseInfo *response);
+
+/* Count the number of servers matching a given glob mask and capabilities, except for servers in the direction of one
+ * This helps provide an accurate count for begin_remote_response_batch() when broadcasting to multiple servers
+ */
+int count_match_servs(struct Client *one, const char *mask, uint64_t cap, uint64_t negcap);
+
+#endif /* INCLUDED_response_h */

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -48,10 +48,12 @@ struct Channel;
 /* Capabilities */
 extern struct CapabilityIndex *serv_capindex;
 extern struct CapabilityIndex *cli_capindex;
+extern uint64_t serv_clicapmask;
 
 /* register client capabilities with this structure for 3.2 enhanced capability negotiation */
 #define CLICAP_FLAGS_STICKY    0x001
 #define CLICAP_FLAGS_PRIORITY  0x002
+#define CLICAP_FLAGS_NOPROP    0x004
 
 struct ClientCapability {
 	bool (*visible)(struct Client *);		/* whether or not to display the capability.  set to NULL or true return value = displayed */
@@ -60,6 +62,7 @@ struct ClientCapability {
 };
 
 /* builtin client capabilities */
+extern uint64_t CLICAP_SERVONLY;           /* for s2s-only message tag propagation; no client ever has this cap */
 extern uint64_t CLICAP_MULTI_PREFIX;
 extern uint64_t CLICAP_ACCOUNT_NOTIFY;
 extern uint64_t CLICAP_EXTENDED_JOIN;
@@ -104,11 +107,11 @@ extern uint64_t CAP_STAG;			/* supports s2s tags and TAGMSG */
 /*
  * Capability macros.
  */
-#define IsClientCapable(x, cap)         (((x)->localClient->client_caps & (cap)) == cap)
+#define IsClientCapable(x, cap)         (((x)->localClient->client_caps & (cap)) == (cap))
 #define NotClientCapable(x, cap)        (((x)->localClient->client_caps & (cap)) == 0)
 #define SetClientCap(x, cap)            ((x)->localClient->client_caps |= (cap))
 #define ClearClientCap(x, cap)          ((x)->localClient->client_caps &= ~(cap))
-#define IsServerCapable(x, cap)         (((x)->localClient->server_caps & (cap)) == cap)
+#define IsServerCapable(x, cap)         (((x)->localClient->server_caps & (cap)) == (cap))
 #define NotServerCapable(x, cap)        (((x)->localClient->server_caps & (cap)) == 0)
 #define SetServerCap(x, cap)            ((x)->localClient->server_caps |= (cap))
 #define ClearServerCap(x, cap)          ((x)->localClient->server_caps &= ~(cap))

--- a/include/s_stats.h
+++ b/include/s_stats.h
@@ -66,6 +66,9 @@ struct ServerStatistics
 	unsigned int is_sbad;	/* failed sasl authentications */
 	unsigned int is_tgch;	/* messages blocked due to target change */
 	unsigned int is_rl;     /* commands blocked due to ratelimit */
+	unsigned int is_cib;    /* number of open client-initiated batches */
+	unsigned int is_cibl;   /* number of queued lines in open client-initiated batches */
+	unsigned int is_rrb;    /* number of open remote response batches */
 };
 
 extern struct ServerStatistics ServerStats;

--- a/ircd/Makefile.am
+++ b/ircd/Makefile.am
@@ -48,6 +48,7 @@ libircd_la_SOURCES =                  \
   privilege.c                   \
   ratelimit.c			\
   reject.c                      \
+  response.c                    \
   restart.c                     \
   s_conf.c                      \
   s_newconf.c                   \

--- a/ircd/batch.c
+++ b/ircd/batch.c
@@ -22,6 +22,7 @@
 #include "stdinc.h"
 #include "batch.h"
 #include "rb_dictionary.h"
+#include "response.h"
 
 static rb_dictionary *handlers = NULL;
 
@@ -65,9 +66,6 @@ generate_batch_id(char *buf, size_t size)
 {
 	static const char *alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-A";
 
-	if (size > BATCH_ID_LEN + 1)
-		size = BATCH_ID_LEN + 1;
-
 	for (size_t i = 0; i < size - 1; i++)
 		buf[i] = alphabet[rand() % 64];
 
@@ -109,6 +107,7 @@ batch_free(struct Batch *batch)
 		batch_free(child);
 	}
 
+	free_response_batch(batch->response_info);
 	rb_free(batch->start->data);
 	rb_free(batch->start);
 	rb_free(batch);

--- a/ircd/batch.c
+++ b/ircd/batch.c
@@ -122,8 +122,12 @@ allocate_batch_message(struct MsgBuf *msg)
 
 	for (int i = 0; i < msg->n_tags; i++)
 	{
+		if (msg->tags[i].key == NULL)
+			continue;
+
 		len += strlen(msg->tags[i].key) + 1;
-		len += strlen(msg->tags[i].value) + 1;
+		if (msg->tags[i].value != NULL)
+			len += strlen(msg->tags[i].value) + 1;
 	}
 
 	for (int i = 0; i < msg->n_para; i++)
@@ -146,15 +150,27 @@ allocate_batch_message(struct MsgBuf *msg)
 
 	copy->msg.n_tags = msg->n_tags;
 	copy->msg.tagslen = msg->tagslen;
-	for (int i = 0; i < msg->n_tags; i++)
+	for (int i = 0, j = 0; i < msg->n_tags; i++)
 	{
+		if (msg->tags[i].key == NULL)
+		{
+			copy->msg.n_tags--;
+			continue;
+		}
+
 		strcpy(c, msg->tags[i].key);
-		copy->msg.tags[i].key = c;
+		copy->msg.tags[j].key = c;
 		c += strlen(c) + 1;
 
-		strcpy(c, msg->tags[i].value);
-		copy->msg.tags[i].value = c;
-		c += strlen(c) + 1;
+		if (msg->tags[i].value != NULL)
+		{
+			strcpy(c, msg->tags[i].value);
+			copy->msg.tags[j].value = c;
+			c += strlen(c) + 1;
+		}
+
+		copy->msg.tags[j].capmask = msg->tags[i].capmask;
+		j++;
 	}
 
 	copy->msg.n_para = msg->n_para;

--- a/ircd/capability.c
+++ b/ircd/capability.c
@@ -22,6 +22,7 @@
 #include "capability.h"
 #include "rb_dictionary.h"
 #include "s_assert.h"
+#include "s_serv.h"
 
 static rb_dlink_list capability_indexes = { NULL, NULL, 0 };
 
@@ -72,6 +73,14 @@ capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 			s_assert(entry->ownerdata == NULL);
 			entry->ownerdata = ownerdata;
 		}
+
+		if (idx == cli_capindex
+			&& entry->ownerdata != NULL
+			&& (((struct ClientCapability *)entry->ownerdata)->flags & CLICAP_FLAGS_NOPROP) == CLICAP_FLAGS_NOPROP)
+		{
+			serv_clicapmask &= ~(1ull << entry->value);
+		}
+
 		return (1ull << entry->value);
 	}
 
@@ -86,6 +95,13 @@ capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 	idx->highest_bit++;
 	if (idx->highest_bit % (sizeof(uint64_t) * 8) == 0)
 		idx->highest_bit = 0;
+
+	if (idx == cli_capindex
+			&& entry->ownerdata != NULL
+			&& (((struct ClientCapability *)entry->ownerdata)->flags & CLICAP_FLAGS_NOPROP) == CLICAP_FLAGS_NOPROP)
+	{
+		serv_clicapmask &= ~(1ull << entry->value);
+	}
 
 	return (1ull << entry->value);
 }
@@ -115,6 +131,13 @@ capability_orphan(struct CapabilityIndex *idx, const char *cap)
 	entry = rb_dictionary_retrieve(idx->cap_dict, cap);
 	if (entry != NULL)
 	{
+		if (idx == cli_capindex
+			&& entry->ownerdata != NULL
+			&& (((struct ClientCapability *)entry->ownerdata)->flags & CLICAP_FLAGS_NOPROP) == CLICAP_FLAGS_NOPROP)
+		{
+			serv_clicapmask |= 1ull << entry->value;
+		}
+
 		entry->flags &= ~CAP_REQUIRED;
 		entry->flags |= CAP_ORPHANED;
 		entry->ownerdata = NULL;

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -53,6 +53,7 @@
 #include "rb_dictionary.h"
 #include "sslproc.h"
 #include "s_assert.h"
+#include "response.h"
 
 #define DEBUG_EXITED_CLIENTS
 
@@ -1718,6 +1719,7 @@ exit_client(struct Client *client_p,	/* The local client originating the
 	)
 {
 	int ret = -1;
+	rb_dlink_node *ptr, *nptr;
 
 	hook_data_client_exit hdata;
 	if(IsClosing(source_p))
@@ -1745,6 +1747,11 @@ exit_client(struct Client *client_p,	/* The local client originating the
 		/* IsUnknown || IsConnecting || IsHandShake */
 		else if(!IsReject(source_p))
 			ret = exit_unknown_client(client_p, source_p, from, comment);
+
+		RB_DLINK_FOREACH_SAFE(ptr, nptr, source_p->localClient->pending_remote_responses.head)
+		{
+			free_response_batch(ptr->data);
+		}
 	}
 	else
 	{

--- a/ircd/hook.c
+++ b/ircd/hook.c
@@ -75,6 +75,7 @@ int h_priv_change;
 int h_cap_change;
 int h_message_tag;
 int h_message_handler;
+int h_parse_end;
 
 void
 init_hook(void)
@@ -103,6 +104,7 @@ init_hook(void)
 	h_cap_change = register_hook("cap_change");
 	h_message_tag = register_hook("message_tag");
 	h_message_handler = register_hook("message_handler");
+	h_parse_end = register_hook("parse_end");
 }
 
 /* grow_hooktable()

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -64,6 +64,7 @@
 #include "bandbi.h"
 #include "authproc.h"
 #include "operhash.h"
+#include "response.h"
 
 static void
 ircd_die_cb(const char *str) __attribute__((noreturn));
@@ -659,6 +660,7 @@ solanum_main(int argc, char * const argv[])
 	init_reject();
 	init_cache();
 	init_monitor();
+	init_response();
 
         construct_cflags_strings();
 

--- a/ircd/meson.build
+++ b/ircd/meson.build
@@ -54,6 +54,7 @@ libircd_sources = files(
   'privilege.c',
   'ratelimit.c',
   'reject.c',
+  'response.c',
   'restart.c',
   's_conf.c',
   's_newconf.c',

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -137,29 +137,6 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 		return;
 	}
 
-	if(IsDigit(*msgbuf.cmd) && IsDigit(*(msgbuf.cmd + 1)) && IsDigit(*(msgbuf.cmd + 2)))
-	{
-		mptr = NULL;
-		numeric = atoi(msgbuf.cmd);
-		ServerStats.is_num++;
-	}
-	else
-	{
-		mptr = rb_dictionary_retrieve(cmd_dict, msgbuf.cmd);
-
-		/* no command or its encap only, error */
-		if(!mptr || !mptr->cmd)
-		{
-			if(IsPerson(from))
-			{
-				sendto_one(from, form_str(ERR_UNKNOWNCOMMAND),
-					   me.name, from->name, msgbuf.cmd);
-			}
-			ServerStats.is_unco++;
-			return;
-		}
-	}
-
 	/* The tags array may be mutated via hooks; this holds the updated array */
 	struct MsgBuf updated_msg;
 	int ntags = msgbuf.n_tags;
@@ -207,7 +184,10 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 			break;
 
 		case MESSAGE_TAG_DROP:
-			/* entire message is rejected, don't send at all */
+			/* entire message is rejected, don't send at all;
+			 * call parse_end in case any cleanup is needed for tags already processed
+			 */
+			call_hook(h_parse_end, NULL);
 			return;
 		}
 	}
@@ -217,9 +197,30 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 	incoming_message = &updated_msg;
 	incoming_client = client_p;
 
-	if (mptr == NULL)
+	if (IsDigit(*msgbuf.cmd) && IsDigit(*(msgbuf.cmd + 1)) && IsDigit(*(msgbuf.cmd + 2)))
+	{
+		mptr = NULL;
+		numeric = atoi(msgbuf.cmd);
+		ServerStats.is_num++;
+	}
+	else
+	{
+		mptr = rb_dictionary_retrieve(cmd_dict, msgbuf.cmd);
+		numeric = -1;
+	}
+
+	if (numeric != -1)
 	{
 		do_numeric(numeric, client_p, from, &updated_msg);
+	}
+	else if (!mptr || !mptr->cmd)
+	{
+		/* no command or its encap only, error */
+		if (IsPerson(from))
+			sendto_one(from, form_str(ERR_UNKNOWNCOMMAND),
+				   me.name, from->name, msgbuf.cmd);
+
+		ServerStats.is_unco++;
 	}
 	else if (handle_command(mptr, &updated_msg, client_p, from) < -1)
 	{
@@ -244,6 +245,8 @@ parse(struct Client *client_p, char *pbuffer, char *bufend)
 				     p[6], p[7], p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
 		}
 	}
+
+	call_hook(h_parse_end, NULL);
 
 	incoming_message = NULL;
 	incoming_client = NULL;

--- a/ircd/response.c
+++ b/ircd/response.c
@@ -25,6 +25,7 @@
 #include "client.h"
 #include "response.h"
 #include "send.h"
+#include "s_assert.h"
 #include "s_serv.h"
 
 /* number of seconds we'll wait for remote servers to finish sending their responses
@@ -93,16 +94,17 @@ begin_local_response_batch(void)
 }
 
 void
-begin_remote_response_batch(int server_count)
+begin_remote_response_batch(int server_count, const char *mask)
 {
 	if (outgoing_response_info == NULL || !MyConnect(outgoing_response_info->source_p))
 		return;
 
 	if (EmptyString(outgoing_response_info->batch))
 	{
-		/* creating a new remote response batch */
+		/* creating a new response batch */
 		generate_batch_id(outgoing_response_info->batch, sizeof(outgoing_response_info->batch));
 		outgoing_response_info->remote_response = server_count;
+		rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
 		outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
 		rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
 		rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
@@ -111,16 +113,14 @@ begin_remote_response_batch(int server_count)
 	}
 	else
 	{
-		/* increase the number of servers we're expecting responses from */
-		outgoing_response_info->remote_response += server_count;
+		/* can only upgrade local batches to remote */
+		s_assert(outgoing_response_info->remote_response == 0);
 
-		/* if we're upgrading a local batch to a remote batch, add it to tracking places */
-		if (outgoing_response_info->expires == 0)
-		{
-			outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
-			rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
-			rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
-		}
+		outgoing_response_info->remote_response += server_count;
+		rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
+		outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
+		rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
+		rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
 	}
 }
 
@@ -167,7 +167,7 @@ count_match_servs(struct Client *one, const char *mask, uint64_t cap, uint64_t n
 	RB_DLINK_FOREACH(ptr, global_serv_list.head)
 	{
 		struct Client *target_p = ptr->data;
-		if (target_p == &me)
+		if (IsMe(target_p))
 			continue;
 
 		if (target_p->from == one->from)

--- a/ircd/response.c
+++ b/ircd/response.c
@@ -1,0 +1,189 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * response.c: labeled-response helpers
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "rb_dictionary.h"
+#include "batch.h"
+#include "client.h"
+#include "response.h"
+#include "send.h"
+#include "s_serv.h"
+
+/* number of seconds we'll wait for remote servers to finish sending their responses
+ * before we abort a pending remote labeled-response batch
+ */
+#define RESPONSE_EXPIRY 10
+
+struct ResponseInfo *outgoing_response_info;
+static rb_dictionary *pending_responses;
+
+static int
+response_cmp(const void *s1, const void *s2)
+{
+	return strcmp(s1, s2);
+}
+
+static void
+cleanup_pending_responses(void *unused)
+{
+	struct ResponseInfo *response;
+	rb_dictionary_iter iter;
+	rb_dlink_list freelist = { NULL, NULL, 0 };
+	rb_dlink_node *ptr, *nptr;
+	time_t now = rb_current_time();
+
+	/* RB_DICTIONARY_FOREACH is not safe for deletion, so need to do this in two passes */
+	RB_DICTIONARY_FOREACH(response, &iter, pending_responses)
+	{
+		if (response->expires < now)
+		{
+			rb_dlinkAddAlloc(response, &freelist);
+		}
+	}
+
+	RB_DLINK_FOREACH_SAFE(ptr, nptr, freelist.head)
+	{
+		response = ptr->data;
+		if (response->remote_response > 0)
+			sendto_one(response->source_p, ":%s BATCH -%s", me.name, response->batch);
+		rb_dlinkDestroy(ptr, &freelist);
+		rb_dictionary_delete(pending_responses, response->batch);
+		free_response_batch(response);
+	}
+}
+
+void
+init_response(void)
+{
+	pending_responses = rb_dictionary_create("pending remote labeled responses", response_cmp);
+
+	rb_event_addish("cleanup_pending_responses", &cleanup_pending_responses, NULL, 10);
+}
+
+void
+begin_local_response_batch(void)
+{
+	if (outgoing_response_info == NULL || !MyConnect(outgoing_response_info->source_p))
+		return;
+
+	if (!EmptyString(outgoing_response_info->batch))
+		return;
+
+	generate_batch_id(outgoing_response_info->batch, sizeof(outgoing_response_info->batch));
+	sendto_one(outgoing_response_info->source_p, ":%s BATCH +%s labeled-response",
+		me.name, outgoing_response_info->batch);
+}
+
+void
+begin_remote_response_batch(int server_count)
+{
+	if (outgoing_response_info == NULL || !MyConnect(outgoing_response_info->source_p))
+		return;
+
+	if (EmptyString(outgoing_response_info->batch))
+	{
+		/* creating a new remote response batch */
+		generate_batch_id(outgoing_response_info->batch, sizeof(outgoing_response_info->batch));
+		outgoing_response_info->remote_response = server_count;
+		outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
+		rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
+		rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
+		sendto_one(outgoing_response_info->source_p, ":%s BATCH +%s labeled-response",
+			me.name, outgoing_response_info->batch);
+	}
+	else
+	{
+		/* increase the number of servers we're expecting responses from */
+		outgoing_response_info->remote_response += server_count;
+
+		/* if we're upgrading a local batch to a remote batch, add it to tracking places */
+		if (outgoing_response_info->expires == 0)
+		{
+			outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
+			rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
+			rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
+		}
+	}
+}
+
+struct ResponseInfo *
+get_remote_response_batch(const char *batch)
+{
+	return rb_dictionary_retrieve(pending_responses, batch);
+}
+
+void
+free_response_batch(struct ResponseInfo *response)
+{
+	rb_dlink_node *ptr, *nptr;
+
+	if (response == NULL)
+		return;
+
+	if (MyConnect(response->source_p))
+	{
+		RB_DLINK_FOREACH_SAFE(ptr, nptr, response->source_p->localClient->pending_remote_responses.head)
+		{
+			if (ptr->data == response)
+			{
+				rb_dlinkDestroy(ptr, &response->source_p->localClient->pending_remote_responses);
+				break;
+			}
+		}
+
+		rb_dictionary_delete(pending_responses, response->batch);
+	}
+
+	rb_free(response);
+}
+
+int
+count_match_servs(struct Client *one, const char *mask, uint64_t cap, uint64_t negcap)
+{
+	int count = 0;
+	rb_dlink_node *ptr;
+
+	if (EmptyString(mask))
+		return 0;
+
+	RB_DLINK_FOREACH(ptr, global_serv_list.head)
+	{
+		struct Client *target_p = ptr->data;
+		if (target_p == &me)
+			continue;
+
+		if (target_p->from == one->from)
+			continue;
+
+		if (!match(mask, target_p->name))
+			continue;
+
+		if (cap && !IsServerCapable(target_p->from, cap))
+			continue;
+
+		if (negcap && !NotServerCapable(target_p->from, negcap))
+			continue;
+
+		count++;
+	}
+
+	return count;
+}

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -51,6 +51,7 @@
 #include "reject.h"
 #include "sslproc.h"
 #include "capability.h"
+#include "response.h"
 #include "s_assert.h"
 
 int MaxConnectionCount = 1;
@@ -245,6 +246,7 @@ hunt_server(struct Client *client_p, struct Client *source_p,
 		old = parv[server];
 		parv[server] = get_id(target_p, target_p);
 
+		begin_remote_response_batch(1);
 		sendto_one(target_p, command, get_id(source_p, target_p),
 			   parv[1], parv[2], parv[3], parv[4], parv[5], parv[6], parv[7], parv[8]);
 		parv[server] = old;

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -66,6 +66,7 @@ static char buf[BUFSIZE];
  */
 struct CapabilityIndex *serv_capindex = NULL;
 struct CapabilityIndex *cli_capindex = NULL;
+uint64_t serv_clicapmask = UINT64_MAX;
 
 uint64_t CAP_CAP;
 uint64_t CAP_QS;
@@ -90,6 +91,7 @@ uint64_t CAP_MLOCK;
 uint64_t CAP_EBMASK;
 uint64_t CAP_STAG;
 
+uint64_t CLICAP_SERVONLY;
 uint64_t CLICAP_MULTI_PREFIX;
 uint64_t CLICAP_ACCOUNT_NOTIFY;
 uint64_t CLICAP_EXTENDED_JOIN;
@@ -143,6 +145,7 @@ init_builtin_capabs(void)
 
 	cli_capindex = capability_index_create("client capabilities");
 
+	CLICAP_SERVONLY = capability_put_anonymous(cli_capindex);
 	CLICAP_MULTI_PREFIX = capability_put(cli_capindex, "multi-prefix", &high_priority);
 	CLICAP_ACCOUNT_NOTIFY = capability_put(cli_capindex, "account-notify", &high_priority);
 	CLICAP_EXTENDED_JOIN = capability_put(cli_capindex, "extended-join", &high_priority);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -246,7 +246,7 @@ hunt_server(struct Client *client_p, struct Client *source_p,
 		old = parv[server];
 		parv[server] = get_id(target_p, target_p);
 
-		begin_remote_response_batch(1);
+		begin_remote_response_batch(1, target_p->servptr->name);
 		sendto_one(target_p, command, get_id(source_p, target_p),
 			   parv[1], parv[2], parv[3], parv[4], parv[5], parv[6], parv[7], parv[8]);
 		parv[server] = old;

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -262,14 +262,16 @@ linebuf_put_msgf(buf_head_t *linebuf, const rb_strf_t *message, const char *form
 
 /* build_msgbuf
  *
- * inputs       - msgbuf object, client the message is from, line (excluding tags), tags to include
+ * inputs       - msgbuf object, client the message is from, target (NULL if multi-target), line (excluding tags), tags to include
  * outputs      - none
  * side effects - a msgbuf object is populated with the full command and relevant tags
  */
 static void
-build_msgbuf(struct MsgBuf *msgbuf, struct Client *from, char *line, size_t n_tags, const struct MsgTag tags[])
+build_msgbuf(struct MsgBuf *msgbuf, struct Client *from,
+	struct Client *target, struct Channel *chptr, bool source_sees_message,
+	char *line, size_t n_tags, const struct MsgTag tags[])
 {
-	hook_data hdata;
+	hook_data_outbound_msgbuf hdata;
 
 	msgbuf_init(msgbuf);
 	msgbuf_partial_parse(msgbuf, line);
@@ -280,8 +282,11 @@ build_msgbuf(struct MsgBuf *msgbuf, struct Client *from, char *line, size_t n_ta
 			msgbuf_append_tag(msgbuf, tags[i].key, tags[i].value, tags[i].capmask);
 	}
 
-	hdata.client = from;
-	hdata.arg1 = msgbuf;
+	hdata.source = from;
+	hdata.msgbuf = msgbuf;
+	hdata.target = target;
+	hdata.chptr = chptr;
+	hdata.source_sees_message = source_sees_message;
 
 	call_hook(h_outbound_msgbuf, &hdata);
 
@@ -312,7 +317,7 @@ sendto_one(struct Client *target_p, const char *pattern, ...)
 	rb_fsnprint(buf, sizeof(buf), &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, 0, NULL);
+	build_msgbuf(&msgbuf, &me, target_p, NULL, false, buf, 0, NULL);
 	send_msgbuf(target_p, &msgbuf);
 }
 
@@ -348,7 +353,8 @@ sendto_one_prefix(struct Client *target_p, struct Client *source_p,
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, source_p, buf, 0, NULL);
+	bool receives_message = MyClient(source_p) && source_p == target_p;
+	build_msgbuf(&msgbuf, source_p, target_p, NULL, receives_message, buf, 0, NULL);
 	send_msgbuf(target_p, &msgbuf);
 }
 
@@ -387,7 +393,7 @@ sendto_one_notice(struct Client *target_p, const char *pattern, ...)
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, 0, NULL);
+	build_msgbuf(&msgbuf, &me, target_p, NULL, false, buf, 0, NULL);
 	send_msgbuf(target_p, &msgbuf);
 }
 
@@ -427,7 +433,7 @@ sendto_one_numeric(struct Client *target_p, int numeric, const char *pattern, ..
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, 0, NULL);
+	build_msgbuf(&msgbuf, &me, target_p, NULL, false, buf, 0, NULL);
 	send_msgbuf(target_p, &msgbuf);
 }
 
@@ -457,7 +463,7 @@ sendto_one_tags(struct Client *target_p, uint64_t serv_cap, uint64_t serv_negcap
 	rb_fsnprint(buf, sizeof(buf), &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, n_tags, tags);
+	build_msgbuf(&msgbuf, &me, target_p, NULL, false, buf, n_tags, tags);
 	send_msgbuf(target_p, &msgbuf);
 }
 
@@ -495,7 +501,7 @@ sendto_server_internal(struct Client *one, struct Channel *chptr, uint64_t caps,
 		return;
 
 	rb_fsnprint(buf, sizeof(buf), &strings);
-	build_msgbuf(&msgbuf, &me, buf, n_tags, tags);
+	build_msgbuf(&msgbuf, &me, NULL, chptr, false, buf, n_tags, tags);
 	/* source is already provided as part of format; don't overwrite it with anything else */
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
@@ -606,7 +612,23 @@ sendto_channel_flags_internal(struct Client *one, int type, struct Client *sourc
 		source_p->name, source_p->username, source_p->host);
 
 	rb_fsnprint(buf, sizeof(buf), strings);
-	build_msgbuf(&msgbuf, source_p, buf, n_tags, tags);
+
+	bool receives_message = false;
+	if (MyClient(source_p))
+	{
+		receives_message = IsClientCapable(source_p, CLICAP_ECHO_MESSAGE);
+		if (!receives_message && (msptr = find_channel_membership(chptr, source_p)) != NULL)
+		{
+			receives_message = source_p != one
+				&& (!type || (msptr->flags & type) != 0)
+				&& !IsDeaf(source_p)
+				&& IsClientCapable(source_p, cli_cap)
+				&& NotClientCapable(source_p, cli_negcap)
+				&& (priv == NULL || HasPrivilege(source_p, priv));
+		}
+	}
+
+	build_msgbuf(&msgbuf, source_p, NULL, chptr, receives_message, buf, n_tags, tags);
 
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, local_source, use_id(source_p));
 
@@ -732,7 +754,22 @@ sendto_channel_opmod_internal(struct Client *one, struct Client *source_p, struc
 		source_p->name, source_p->username, source_p->host);
 
 	snprintf(buf, sizeof(buf), fmt, command, statusmsg_prefix, chptr->chname, text);
-	build_msgbuf(&msgbuf_statusmsg, source_p, buf, n_tags, tags);
+
+	bool receives_message = false;
+	if (MyClient(source_p))
+	{
+		receives_message = IsClientCapable(source_p, CLICAP_ECHO_MESSAGE);
+		if (!receives_message && (msptr = find_channel_membership(chptr, source_p)) != NULL)
+		{
+			receives_message = source_p != one
+				&& (msptr->flags & CHFL_CHANOP) != 0
+				&& !IsDeaf(source_p)
+				&& IsClientCapable(source_p, cli_cap)
+				&& NotClientCapable(source_p, cli_negcap);
+		}
+	}
+
+	build_msgbuf(&msgbuf_statusmsg, source_p, NULL, chptr, receives_message, buf, n_tags, tags);
 	msgbuf_cache_init(&msgbuf_cache_statusmsg, &msgbuf_statusmsg, local_source, use_id(source_p));
 
 	memcpy(&msgbuf_eopmod, &msgbuf_statusmsg, sizeof(struct MsgBuf));
@@ -845,7 +882,18 @@ sendto_channel_local_internal(struct Client *one, int type, struct Client *sourc
 	rb_strf_t strings = { .format = pattern, .format_args = args, .next = NULL };
 
 	rb_fsnprint(buf, sizeof(buf), &strings);
-	build_msgbuf(&msgbuf, source_p, buf, n_tags, tags);
+
+	bool receives_message = false;
+	if (MyClient(source_p) && (msptr = find_channel_membership(chptr, source_p)) != NULL)
+	{
+		receives_message = source_p != one
+			&& (!type || (msptr->flags & type) != 0)
+			&& IsClientCapable(source_p, caps)
+			&& NotClientCapable(source_p, negcaps)
+			&& (priv == NULL || HasPrivilege(source_p, priv));
+	}
+
+	build_msgbuf(&msgbuf, source_p, NULL, chptr, receives_message, buf, n_tags, tags);
 
 	/* source is already provided as part of pattern; don't overwrite it with anything else */
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
@@ -1035,7 +1083,12 @@ sendto_common_channels_local_internal(struct Client *one, struct Client *user, u
 	rb_strf_t strings = { .format = pattern, .format_args = args, .next = NULL };
 	rb_fsnprint(buf, sizeof(buf), &strings);
 
-	build_msgbuf(&msgbuf, user, buf, n_tags, tags);
+	bool receives_message = MyClient(user)
+		&& user != one
+		&& IsClientCapable(user, caps)
+		&& NotClientCapable(user, negcaps);
+
+	build_msgbuf(&msgbuf, user, NULL, NULL, receives_message, buf, n_tags, tags);
 	/* source is already provided as part of pattern; don't overwrite it with anything else */
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
@@ -1191,7 +1244,14 @@ sendto_match_internal(struct Client *one, struct Client *source_p, const char *m
 	snprintf(local_source, sizeof(local_source), IsPerson(source_p) ? "%s!%s@%s" : "%s",
 		source_p->name, source_p->username, source_p->host);
 
-	build_msgbuf(&msgbuf, source_p, buf, n_tags, tags);
+	bool receives_message = false;
+	if (MyClient(source_p) && IsClientCapable(source_p, cli_cap) && NotClientCapable(source_p, cli_negcap))
+	{
+		receives_message = (what == MATCH_HOST && match(mask, source_p->host))
+			|| (what == MATCH_SERVER && match(mask, me.name));
+	}
+
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, receives_message, buf, n_tags, tags);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, local_source, use_id(source_p));
 
 	if (what == MATCH_HOST)
@@ -1288,7 +1348,7 @@ sendto_match_servs_internal(struct Client *source_p, const char *mask, uint64_t 
 	int used = snprintf(buf, sizeof(buf), ":%s ", use_id(source_p));
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 
-	build_msgbuf(&msgbuf, source_p, buf, n_tags, tags);
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, false, buf, n_tags, tags);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	current_serial++;
@@ -1376,7 +1436,7 @@ sendto_local_clients_with_capability(uint64_t cap, const char *pattern, ...)
 	rb_fsnprint(buf, sizeof(buf), &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, 0, NULL);
+	build_msgbuf(&msgbuf, &me, NULL, NULL, false, buf, 0, NULL);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	RB_DLINK_FOREACH(ptr, lclient_list.head)
@@ -1414,7 +1474,7 @@ sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *patt
 	rb_fsnprint(buf, sizeof(buf), &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, source_p, buf, 0, NULL);
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, false, buf, 0, NULL);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, monptr->users.head)
@@ -1459,7 +1519,8 @@ sendto_anywhere_internal(struct Client *dest_p, struct Client *target_p,
 			get_id(source_p, target_p), command, get_id(target_p, target_p));
 
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
-	build_msgbuf(&msgbuf, source_p, buf, n_tags, tags);
+	bool receives_message = MyClient(source_p) && source_p == dest_p;
+	build_msgbuf(&msgbuf, source_p, dest_p, NULL, receives_message, buf, n_tags, tags);
 	send_msgbuf(dest_p, &msgbuf);
 }
 
@@ -1543,7 +1604,7 @@ sendto_realops_snomask(int flags, int level, const char *pattern, ...)
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, &me, buf, 0, NULL);
+	build_msgbuf(&msgbuf, &me, NULL, NULL, false, buf, 0, NULL);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	/* Be very sure not to do things like "Trying to send to myself"
@@ -1607,7 +1668,15 @@ sendto_realops_snomask_from(int flags, int level, struct Client *source_p,
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, source_p, buf, 0, NULL);
+	bool receives_message = false;
+	if (MyClient(source_p) && (source_p->snomask & flags) != 0)
+	{
+		receives_message = (level == L_ADMIN && IsOperAdmin(source_p))
+			|| (level == L_OPER && !IsOperAdmin(source_p))
+			|| (level != L_OPER && level != L_ADMIN);
+	}
+
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, receives_message, buf, 0, NULL);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, local_oper_list.head)
@@ -1656,7 +1725,8 @@ sendto_wallops_flags(int flags, struct Client *source_p, const char *pattern, ..
 	rb_fsnprint(buf + used, sizeof(buf) - used, &strings);
 	va_end(args);
 
-	build_msgbuf(&msgbuf, source_p, buf, 0, NULL);
+	bool receives_message = MyClient(source_p) && (source_p->umodes & flags) != 0;
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, receives_message, buf, 0, NULL);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
 	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, IsPerson(source_p) && flags == UMODE_WALLOP ? lclient_list.head : local_oper_list.head)

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -40,7 +40,7 @@
 #include "monitor.h"
 #include "msgbuf.h"
 
-#define CLIENT_CAP_MASK(x)	((x)->from->localClient->client_caps | (IsServerCapable((x)->from, CAP_STAG) ? UINT64_MAX : 0))
+#define CLIENT_CAP_MASK(x)	((x)->from->localClient->client_caps | (IsServerCapable((x)->from, CAP_STAG) ? serv_clicapmask : 0))
 
 static void send_queued_write(rb_fde_t *F, void *data);
 

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -8,6 +8,7 @@ auto_load_moddir=@moduledir@/autoload
 
 auto_load_mod_LTLIBRARIES = \
   cap_account_tag.la \
+  cap_labeled_response.la \
   cap_server_time.la \
   chm_nocolour.la \
   chm_noctcp.la \

--- a/modules/cap_account_tag.c
+++ b/modules/cap_account_tag.c
@@ -51,11 +51,11 @@ mapi_cap_list_av2 cap_account_tag_cap_list[] = {
 static void
 cap_account_tag_process(void *data_)
 {
-	hook_data *data = data_;
-	struct MsgBuf *msgbuf = data->arg1;
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
 
-	if (data->client != NULL && IsPerson(data->client) && *data->client->user->suser)
-		msgbuf_append_tag(msgbuf, "account", data->client->user->suser, CLICAP_ACCOUNT_TAG);
+	if (data->source != NULL && IsPerson(data->source) && *data->source->user->suser)
+		msgbuf_append_tag(msgbuf, "account", data->source->user->suser, CLICAP_ACCOUNT_TAG);
 }
 
 DECLARE_MODULE_AV2(cap_account_tag, NULL, NULL, NULL, NULL, cap_account_tag_hfnlist, cap_account_tag_cap_list, NULL, cap_account_tag_desc);

--- a/modules/cap_labeled_response.c
+++ b/modules/cap_labeled_response.c
@@ -99,17 +99,25 @@ cap_labeled_response_incoming(void *data_)
 	}
 	else if (IsServer(data->client) && !strcmp(serv_response_tag, data->key) && !EmptyString(data->value))
 	{
-		/* tag value should be UID,batch_id */
-		char uid[IDLEN] = { 0 };
-		const char *batch_id = strchr(data->value, ',');
-		if (batch_id == NULL)
-			return;
+		/* tag value should be UID,batch_id,mask */
+		char *buf = rb_strdup(data->value);
+		char *p;
+		const char *uid = rb_strtok_r(buf, ",", &p);
+		const char *batch_id = rb_strtok_r(NULL, ",", &p);
+		const char *mask = rb_strtok_r(NULL, ",", &p);
 
-		++batch_id;
-		memcpy(uid, data->value, sizeof(uid) - 1);
+		if (uid == NULL || batch_id == NULL || mask == NULL)
+		{
+			rb_free(buf);
+			return;
+		}
+
 		struct Client *client = find_id(uid);
 		if (client == NULL)
+		{
+			rb_free(buf);
 			return;
+		}
 
 		if (MyConnect(client))
 		{
@@ -120,15 +128,17 @@ cap_labeled_response_incoming(void *data_)
 				SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
 			}
 		}
-		else
+		else if (data->client == client->from && match(mask, me.name))
 		{
 			outgoing_response_info = rb_malloc(sizeof(struct ResponseInfo));
 			outgoing_response_info->source_p = client;
 			outgoing_response_info->client_p = client->from;
 			rb_strlcpy(outgoing_response_info->batch, batch_id, sizeof(outgoing_response_info->batch));
+			rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
 			outgoing_response_info->sent = true;
 		}
 
+		rb_free(buf);
 		data->approved = MESSAGE_TAG_ALLOW;
 		data->capmask = CLICAP_SERVONLY;
 	}
@@ -174,8 +184,8 @@ cap_labeled_response_process(void *data_)
 	}
 	else if (outgoing_response_info != NULL && outgoing_response_info->remote_response > 0)
 	{
-		snprintf(response_tag_buf, sizeof(response_tag_buf), "%s,%s",
-			outgoing_response_info->source_p->id, outgoing_response_info->batch);
+		snprintf(response_tag_buf, sizeof(response_tag_buf), "%s,%s,%s",
+			outgoing_response_info->source_p->id, outgoing_response_info->batch, outgoing_response_info->mask);
 		msgbuf_append_tag(msgbuf, serv_response_tag, response_tag_buf, CLICAP_SERVONLY);
 	}
 }

--- a/modules/cap_labeled_response.c
+++ b/modules/cap_labeled_response.c
@@ -1,0 +1,230 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * cap_labeled_response.c: labeled-response hooks
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "hash.h"
+#include "modules.h"
+#include "response.h"
+#include "send.h"
+#include "s_serv.h"
+
+#define IsMeOrServer(x) (IsMe(x) || IsServer(x))
+
+static const char cap_labeled_response_desc[] =
+	"Provides the labeled-response client capability";
+
+static bool cap_receive_label_visible(struct Client *);
+static void cap_labeled_response_incoming(void *);
+static void cap_labeled_response_process(void *);
+static void cap_labeled_response_cleanup(void *);
+static void me_ack(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
+
+static const char *serv_response_tag = "solanum.chat/response";
+static char response_tag_buf[BUFSIZE];
+/* other modules may modify outgoing_response_info, so keep track of who we add CLICAP_RECEIVE_LABEL to here */
+static struct Client *label_eligible = NULL;
+
+static uint64_t CLICAP_LABELED_RESPONSE;
+static uint64_t CLICAP_RECEIVE_LABEL;
+
+static struct ClientCapability capdata_receive_label = {
+	.visible = cap_receive_label_visible,
+	.flags = CLICAP_FLAGS_NOPROP,
+};
+
+struct Message ack_msgtab = {
+	"ACK", 0, 0, 0, 0,
+	{mg_ignore, mg_ignore, mg_ignore, mg_ignore, {me_ack, 0}, mg_ignore}
+};
+
+mapi_clist_av1 cap_labeled_response_clist[] = { &ack_msgtab, NULL };
+
+mapi_cap_list_av2 cap_labeled_response_cap_list[] = {
+	{ MAPI_CAP_CLIENT, "?receive_label", &capdata_receive_label, &CLICAP_RECEIVE_LABEL },
+	{ MAPI_CAP_CLIENT, "labeled-response", NULL, &CLICAP_LABELED_RESPONSE },
+	{ 0, NULL, NULL, NULL },
+};
+
+mapi_hfn_list_av1 cap_labeled_response_hfnlist[] = {
+	{ "message_tag", cap_labeled_response_incoming },
+	{ "outbound_msgbuf", cap_labeled_response_process },
+	{ "parse_end", cap_labeled_response_cleanup, HOOK_HIGHEST },
+	{ NULL, NULL }
+};
+
+static bool
+cap_receive_label_visible(struct Client *client)
+{
+	return false;
+}
+
+static void
+cap_labeled_response_incoming(void *data_)
+{
+	hook_data_message_tag *data = data_;
+
+	if (MyConnect(data->source)
+		&& IsClientCapable(data->source, CLICAP_LABELED_RESPONSE | CLICAP_BATCH)
+		&& !strcmp("label", data->key)
+		&& !EmptyString(data->value)
+		&& strlen(data->value) <= 64)
+	{
+		label_eligible = data->source;
+		SetClientCap(data->source, CLICAP_RECEIVE_LABEL);
+		outgoing_response_info = rb_malloc(sizeof(struct ResponseInfo));
+		outgoing_response_info->source_p = data->source;
+		outgoing_response_info->client_p = data->client;
+		rb_strlcpy(outgoing_response_info->label, data->value, sizeof(outgoing_response_info->label));
+		/* don't propagate label further, but approve the tag so modules like m_batch can make use of it */
+		data->approved = MESSAGE_TAG_ALLOW;
+		data->capmask = NOCAPS;
+	}
+	else if (IsServer(data->client) && !strcmp(serv_response_tag, data->key) && !EmptyString(data->value))
+	{
+		/* tag value should be UID,batch_id */
+		char uid[IDLEN] = { 0 };
+		const char *batch_id = strchr(data->value, ',');
+		if (batch_id == NULL)
+			return;
+
+		++batch_id;
+		memcpy(uid, data->value, sizeof(uid) - 1);
+		struct Client *client = find_id(uid);
+		if (client == NULL)
+			return;
+
+		if (MyConnect(client))
+		{
+			outgoing_response_info = get_remote_response_batch(batch_id);
+			if (outgoing_response_info != NULL && IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH))
+			{
+				label_eligible = outgoing_response_info->source_p;
+				SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+			}
+		}
+		else
+		{
+			outgoing_response_info = rb_malloc(sizeof(struct ResponseInfo));
+			outgoing_response_info->source_p = client;
+			outgoing_response_info->client_p = client->from;
+			rb_strlcpy(outgoing_response_info->batch, batch_id, sizeof(outgoing_response_info->batch));
+			outgoing_response_info->sent = true;
+		}
+
+		data->approved = MESSAGE_TAG_ALLOW;
+		data->capmask = CLICAP_SERVONLY;
+	}
+}
+
+static void
+cap_labeled_response_process(void *data_)
+{
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
+	const char *response_tag = NULL;
+
+	if (incoming_message != NULL)
+		response_tag = msgbuf_get_tag(incoming_message, serv_response_tag);
+
+	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p))
+	{
+		/* this assumes messages with a server as a source sent to a channel go to all members */
+		bool attach_tags = data->source_sees_message
+			|| outgoing_response_info->source_p == data->target
+			|| (data->chptr != NULL && IsMeOrServer(data->source) && find_channel_membership(data->chptr, outgoing_response_info->source_p) != NULL);
+
+		if (!outgoing_response_info->sent && attach_tags && !outgoing_response_info->skip_tags)
+		{
+			outgoing_response_info->sent = true;
+			msgbuf_append_tag(msgbuf, "label", outgoing_response_info->label, CLICAP_RECEIVE_LABEL);
+		}
+
+		if (attach_tags
+			&& !outgoing_response_info->skip_tags
+			&& !EmptyString(outgoing_response_info->batch)
+			&& msgbuf_get_tag(msgbuf, "batch") == NULL
+			&& strcmp(msgbuf->cmd, "BATCH") != 0)
+		{
+			msgbuf_append_tag(msgbuf, "batch", outgoing_response_info->batch, CLICAP_RECEIVE_LABEL);
+		}
+	}
+
+	/* propagate solanum.chat/response to other servers */
+	if (response_tag != NULL)
+	{
+		msgbuf_append_tag(msgbuf, serv_response_tag, response_tag, CLICAP_SERVONLY);
+	}
+	else if (outgoing_response_info != NULL && outgoing_response_info->remote_response > 0)
+	{
+		snprintf(response_tag_buf, sizeof(response_tag_buf), "%s,%s",
+			outgoing_response_info->source_p->id, outgoing_response_info->batch);
+		msgbuf_append_tag(msgbuf, serv_response_tag, response_tag_buf, CLICAP_SERVONLY);
+	}
+}
+
+static void
+cap_labeled_response_cleanup(void *unused)
+{
+	if (outgoing_response_info != NULL)
+	{
+		if (MyConnect(outgoing_response_info->source_p))
+		{
+			/* send an ACK if the handlers didn't send anything */
+			if (!outgoing_response_info->sent)
+				sendto_one(outgoing_response_info->source_p, ":%s ACK", me.name);
+
+			if (!EmptyString(outgoing_response_info->batch) && outgoing_response_info->remote_response == 0)
+			{
+				sendto_one(outgoing_response_info->source_p, ":%s BATCH -%s",
+					me.name, outgoing_response_info->batch);
+			}
+		}
+		else
+		{
+			/* notify remote that we're done sending responses to this command */
+			sendto_one(outgoing_response_info->source_p, ":%s ENCAP %s ACK",
+				me.id, outgoing_response_info->source_p->servptr->name);
+		}
+
+		if (outgoing_response_info->remote_response == 0)
+			free_response_batch(outgoing_response_info);
+
+		outgoing_response_info = NULL;
+	}
+
+	if (label_eligible != NULL)
+	{
+		ClearClientCap(label_eligible, CLICAP_RECEIVE_LABEL);
+		label_eligible = NULL;
+	}
+}
+
+static void
+me_ack(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
+{
+	/* client already left or something, so nothing to do here */
+	if (outgoing_response_info == NULL)
+		return;
+
+	outgoing_response_info->remote_response--;
+}
+
+DECLARE_MODULE_AV2(cap_labeled_response, NULL, NULL, cap_labeled_response_clist, NULL, cap_labeled_response_hfnlist, cap_labeled_response_cap_list, NULL, cap_labeled_response_desc);

--- a/modules/cap_server_time.c
+++ b/modules/cap_server_time.c
@@ -65,10 +65,10 @@ cap_server_time_incoming(void *data_)
 static void
 cap_server_time_process(void *data_)
 {
-	hook_data *data = data_;
+	hook_data_outbound_msgbuf *data = data_;
 	static char buf[BUFSIZE];
 	const char *tagged_time;
-	struct MsgBuf *msgbuf = data->arg1;
+	struct MsgBuf *msgbuf = data->msgbuf;
 	struct timeval tv;
 
 	if (msgbuf_get_tag(msgbuf, "time"))
@@ -80,7 +80,7 @@ cap_server_time_process(void *data_)
 		return;
 	}
 
-	if (data->client != NULL && !IsMe(data->client) && !MyClient(data->client))
+	if (data->source != NULL && !IsMe(data->source) && !MyClient(data->source))
 		return;
 
 	if (!rb_gettimeofday(&tv, NULL)) {

--- a/modules/core/m_ban.c
+++ b/modules/core/m_ban.c
@@ -44,6 +44,7 @@
 #include "reject.h"
 #include "hostmask.h"
 #include "logger.h"
+#include "response.h"
 
 static const char ban_desc[] = "Provides the TS6 BAN command for propagating network-wide bans";
 
@@ -62,6 +63,7 @@ DECLARE_MODULE_AV2(ban, NULL, NULL, ban_clist, NULL, NULL, NULL, NULL, ban_desc)
 static void
 m_ban(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
+	begin_local_response_batch();
 	sendto_one_notice(source_p, ":The BAN command is not user-accessible.");
 	sendto_one_notice(source_p, ":To ban a user from a channel, see /QUOTE HELP CMODE");
 	if (IsOperGeneral(source_p))

--- a/modules/core/m_join.c
+++ b/modules/core/m_join.c
@@ -42,6 +42,7 @@
 #include "s_assert.h"
 #include "hook.h"
 #include "batch.h"
+#include "response.h"
 
 static const char join_desc[] = "Provides the JOIN and TS6 SJOIN commands to facilitate joining and creating channels";
 
@@ -179,6 +180,11 @@ m_join(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	char *mykey;
 
 	jbuf[0] = '\0';
+
+	/* always batch a labeled-response since they could be trying to join multiple channels;
+	 * easier to have one code path than trying to save some bandwidth in the single-channel case
+	 */
+	begin_local_response_batch();
 
 	/* rebuild the list of channels theyre supposed to be joining.
 	 * this code has a side effect of losing keys, but..

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -42,6 +42,8 @@
 #include "s_stats.h"
 #include "tgchange.h"
 #include "client_tags.h"
+#include "response.h"
+#include "s_assert.h"
 #include "inline/stringops.h"
 
 static const char message_desc[] =
@@ -80,7 +82,12 @@ static uint64_t CAP_ECHO;
 
 struct entity
 {
-	void* ptr;
+	union
+	{
+		struct Client *target_p;
+		struct Channel *chptr;
+	};
+	char mask[NICKLEN + HOSTLEN + 2];
 	int type;
 	int flags;
 };
@@ -140,11 +147,11 @@ static bool flood_attack_client(enum message_type msgtype, struct Client *source
 #define ENTITY_CHANNEL_OPMOD 2
 #define ENTITY_CHANOPS_ON_CHANNEL 3
 #define ENTITY_CLIENT  4
+#define ENTITY_TARGET_ON_SERVER 5
+#define ENTITY_MASS_MESSAGE 6
 
 static struct entity targets[512];
 static int ntargets = 0;
-
-static bool duplicate_ptr(void *);
 
 static void msg_channel(enum message_type msgtype,
 			struct Client *client_p,
@@ -166,9 +173,12 @@ static void msg_client(enum message_type msgtype,
 		       struct Client *source_p, struct Client *target_p, const char *text,
 		       struct MsgBuf *msgbuf_p);
 
-static void handle_special(enum message_type msgtype,
-			   struct Client *client_p, struct Client *source_p, const char *nick,
-			   const char *text, struct MsgBuf *msgbuf_p);
+static void msg_client_targeted(enum message_type msgtype,
+	struct Client *source_p, const char *nick, struct Client *target_p,
+	const char *text, struct MsgBuf *msgbuf_p);
+
+static void msg_mass(enum message_type msgtype, struct Client *client_p,
+	struct Client *source_p, const char *mask, const char *text, struct MsgBuf *msgbuf_p);
 
 /*
 ** m_privmsg
@@ -268,6 +278,10 @@ m_message(enum message_type msgtype, struct MsgBuf *msgbuf_p,
 	if (text == NULL)
 		text = "";
 
+	/* start a batch for multi-target messages */
+	if (strchr(parv[1], ',') != NULL)
+		begin_local_response_batch();
+
 	build_target_list(msgtype, client_p, source_p, parv[1], text, &msgbuf);
 	if (ntargets <= 0)
 		return;
@@ -277,24 +291,27 @@ m_message(enum message_type msgtype, struct MsgBuf *msgbuf_p,
 		switch (targets[i].type)
 		{
 		case ENTITY_CHANNEL:
-			msg_channel(msgtype, client_p, source_p,
-				    (struct Channel *) targets[i].ptr, text, &msgbuf);
+			msg_channel(msgtype, client_p, source_p, targets[i].chptr, text, &msgbuf);
 			break;
 
 		case ENTITY_CHANNEL_OPMOD:
-			msg_channel_opmod(msgtype, client_p, source_p,
-				   (struct Channel *) targets[i].ptr, text, &msgbuf);
+			msg_channel_opmod(msgtype, client_p, source_p, targets[i].chptr, text, &msgbuf);
 			break;
 
 		case ENTITY_CHANOPS_ON_CHANNEL:
-			msg_channel_flags(msgtype, client_p, source_p,
-					  (struct Channel *) targets[i].ptr,
-					  targets[i].flags, text, &msgbuf);
+			msg_channel_flags(msgtype, client_p, source_p, targets[i].chptr, targets[i].flags, text, &msgbuf);
 			break;
 
 		case ENTITY_CLIENT:
-			msg_client(msgtype, source_p,
-				   (struct Client *) targets[i].ptr, text, &msgbuf);
+			msg_client(msgtype, source_p, targets[i].target_p, text, &msgbuf);
+			break;
+
+		case ENTITY_TARGET_ON_SERVER:
+			msg_client_targeted(msgtype, source_p, targets[i].mask, targets[i].target_p, text, &msgbuf);
+			break;
+
+		case ENTITY_MASS_MESSAGE:
+			msg_mass(msgtype, client_p, source_p, targets[i].mask, text, &msgbuf);
 			break;
 		}
 	}
@@ -323,6 +340,43 @@ m_echo(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		text = "";
 
 	echo_msg(source_p, target_p, msgtype, parv[3], msgbuf_p);
+}
+
+/*
+ * duplicate_*
+ *
+ * inputs	- pointer to check
+ *		- pointer to table of entities
+ *		- number of valid entities so far
+ * output	- true if duplicate pointer in table, false if not.
+ *		  note, this does the canonize using pointers
+ * side effects	- NONE
+ */
+static bool
+duplicate_client(struct Client *ptr)
+{
+	for (int i = 0; i < ntargets; i++)
+		if (targets[i].target_p == ptr)
+			return true;
+	return false;
+}
+
+static bool
+duplicate_channel(struct Channel *ptr)
+{
+	for (int i = 0; i < ntargets; i++)
+		if (targets[i].chptr == ptr)
+			return true;
+	return false;
+}
+
+static bool
+duplicate_mask(const char *mask)
+{
+	for (int i = 0; i < ntargets; i++)
+		if (!strcmp(targets[i].mask, mask))
+			return true;
+	return false;
 }
 
 /*
@@ -359,6 +413,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 	for(nick = rb_strtok_r(target_list, ",", &p); nick; nick = rb_strtok_r(NULL, ",", &p))
 	{
 		char *with_prefix;
+		rb_strlcpy(targets[ntargets].mask, nick, sizeof(targets[ntargets].mask));
 		/*
 		 * channels are privmsg'd a lot more than other clients, moved up
 		 * here plain old channel msg?
@@ -372,7 +427,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 
 			if((chptr = find_channel(nick)) != NULL)
 			{
-				if(!duplicate_ptr(chptr))
+				if(!duplicate_channel(chptr))
 				{
 					if(ntargets >= ConfigFileEntry.max_targets)
 					{
@@ -380,7 +435,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 							   me.name, source_p->name, nick);
 						return (1);
 					}
-					targets[ntargets].ptr = (void *) chptr;
+					targets[ntargets].chptr = chptr;
 					targets[ntargets++].type = ENTITY_CHANNEL;
 				}
 			}
@@ -401,7 +456,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 		/* look for a privmsg to another client */
 		if(target_p)
 		{
-			if(!duplicate_ptr(target_p))
+			if(!duplicate_client(target_p))
 			{
 				if(ntargets >= ConfigFileEntry.max_targets)
 				{
@@ -409,7 +464,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 						   me.name, source_p->name, nick);
 					return (1);
 				}
-				targets[ntargets].ptr = (void *) target_p;
+				targets[ntargets].target_p = target_p;
 				targets[ntargets].type = ENTITY_CLIENT;
 				targets[ntargets++].flags = 0;
 			}
@@ -461,7 +516,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 					continue;
 				}
 
-				if(!duplicate_ptr(chptr))
+				if(!duplicate_channel(chptr))
 				{
 					if(ntargets >= ConfigFileEntry.max_targets)
 					{
@@ -469,7 +524,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 							   me.name, source_p->name, nick);
 						return (1);
 					}
-					targets[ntargets].ptr = (void *) chptr;
+					targets[ntargets].chptr = chptr;
 					targets[ntargets].type = ENTITY_CHANOPS_ON_CHANNEL;
 					targets[ntargets++].flags = type;
 				}
@@ -488,7 +543,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 			nick++;
 			if((chptr = find_channel(nick)) != NULL)
 			{
-				if(!duplicate_ptr(chptr))
+				if(!duplicate_channel(chptr))
 				{
 					if(ntargets >= ConfigFileEntry.max_targets)
 					{
@@ -496,7 +551,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 							   me.name, source_p->name, nick);
 						return (1);
 					}
-					targets[ntargets].ptr = (void *) chptr;
+					targets[ntargets].chptr = chptr;
 					targets[ntargets++].type = ENTITY_CHANNEL_OPMOD;
 				}
 			}
@@ -509,9 +564,83 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 			continue;
 		}
 
-		if(strchr(nick, '@') || (IsOper(source_p) && (*nick == '$')))
+		char *server = strchr(targets[ntargets].mask, '@');
+		if (server != NULL)
 		{
-			handle_special(msgtype, client_p, source_p, nick, text, msgbuf_p);
+			*server++ = '\0';
+			target_p = find_server(source_p, server);
+			if (target_p == NULL)
+			{
+				if (msgtype == MESSAGE_TYPE_PRIVMSG)
+					sendto_one_numeric(source_p, ERR_NOSUCHSERVER,
+						form_str(ERR_NOSUCHSERVER), server);
+				continue;
+			}
+
+			/* This was not very useful except for bypassing certain
+			 * restrictions. Note that we still allow sending to
+			 * remote servers this way, for messaging pseudoservers
+			 * securely whether they have a service{} block or not.
+			 * -- jilles
+			 */
+			if (IsMe(target_p))
+			{
+				if (msgtype == MESSAGE_TYPE_PRIVMSG)
+					sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+						   form_str(ERR_NOSUCHNICK), nick);
+				continue;
+			}
+
+			if (!duplicate_client(target_p) && !duplicate_mask(targets[ntargets].mask))
+			{
+				if (ntargets >= ConfigFileEntry.max_targets)
+				{
+					sendto_one(source_p, form_str(ERR_TOOMANYTARGETS),
+						me.name, source_p->name, nick);
+					return 1;
+				}
+
+				targets[ntargets].target_p = target_p;
+				targets[ntargets++].type = ENTITY_TARGET_ON_SERVER;
+			}
+
+			continue;
+		}
+
+		if (*nick == '$')
+		{
+			if (MyClient(source_p) && !IsOperMassNotice(source_p))
+			{
+				if (!IsOper(source_p))
+					sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
+						form_str(ERR_NOPRIVILEGES));
+				else
+					sendto_one(source_p, form_str(ERR_NOPRIVS),
+						me.name, source_p->name, "mass_notice");
+				continue;
+			}
+
+			if (*(nick + 1) != '$' && *(nick + 1) != '#')
+			{
+				sendto_one(source_p,
+					":%s NOTICE %s :The command %s %s is no longer supported, please use $%s",
+					me.name, source_p->name, cmdname[msgtype], nick, nick);
+				continue;
+			}
+
+			if (!duplicate_mask(targets[ntargets].mask))
+			{
+				if (ntargets >= ConfigFileEntry.max_targets)
+				{
+					sendto_one(source_p, form_str(ERR_TOOMANYTARGETS),
+						me.name, source_p->name, nick);
+					return 1;
+				}
+
+				targets[ntargets].target_p = NULL;
+				targets[ntargets++].type = ENTITY_MASS_MESSAGE;
+			}
+
 			continue;
 		}
 
@@ -533,26 +662,6 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 
 	}
 	return (1);
-}
-
-/*
- * duplicate_ptr
- *
- * inputs	- pointer to check
- *		- pointer to table of entities
- *		- number of valid entities so far
- * output	- true if duplicate pointer in table, false if not.
- *		  note, this does the canonize using pointers
- * side effects	- NONE
- */
-static bool
-duplicate_ptr(void *ptr)
-{
-	int i;
-	for(i = 0; i < ntargets; i++)
-		if(targets[i].ptr == ptr)
-			return true;
-	return false;
 }
 
 /*
@@ -941,6 +1050,10 @@ msg_client(enum message_type msgtype,
 			return;
 		}
 
+		/* suppress labeled-response on the primary message if they're messaging themselves */
+		if (outgoing_response_info != NULL && source_p == target_p)
+			outgoing_response_info->skip_tags++;
+
 		if (msgtype == MESSAGE_TYPE_TAGMSG && IsClientCapable(target_p, CLICAP_MESSAGE_TAGS))
 		{
 			add_reply_target(target_p, source_p);
@@ -954,10 +1067,14 @@ msg_client(enum message_type msgtype,
 				NOCAPS, NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags, ":%s", text);
 		}
 
+		if (outgoing_response_info != NULL && source_p == target_p)
+			outgoing_response_info->skip_tags--;
+
 		echo_msg(target_p, source_p, msgtype, text, msgbuf_p);
 	}
 	else
 	{
+		begin_remote_response_batch(1);
 		sendto_anywhere_tags(target_p, source_p, cmdname[msgtype],
 			msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS,
 			NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
@@ -967,6 +1084,89 @@ msg_client(enum message_type msgtype,
 		/* if the remote doesn't support ECHO, generate a local echo-message instead */
 		if (!IsServerCapable(target_p->from, CAP_ECHO))
 			echo_msg(target_p, source_p, msgtype, text, msgbuf_p);
+	}
+}
+
+static void
+msg_client_targeted(enum message_type msgtype,
+	struct Client *source_p, const char *nick, struct Client *target_p,
+	const char *text, struct MsgBuf *msgbuf_p)
+{
+	s_assert(!IsMe(target_p) && IsServer(target_p));
+
+	begin_remote_response_batch(1);
+	sendto_one_tags(target_p,
+		msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS,
+		NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
+		msgtype == MESSAGE_TYPE_TAGMSG ? ":%s %s %s@%s" : ":%s %s %s@%s :%s",
+		get_id(source_p, target_p), cmdname[msgtype], nick, target_p->name, text);
+
+	/* ECHO doesn't work with special syntax, so generate a local echo instead */
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+	{
+		const char *fmt = msgtype == MESSAGE_TYPE_TAGMSG
+			? ":%s!%s@%s %s %s@%s"
+			: ":%s!%s@%s %s %s@%s :%s";
+
+		sendto_one_tags(source_p, NOCAPS, NOCAPS,
+			msgbuf_p->n_tags, msgbuf_p->tags, fmt,
+			source_p->name, source_p->username, source_p->host,
+			cmdname[msgtype], nick, target_p->name, text);
+	}
+}
+
+static void
+msg_mass(enum message_type msgtype, struct Client *client_p, struct Client *source_p,
+	const char *mask, const char *text, struct MsgBuf *msgbuf_p)
+{
+	uint64_t cli_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CLICAP_MESSAGE_TAGS : NOCAPS;
+	uint64_t serv_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS;
+
+	/* skip past initial '$' */
+	mask++;
+
+	begin_local_response_batch();
+
+	if (MyClient(source_p))
+	{
+		/* tag data could easily exceed max IRC message length, so including the tags in the snote
+		 * text isn't really workable. Sending a mass-tagmsg in itself is already pretty questionable,
+		 * but the spec allows for it. */
+		sendto_realops_snomask(SNO_GENERAL, L_ALL | L_NETWIDE,
+				msgtype == MESSAGE_TYPE_TAGMSG ? "%s sent mass-%s to %s" : "%s sent mass-%s to %s: %s",
+				get_oper_name(source_p),
+				cmdname_lower[msgtype],
+				mask, text);
+	}
+
+	/* suppress labeled-response on the message (it might be going to themselves) */
+	if (outgoing_response_info != NULL)
+		outgoing_response_info->skip_tags++;
+
+	sendto_match_butone_tags(IsServer(client_p) ? client_p : NULL, source_p,
+		mask + 1,
+		(*mask == '#') ? MATCH_HOST : MATCH_SERVER,
+		cli_cap, NOCAPS, serv_cap, NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
+		msgtype == MESSAGE_TYPE_TAGMSG ? "%s $%s" : "%s $%s :%s",
+		cmdname[msgtype], mask, text);
+
+	if (msgtype == MESSAGE_TYPE_PRIVMSG && *text == '\001')
+		source_p->large_ctcp_sent = rb_current_time();
+
+	if (outgoing_response_info != NULL)
+		outgoing_response_info->skip_tags--;
+
+	/* ECHO doesn't work with special syntax, so generate a local echo instead */
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+	{
+		const char *fmt = msgtype == MESSAGE_TYPE_TAGMSG
+			? ":%s!%s@%s %s %s"
+			: ":%s!%s@%s %s %s :%s";
+
+		sendto_one_tags(source_p, NOCAPS, NOCAPS,
+			msgbuf_p->n_tags, msgbuf_p->tags, fmt,
+			source_p->name, source_p->username, source_p->host,
+			cmdname[msgtype], mask, text);
 	}
 }
 
@@ -1028,130 +1228,4 @@ flood_attack_client(enum message_type msgtype, struct Client *source_p, struct C
 	}
 
 	return false;
-}
-
-/*
- * handle_special
- *
- * inputs	- server pointer
- *		- client pointer
- *		- nick stuff to grok for opers
- *		- text to send if grok
- *		- tags to send
- * output	- none
- * side effects	- all the traditional oper type messages are parsed here.
- *		  i.e. "/msg #some.host."
- *		  However, syntax has been changed.
- *		  previous syntax "/msg #some.host.mask"
- *		  now becomes     "/msg $#some.host.mask"
- *		  previous syntax of: "/msg $some.server.mask" remains
- *		  This disambiguates the syntax.
- */
-static void
-handle_special(enum message_type msgtype, struct Client *client_p,
-	       struct Client *source_p, const char *nick, const char *text, struct MsgBuf *msgbuf_p)
-{
-	struct Client *target_p;
-	char *server;
-	int cli_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CLICAP_MESSAGE_TAGS : 0;
-	int serv_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : 0;
-
-	/* user[%host]@server addressed?
-	 * NOTE: users can send to user@server, but not user%host@server
-	 * or opers@server
-	 */
-	if ((server = strchr(nick, '@')) != NULL)
-	{
-		if ((target_p = find_server(source_p, server + 1)) == NULL)
-		{
-			sendto_one_numeric(source_p, ERR_NOSUCHSERVER,
-					   form_str(ERR_NOSUCHSERVER), server + 1);
-			return;
-		}
-
-		if (!IsOper(source_p))
-		{
-			if(strchr(nick, '%') || (strncmp(nick, "opers", 5) == 0))
-			{
-				sendto_one_numeric(source_p, ERR_NOSUCHNICK,
-						   form_str(ERR_NOSUCHNICK), nick);
-				return;
-			}
-		}
-
-		/* somewhere else.. */
-		if (!IsMe(target_p))
-		{
-			sendto_one_tags(target_p, serv_cap, NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
-				msgtype == MESSAGE_TYPE_TAGMSG ? ":%s %s %s" : ":%s %s %s :%s",
-				get_id(source_p, target_p), cmdname[msgtype], nick, text);
-			return;
-		}
-
-		/* Check if someones msg'ing opers@our.server */
-		if (strncmp(nick, "opers@", 6) == 0)
-		{
-			if (msgtype != MESSAGE_TYPE_TAGMSG)
-				sendto_realops_snomask(SNO_GENERAL, L_ALL, "To opers: From: %s: %s",
-					source_p->name, text);
-			return;
-		}
-
-		/* This was not very useful except for bypassing certain
-		 * restrictions. Note that we still allow sending to
-		 * remote servers this way, for messaging pseudoservers
-		 * securely whether they have a service{} block or not.
-		 * -- jilles
-		 */
-		sendto_one_numeric(source_p, ERR_NOSUCHNICK,
-				   form_str(ERR_NOSUCHNICK), nick);
-		return;
-	}
-
-	/*
-	 * the following two cases allow masks in NOTICEs
-	 * (for OPERs only)
-	 *
-	 * Armin, 8Jun90 (gruner@informatik.tu-muenchen.de)
-	 */
-	if (IsOper(source_p) && *nick == '$')
-	{
-		if((*(nick + 1) == '$' || *(nick + 1) == '#'))
-			nick++;
-		else if (MyOper(source_p))
-		{
-			sendto_one(source_p,
-				   ":%s NOTICE %s :The command %s %s is no longer supported, please use $%s",
-				   me.name, source_p->name, cmdname[msgtype], nick, nick);
-			return;
-		}
-
-		if (MyClient(source_p) && !IsOperMassNotice(source_p))
-		{
-			sendto_one(source_p, form_str(ERR_NOPRIVS),
-				   me.name, source_p->name, "mass_notice");
-			return;
-		}
-
-		if (MyClient(source_p))
-		{
-			/* tag data could easily exceed max IRC message length, so including the tags in the snote
-			 * text isn't really workable. Sending a mass-tagmsg in itself is already pretty questionable,
-			 * but the spec allows for it. */
-			sendto_realops_snomask(SNO_GENERAL, L_ALL | L_NETWIDE,
-					msgtype == MESSAGE_TYPE_TAGMSG ? "%s sent mass-%s to %s" : "%s sent mass-%s to %s: %s",
-					get_oper_name(source_p),
-					cmdname_lower[msgtype],
-					nick, text);
-		}
-
-		sendto_match_butone_tags(IsServer(client_p) ? client_p : NULL, source_p,
-				    nick + 1,
-				    (*nick == '#') ? MATCH_HOST : MATCH_SERVER,
-				    cli_cap, 0, serv_cap, NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
-				    msgtype == MESSAGE_TYPE_TAGMSG ? "%s $%s" : "%s $%s :%s",
-					cmdname[msgtype], nick, text);
-		if (msgtype == MESSAGE_TYPE_PRIVMSG && *text == '\001')
-			source_p->large_ctcp_sent = rb_current_time();
-	}
 }

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -1074,7 +1074,7 @@ msg_client(enum message_type msgtype,
 	}
 	else
 	{
-		begin_remote_response_batch(1);
+		begin_remote_response_batch(1, target_p->servptr->name);
 		sendto_anywhere_tags(target_p, source_p, cmdname[msgtype],
 			msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS,
 			NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,
@@ -1094,7 +1094,7 @@ msg_client_targeted(enum message_type msgtype,
 {
 	s_assert(!IsMe(target_p) && IsServer(target_p));
 
-	begin_remote_response_batch(1);
+	begin_remote_response_batch(1, target_p->servptr->name);
 	sendto_one_tags(target_p,
 		msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS,
 		NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags,

--- a/modules/core/m_modules.c
+++ b/modules/core/m_modules.c
@@ -185,7 +185,7 @@ mo_modlist(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 
 	if(parc > 2)
 	{
-		begin_remote_response_batch(count_match_servs(source_p, parv[2], CAP_ENCAP, NOCAPS));
+		begin_remote_response_batch(count_match_servs(source_p, parv[2], CAP_ENCAP, NOCAPS), parv[2]);
 		sendto_match_servs(source_p, parv[2], CAP_ENCAP, NOCAPS,
 				"ENCAP %s MODLIST %s", parv[2], parv[1]);
 		if(match(parv[2], me.name) == 0)

--- a/modules/core/m_modules.c
+++ b/modules/core/m_modules.c
@@ -33,6 +33,7 @@
 #include "send.h"
 #include "packet.h"
 #include "logger.h"
+#include "response.h"
 
 static const char modules_desc[] = "Provides module management commands";
 
@@ -184,12 +185,14 @@ mo_modlist(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sour
 
 	if(parc > 2)
 	{
+		begin_remote_response_batch(count_match_servs(source_p, parv[2], CAP_ENCAP, NOCAPS));
 		sendto_match_servs(source_p, parv[2], CAP_ENCAP, NOCAPS,
 				"ENCAP %s MODLIST %s", parv[2], parv[1]);
 		if(match(parv[2], me.name) == 0)
 			return;
 	}
 
+	begin_local_response_batch();
 	do_modlist(source_p, parc > 1 ? parv[1] : 0);
 }
 

--- a/modules/m_accept.c
+++ b/modules/m_accept.c
@@ -33,6 +33,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char accept_desc[] =
 	"Provides the ACCEPT command for use with Caller ID/user mode +g";
@@ -70,6 +71,7 @@ m_accept(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	if(*parv[1] == '*')
 	{
+		begin_local_response_batch();
 		list_accepts(source_p);
 		return;
 	}

--- a/modules/m_admin.c
+++ b/modules/m_admin.c
@@ -33,6 +33,7 @@
 #include "parse.h"
 #include "hook.h"
 #include "modules.h"
+#include "response.h"
 
 const char admin_desc[] =
 	"Provides the ADMIN command to show server administrator information";
@@ -71,6 +72,7 @@ mr_admin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	else
 		last_used = rb_current_time();
 
+	begin_local_response_batch();
 	do_admin(source_p);
 }
 
@@ -94,10 +96,11 @@ m_admin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		else
 			last_used = rb_current_time();
 
-		if(hunt_server(client_p, source_p, ":%s ADMIN :%s", 1, parc, parv) != HUNTED_ISME)
+		if (hunt_server(client_p, source_p, ":%s ADMIN :%s", 1, parc, parv) != HUNTED_ISME)
 			return;
 	}
 
+	begin_local_response_batch();
 	do_admin(source_p);
 }
 
@@ -109,9 +112,10 @@ m_admin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 static void
 ms_admin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(hunt_server(client_p, source_p, ":%s ADMIN :%s", 1, parc, parv) != HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s ADMIN :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
+	begin_local_response_batch();
 	do_admin(source_p);
 }
 

--- a/modules/m_batch.c
+++ b/modules/m_batch.c
@@ -91,7 +91,7 @@ reset_global_context(const struct Client *orig_ic, const struct MsgBuf *orig_im,
 	outgoing_response_info = orig_ori;
 	incoming_client = orig_ic;
 	incoming_message = orig_im;
-	if (set_cap)
+	if (orig_ori != NULL && set_cap)
 		SetClientCap(orig_ori->source_p, set_cap);
 }
 

--- a/modules/m_batch.c
+++ b/modules/m_batch.c
@@ -32,6 +32,7 @@
 #include "hook.h"
 #include "modules.h"
 #include "batch.h"
+#include "response.h"
 
 static const char batch_desc[] =
 	"Provides the BATCH command for client-initiated or propagated batches";
@@ -62,6 +63,38 @@ mapi_hfn_list_av1 batch_hfnlist[] = {
 
 DECLARE_MODULE_AV2(batch, batch_modinit, batch_moddeinit, batch_clist, NULL, batch_hfnlist, NULL, NULL, batch_desc);
 
+/* Restore global contextual pointers with the opening BATCH message */
+static void
+restore_global_context(struct Client *client_p, struct Batch *batch)
+{
+	uint64_t CLICAP_LABELED_RESPONSE = capability_get(cli_capindex, "labeled-response", NULL);
+	uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
+	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p) && CLICAP_RECEIVE_LABEL)
+		ClearClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+
+	outgoing_response_info = batch->response_info;
+	incoming_client = client_p;
+	incoming_message = &batch->start->msg;
+
+	if (outgoing_response_info != NULL
+		&& MyConnect(outgoing_response_info->source_p)
+		&& IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH)
+		&& CLICAP_RECEIVE_LABEL)
+	{
+		SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+	}
+}
+
+static void
+reset_global_context(const struct Client *orig_ic, const struct MsgBuf *orig_im, struct ResponseInfo *orig_ori, uint64_t set_cap)
+{
+	outgoing_response_info = orig_ori;
+	incoming_client = orig_ic;
+	incoming_message = orig_im;
+	if (set_cap)
+		SetClientCap(orig_ori->source_p, set_cap);
+}
+
 static void
 batch_timeout(void *arg)
 {
@@ -79,6 +112,7 @@ batch_timeout(void *arg)
 			batch = ptr->data;
 			if (arg != NULL || batch->expires <= now)
 			{
+				restore_global_context(client, batch);
 				sendto_one(client, ":%s FAIL BATCH TIMEOUT %s :Batch timed out",
 					me.name, batch->tag);
 				client->localClient->pending_batch_lines -= batch->len + 1;
@@ -103,6 +137,9 @@ batch_timeout(void *arg)
 			client->localClient->pending_batch_lines = 0;
 		}
 	}
+
+	/* reset context back to NULL since we're in an event handler */
+	reset_global_context(NULL, NULL, NULL, NOCAPS);
 }
 
 static void
@@ -136,6 +173,7 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 		struct Batch *other = ptr->data;
 		if (other->parent == batch)
 		{
+			restore_global_context(client_p, other);
 			if (IsClient(source_p))
 				sendto_one(source_p, ":%s FAIL BATCH INCOMPLETE %s :Nested batch not finished before enclosing batch",
 					me.name, other->tag);
@@ -147,6 +185,7 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 	}
 
 	client_p->localClient->pending_batch_lines -= batch->len + 1;
+	restore_global_context(client_p, batch);
 
 	if (handler == NULL)
 	{
@@ -323,6 +362,10 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		batch->parent = parent;
 		rb_dlinkAddAlloc(batch, &client_p->localClient->pending_batches);
 		client_p->localClient->pending_batch_lines++;
+
+		/* postpone any labeled-response to when the batch completes */
+		batch->response_info = outgoing_response_info;
+		outgoing_response_info = NULL;
 	}
 	else
 	{
@@ -347,7 +390,19 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		}
 		else
 		{
+			/* save off global state since finish_batch() smashes it */
+			uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
+			const struct Client *orig_incoming_client = incoming_client;
+			const struct MsgBuf *orig_incoming_message = incoming_message;
+			struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+			bool has_receive_label = outgoing_response_info != NULL
+				&& CLICAP_RECEIVE_LABEL > 0
+				&& IsClientCapable(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+
 			finish_batch(client_p, source_p, batch);
+
+			reset_global_context(orig_incoming_client, orig_incoming_message, orig_outgoing_response_info,
+				has_receive_label ? CLICAP_RECEIVE_LABEL : NOCAPS);
 		}
 	}
 }

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -43,6 +43,7 @@
 #include "send.h"
 #include "s_conf.h"
 #include "hash.h"
+#include "response.h"
 
 static const char cap_desc[] = "Provides the commands used for client capability negotiation";
 
@@ -282,6 +283,7 @@ static void
 cap_list(struct Client *source_p, const char *arg)
 {
 	/* list of what theyre currently using */
+	begin_local_response_batch();
 	clicap_generate(source_p, "LIST",
 			source_p->localClient->client_caps ? source_p->localClient->client_caps : -1);
 }
@@ -304,6 +306,7 @@ cap_ls(struct Client *source_p, const char *arg)
 	}
 
 	/* list of what we support */
+	begin_local_response_batch();
 	clicap_generate(source_p, "LS", 0);
 }
 
@@ -322,6 +325,8 @@ cap_req(struct Client *source_p, const char *arg)
 
 	if(EmptyString(arg))
 		return;
+
+	begin_local_response_batch();
 
 	ret = snprintf(ack_buf, sizeof ack_buf, ":%s CAP %s ACK :%s",
 			me.name, EmptyString(source_p->name)? "*" : source_p->name, arg);

--- a/modules/m_challenge.c
+++ b/modules/m_challenge.c
@@ -45,6 +45,7 @@
 #include "s_user.h"
 #include "cache.h"
 #include "s_newconf.h"
+#include "response.h"
 
 #define CHALLENGE_WIDTH BUFSIZE - (NICKLEN + HOSTLEN + 12)
 #define CHALLENGE_EXPIRES	180	/* 180 seconds should be more than long enough */
@@ -114,6 +115,8 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 	unsigned char *b_response;
 	size_t cnt;
 	int len = 0;
+
+	begin_local_response_batch();
 
         if (ConfigFileEntry.oper_secure_only && !IsSecureClient(source_p))
         {

--- a/modules/m_close.c
+++ b/modules/m_close.c
@@ -30,6 +30,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char close_desc[] = "Provides the CLOSE command to clear all unfinished connections";
 
@@ -55,6 +56,8 @@ mo_close(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	rb_dlink_node *ptr;
 	rb_dlink_node *ptr_next;
 	int closed = 0;
+
+	begin_local_response_batch();
 
 	RB_DLINK_FOREACH_SAFE(ptr, ptr_next, unknown_list.head)
 	{

--- a/modules/m_etrace.c
+++ b/modules/m_etrace.c
@@ -129,7 +129,7 @@ mo_etrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 			{
 				if (!MyClient(target_p))
 				{
-					begin_remote_response_batch(1);
+					begin_remote_response_batch(1, target_p->servptr->name);
 					sendto_one(target_p, ":%s ENCAP %s ETRACE %s",
 						get_id(source_p, target_p),
 						target_p->servptr->name,

--- a/modules/m_etrace.c
+++ b/modules/m_etrace.c
@@ -47,6 +47,7 @@
 #include "parse.h"
 #include "modules.h"
 #include "logger.h"
+#include "response.h"
 #include "supported.h"
 
 static const char etrace_desc[] =
@@ -106,24 +107,37 @@ mo_etrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	if(parc > 1 && !EmptyString(parv[1]))
 	{
 		if(!irccmp(parv[1], "-full"))
+		{
+			begin_local_response_batch();
 			do_etrace_full(source_p);
+		}
 		else if(!irccmp(parv[1], "-v6"))
+		{
+			begin_local_response_batch();
 			do_etrace(source_p, 0, 1);
+		}
 		else if(!irccmp(parv[1], "-v4"))
+		{
+			begin_local_response_batch();
 			do_etrace(source_p, 1, 0);
+		}
 		else
 		{
 			struct Client *target_p = find_named_person(parv[1]);
 
 			if(target_p)
 			{
-				if(!MyClient(target_p))
+				if (!MyClient(target_p))
+				{
+					begin_remote_response_batch(1);
 					sendto_one(target_p, ":%s ENCAP %s ETRACE %s",
 						get_id(source_p, target_p),
 						target_p->servptr->name,
 						get_id(target_p, target_p));
+				}
 				else
 				{
+					begin_local_response_batch();
 					do_single_etrace(source_p, target_p);
 					sendto_one_numeric(source_p, RPL_ENDOFTRACE, form_str(RPL_ENDOFTRACE), target_p->name);
 				}
@@ -134,7 +148,10 @@ mo_etrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 		}
 	}
 	else
+	{
+		begin_local_response_batch();
 		do_etrace(source_p, 1, 1);
+	}
 }
 
 static void
@@ -267,6 +284,8 @@ m_chantrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		return;
 	}
 
+	begin_local_response_batch();
+
 	RB_DLINK_FOREACH(ptr, chptr->members.head)
 	{
 		msptr = ptr->data;
@@ -373,6 +392,7 @@ mo_masktrace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *so
 		return;
 	}
 
+	begin_local_response_batch();
 	match_masktrace(source_p, &global_client_list, username, hostname, name, gecos);
 	sendto_one_numeric(source_p, RPL_ENDOFTRACE, form_str(RPL_ENDOFTRACE), me.name);
 }

--- a/modules/m_grant.c
+++ b/modules/m_grant.c
@@ -14,6 +14,7 @@
 #include "s_conf.h"
 #include "s_newconf.h"
 #include "msgbuf.h"
+#include "response.h"
 
 static void mo_grant(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[]);
 static void me_grant(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[]);
@@ -52,10 +53,12 @@ mo_grant(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	if (MyClient(target_p))
 	{
+		begin_local_response_batch();
 		do_grant(source_p, target_p, parv[2]);
 	}
 	else
 	{
+		begin_remote_response_batch(1);
 		sendto_one(target_p, ":%s ENCAP %s GRANT %s %s",
 				get_id(source_p, target_p), target_p->servptr->name,
 				get_id(target_p, target_p), parv[2]);

--- a/modules/m_grant.c
+++ b/modules/m_grant.c
@@ -58,7 +58,7 @@ mo_grant(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	}
 	else
 	{
-		begin_remote_response_batch(1);
+		begin_remote_response_batch(1, target_p->servptr->name);
 		sendto_one(target_p, ":%s ENCAP %s GRANT %s %s",
 				get_id(source_p, target_p), target_p->servptr->name,
 				get_id(target_p, target_p), parv[2]);

--- a/modules/m_help.c
+++ b/modules/m_help.c
@@ -35,6 +35,7 @@
 #include "hash.h"
 #include "cache.h"
 #include "rb_dictionary.h"
+#include "response.h"
 
 static const char help_desc[] =
 	"Provides the help facility for commands, modes, and server concepts";
@@ -108,6 +109,8 @@ dohelp(struct Client *source_p, int flags, const char *topic)
 
 	fptr = hptr->contents.head;
 	lineptr = fptr->data;
+
+	begin_local_response_batch();
 
 	/* first line cant be empty */
 	sendto_one(source_p, form_str(RPL_HELPSTART),

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -37,6 +37,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 #include "s_newconf.h"
 
 static const char info_desc[] =
@@ -695,9 +696,10 @@ m_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	else
 		last_used = rb_current_time();
 
-	if(hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) != HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
+	begin_local_response_batch();
 	send_info_text(source_p);
 	send_birthdate_online_time(source_p);
 
@@ -711,21 +713,21 @@ m_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 static void
 mo_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) == HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s INFO :%s", 1, parc, parv) != HUNTED_ISME)
+		return;
+
+	begin_local_response_batch();
+	send_info_text(source_p);
+
+	if (IsOperGeneral(source_p))
 	{
-		send_info_text(source_p);
-
-		if(IsOperGeneral(source_p))
-		{
-			send_conf_options(source_p);
-			sendto_one_numeric(source_p, RPL_INFO, ":%s",
-					rb_lib_version());
-		}
-
-		send_birthdate_online_time(source_p);
-
-		sendto_one_numeric(source_p, RPL_ENDOFINFO, form_str(RPL_ENDOFINFO));
+		send_conf_options(source_p);
+		sendto_one_numeric(source_p, RPL_INFO, ":%s", rb_lib_version());
 	}
+
+	send_birthdate_online_time(source_p);
+
+	sendto_one_numeric(source_p, RPL_ENDOFINFO, form_str(RPL_ENDOFINFO));
 }
 
 /*

--- a/modules/m_links.c
+++ b/modules/m_links.c
@@ -34,6 +34,7 @@
 #include "parse.h"
 #include "modules.h"
 #include "hook.h"
+#include "response.h"
 #include "scache.h"
 #include "s_assert.h"
 
@@ -70,7 +71,10 @@ static void
 m_links(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
 	if(ConfigServerHide.flatten_links && !IsExemptShide(source_p))
+	{
+		begin_local_response_batch();
 		scache_send_flattened_links(source_p);
+	}
 	else
 		mo_links(msgbuf_p, client_p, source_p, parc, parv);
 }
@@ -87,10 +91,10 @@ mo_links(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	if(parc > 2)
 	{
-		if(strlen(parv[2]) > HOSTLEN)
+		if (strlen(parv[2]) > HOSTLEN)
 			return;
-		if(hunt_server(client_p, source_p, ":%s LINKS %s :%s", 1, parc, parv)
-		   != HUNTED_ISME)
+
+		if (hunt_server(client_p, source_p, ":%s LINKS %s :%s", 1, parc, parv) != HUNTED_ISME)
 			return;
 
 		mask = parv[2];
@@ -106,6 +110,7 @@ mo_links(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	hd.arg1 = mask;
 	hd.arg2 = NULL;
 
+	begin_local_response_batch();
 	call_hook(doing_links_hook, &hd);
 
 	RB_DLINK_FOREACH(ptr, global_serv_list.head)

--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -50,6 +50,7 @@
 #include "s_assert.h"
 #include "logger.h"
 #include "rb_radixtree.h"
+#include "response.h"
 
 static const char list_desc[] = "Provides the LIST command to clients to view non-hidden channels";
 
@@ -148,6 +149,7 @@ m_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		/* pace this due to the sheer traffic involved */
 		if (((last_used + ConfigFileEntry.pace_wait) > rb_current_time()))
 		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_LOAD2HI), me.name, source_p->name, "LIST");
 			sendto_one(source_p, form_str(RPL_LISTEND), me.name, source_p->name);
 			return;
@@ -193,6 +195,7 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	/* Single channel. */
 	if (args && IsChannelName(args) && !strpbrk(args, "*?, "))
 	{
+		begin_local_response_batch();
 		safelist_channel_named(source_p, args, operspy);
 		return;
 	}
@@ -306,11 +309,16 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		}
 	}
 
+	/* mark it as a "remote" response so we don't terminate the batch at the end of the command handler */
+	begin_remote_response_batch(1);
+	params->response_info = outgoing_response_info;
+
 	safelist_client_instantiate(source_p, params);
 	return;
 
 fail:
 	rb_free(params);
+	begin_local_response_batch();
 	sendto_one(source_p, form_str(RPL_LISTSTART), me.name, source_p->name);
 	sendto_one_notice(source_p, ":Invalid parameters for /LIST");
 	sendto_one(source_p, form_str(RPL_LISTEND), me.name, source_p->name);
@@ -413,9 +421,18 @@ static void safelist_client_release(struct Client *client_p)
 	rb_free(client_p->localClient->safelist_data->nomask);
 	rb_free(client_p->localClient->safelist_data);
 
+	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+	outgoing_response_info = client_p->localClient->safelist_data->response_info;
+
 	client_p->localClient->safelist_data = NULL;
 
 	sendto_one(client_p, form_str(RPL_LISTEND), me.name, client_p->name);
+
+	if (outgoing_response_info != NULL)
+		sendto_one(client_p, ":%s BATCH -%s", me.name, outgoing_response_info->batch);
+
+	free_response_batch(outgoing_response_info);
+	outgoing_response_info = orig_outgoing_response_info;
 }
 
 /*
@@ -514,6 +531,8 @@ static void safelist_iterate_client(struct Client *source_p)
 {
 	struct Channel *chptr;
 	rb_radixtree_iteration_state iter;
+	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+	outgoing_response_info = source_p->localClient->safelist_data->response_info;
 
 	RB_RADIXTREE_FOREACH_FROM(chptr, &iter, channel_tree, source_p->localClient->safelist_data->chname)
 	{
@@ -521,6 +540,7 @@ static void safelist_iterate_client(struct Client *source_p)
 		{
 			rb_free(source_p->localClient->safelist_data->chname);
 			source_p->localClient->safelist_data->chname = rb_strdup(chptr->chname);
+			outgoing_response_info = orig_outgoing_response_info;
 
 			return;
 		}
@@ -528,6 +548,7 @@ static void safelist_iterate_client(struct Client *source_p)
 		safelist_one_channel(source_p, chptr, source_p->localClient->safelist_data);
 	}
 
+	outgoing_response_info = orig_outgoing_response_info;
 	safelist_client_release(source_p);
 }
 

--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -74,6 +74,9 @@ static void safelist_iterate_client(struct Client *source_p);
 static void safelist_iterate_clients(void *unused);
 static void safelist_channel_named(struct Client *source_p, const char *name, int operspy);
 
+static uint64_t restore_global_context(struct Client *);
+static void reset_global_context(struct ResponseInfo *, uint64_t);
+
 struct Message list_msgtab = {
 	"LIST", 0, 0, 0, 0,
 	{mg_unreg, {m_list, 0}, mg_ignore, mg_ignore, mg_ignore, {mo_list, 0}}
@@ -108,7 +111,30 @@ static int _modinit(void)
 
 static void _moddeinit(void)
 {
+	rb_dlink_node *n, *n2;
+	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+	uint64_t set_cap = NOCAPS;
+	bool first = true;
+
 	rb_event_delete(iterate_clients_ev);
+
+	RB_DLINK_FOREACH_SAFE(n, n2, safelisting_clients.head)
+	{
+		struct Client *source_p = n->data;
+		if (first)
+		{
+			set_cap = restore_global_context(source_p);
+			first = false;
+		}
+		else
+			restore_global_context(source_p);
+
+		sendto_one_notice(source_p, ":/LIST aborted");
+		safelist_client_release(source_p);
+	}
+
+	if (!first)
+		reset_global_context(orig_outgoing_response_info, set_cap);
 
 	delete_isupport("SAFELIST");
 	delete_isupport("ELIST");
@@ -122,7 +148,11 @@ static void safelist_check_cliexit(void *data)
 	 */
 	if (MyClient(hdata->target) && hdata->target->localClient->safelist_data != NULL)
 	{
+		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+		uint64_t set_cap = restore_global_context(hdata->target);
+		sendto_one_notice(hdata->target, ":/LIST aborted");
 		safelist_client_release(hdata->target);
+		reset_global_context(orig_outgoing_response_info, set_cap);
 	}
 }
 
@@ -139,8 +169,11 @@ m_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 
 	if (source_p->localClient->safelist_data != NULL)
 	{
+		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+		uint64_t set_cap = restore_global_context(source_p);
 		sendto_one_notice(source_p, ":/LIST aborted");
 		safelist_client_release(source_p);
+		reset_global_context(orig_outgoing_response_info, set_cap);
 		return;
 	}
 
@@ -175,8 +208,11 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	if (source_p->localClient->safelist_data != NULL)
 	{
+		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
+		uint64_t set_cap = restore_global_context(source_p);
 		sendto_one_notice(source_p, ":/LIST aborted");
 		safelist_client_release(source_p);
+		reset_global_context(orig_outgoing_response_info, set_cap);
 		return;
 	}
 
@@ -310,7 +346,7 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	}
 
 	/* mark it as a "remote" response so we don't terminate the batch at the end of the command handler */
-	begin_remote_response_batch(1);
+	begin_remote_response_batch(1, "");
 	params->response_info = outgoing_response_info;
 
 	safelist_client_instantiate(source_p, params);
@@ -399,6 +435,41 @@ static void safelist_client_instantiate(struct Client *client_p, struct ListClie
 	safelist_iterate_client(client_p);
 }
 
+/* Restore global contextual pointers for SAFELIST */
+static uint64_t
+restore_global_context(struct Client *client_p)
+{
+	uint64_t CLICAP_LABELED_RESPONSE = capability_get(cli_capindex, "labeled-response", NULL);
+	uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
+	uint64_t set_cap = NOCAPS;
+
+	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p) && CLICAP_RECEIVE_LABEL)
+	{
+		set_cap = IsClientCapable(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL) ? CLICAP_RECEIVE_LABEL : NOCAPS;
+		ClearClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+	}
+
+	outgoing_response_info = client_p->localClient->safelist_data->response_info;
+
+	if (outgoing_response_info != NULL
+		&& MyConnect(outgoing_response_info->source_p)
+		&& IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH)
+		&& CLICAP_RECEIVE_LABEL)
+	{
+		SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+	}
+
+	return set_cap;
+}
+
+static void
+reset_global_context(struct ResponseInfo *orig, uint64_t set_cap)
+{
+	outgoing_response_info = orig;
+	if (orig != NULL && set_cap)
+		SetClientCap(orig->source_p, set_cap);
+}
+
 /*
  * safelist_client_release()
  *
@@ -409,10 +480,8 @@ static void safelist_client_instantiate(struct Client *client_p, struct ListClie
  */
 static void safelist_client_release(struct Client *client_p)
 {
-	if(!MyClient(client_p))
+	if (!MyClient(client_p))
 		return;
-
-	s_assert(MyClient(client_p));
 
 	rb_dlinkFindDestroy(client_p, &safelisting_clients);
 
@@ -420,9 +489,6 @@ static void safelist_client_release(struct Client *client_p)
 	rb_free(client_p->localClient->safelist_data->mask);
 	rb_free(client_p->localClient->safelist_data->nomask);
 	rb_free(client_p->localClient->safelist_data);
-
-	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-	outgoing_response_info = client_p->localClient->safelist_data->response_info;
 
 	client_p->localClient->safelist_data = NULL;
 
@@ -432,7 +498,6 @@ static void safelist_client_release(struct Client *client_p)
 		sendto_one(client_p, ":%s BATCH -%s", me.name, outgoing_response_info->batch);
 
 	free_response_batch(outgoing_response_info);
-	outgoing_response_info = orig_outgoing_response_info;
 }
 
 /*
@@ -532,7 +597,7 @@ static void safelist_iterate_client(struct Client *source_p)
 	struct Channel *chptr;
 	rb_radixtree_iteration_state iter;
 	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-	outgoing_response_info = source_p->localClient->safelist_data->response_info;
+	uint64_t set_cap = restore_global_context(source_p);
 
 	RB_RADIXTREE_FOREACH_FROM(chptr, &iter, channel_tree, source_p->localClient->safelist_data->chname)
 	{
@@ -548,8 +613,8 @@ static void safelist_iterate_client(struct Client *source_p)
 		safelist_one_channel(source_p, chptr, source_p->localClient->safelist_data);
 	}
 
-	outgoing_response_info = orig_outgoing_response_info;
 	safelist_client_release(source_p);
+	reset_global_context(orig_outgoing_response_info, set_cap);
 }
 
 static void safelist_iterate_clients(void *unused)

--- a/modules/m_lusers.c
+++ b/modules/m_lusers.c
@@ -33,6 +33,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char lusers_desc[] =
 	"Provides the LUSERS command to view the number of current and maximum lusers on a server";
@@ -74,11 +75,11 @@ m_lusers(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		else
 			last_used = rb_current_time();
 
-		if(hunt_server(client_p, source_p, ":%s LUSERS %s :%s", 2, parc, parv) !=
-			   HUNTED_ISME)
+		if (hunt_server(client_p, source_p, ":%s LUSERS %s :%s", 2, parc, parv) != HUNTED_ISME)
 			return;
 	}
 
+	begin_local_response_batch();
 	show_lusers(source_p);
 }
 

--- a/modules/m_map.c
+++ b/modules/m_map.c
@@ -24,6 +24,7 @@
 #include "client.h"
 #include "modules.h"
 #include "numeric.h"
+#include "response.h"
 #include "send.h"
 #include "s_conf.h"
 #include "scache.h"
@@ -54,6 +55,8 @@ static char buf[BUFSIZE];
 static void
 m_map(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
+	begin_local_response_batch();
+
 	if((!IsExemptShide(source_p) && ConfigServerHide.flatten_links) ||
 	   ConfigFileEntry.map_oper_only)
 	{
@@ -72,6 +75,7 @@ m_map(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 static void
 mo_map(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
+	begin_local_response_batch();
 	dump_map(client_p, &me, buf);
 	scache_send_missing(client_p);
 	sendto_one_numeric(client_p, RPL_MAPEND, form_str(RPL_MAPEND));

--- a/modules/m_monitor.c
+++ b/modules/m_monitor.c
@@ -35,6 +35,7 @@
 #include "modules.h"
 #include "monitor.h"
 #include "numeric.h"
+#include "response.h"
 #include "s_conf.h"
 #include "send.h"
 #include "supported.h"
@@ -280,6 +281,7 @@ m_monitor(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 				return;
 			}
 
+			begin_local_response_batch();
 			add_monitor(source_p, parv[2]);
 			break;
 		case '-':
@@ -300,11 +302,13 @@ m_monitor(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 
 		case 'L':
 		case 'l':
+			begin_local_response_batch();
 			list_monitor(source_p);
 			break;
 
 		case 'S':
 		case 's':
+			begin_local_response_batch();
 			show_monitor_status(source_p);
 			break;
 

--- a/modules/m_motd.c
+++ b/modules/m_motd.c
@@ -35,6 +35,7 @@
 #include "s_conf.h"
 #include "cache.h"
 #include "ratelimit.h"
+#include "response.h"
 
 static const char motd_desc[] = "Provides the MOTD command to view the Message of the Day";
 
@@ -63,6 +64,7 @@ m_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		/* do nothing */
 	} else if ((last_used + ConfigFileEntry.pace_wait) > rb_current_time() || !ratelimit_client(source_p, 6)) {
 		/* safe enough to give this on a local connect only */
+		begin_local_response_batch();
 		sendto_one(source_p, form_str(RPL_LOAD2HI),
 			   me.name, source_p->name, "MOTD");
 		sendto_one(source_p, form_str(RPL_ENDOFMOTD),
@@ -72,9 +74,10 @@ m_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		last_used = rb_current_time();
 	}
 
-	if(hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
+	begin_local_response_batch();
 	send_user_motd(source_p);
 }
 
@@ -85,8 +88,9 @@ m_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 static void
 mo_motd(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s MOTD :%s", 1, parc, parv) != HUNTED_ISME)
 		return;
 
+	begin_local_response_batch();
 	send_user_motd(source_p);
 }

--- a/modules/m_names.c
+++ b/modules/m_names.c
@@ -35,6 +35,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 #include "s_newconf.h"
 
 static const char names_desc[] = "Provides the NAMES command to view users on a channel";
@@ -82,7 +83,10 @@ m_names(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		}
 
 		if((chptr = find_channel(p)) != NULL)
+		{
+			begin_local_response_batch();
 			channel_member_names(chptr, source_p, 1);
+		}
 		else
 			sendto_one(source_p, form_str(RPL_ENDOFNAMES),
 				   me.name, source_p->name, p);
@@ -93,6 +97,7 @@ m_names(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		{
 			if((last_used + ConfigFileEntry.pace_wait) > rb_current_time())
 			{
+				begin_local_response_batch();
 				sendto_one(source_p, form_str(RPL_LOAD2HI),
 					   me.name, source_p->name, "NAMES");
 				sendto_one(source_p, form_str(RPL_ENDOFNAMES),
@@ -103,6 +108,7 @@ m_names(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 				last_used = rb_current_time();
 		}
 
+		begin_local_response_batch();
 		names_global(source_p);
 		sendto_one(source_p, form_str(RPL_ENDOFNAMES),
 			   me.name, source_p->name, "*");

--- a/modules/m_oper.c
+++ b/modules/m_oper.c
@@ -38,6 +38,7 @@
 #include "modules.h"
 #include "packet.h"
 #include "cache.h"
+#include "response.h"
 
 static const char oper_desc[] = "Provides the OPER command to become an IRC operator";
 
@@ -151,6 +152,7 @@ m_oper(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 
 	if(match_oper_password(password, oper_p))
 	{
+		begin_local_response_batch();
 		oper_up(source_p, oper_p);
 
 		ilog(L_OPERED, "OPER %s by %s!%s@%s (%s)",

--- a/modules/m_privs.c
+++ b/modules/m_privs.c
@@ -39,6 +39,7 @@
 #include "s_conf.h"
 #include "s_newconf.h"
 #include "hash.h"
+#include "response.h"
 
 static const char privs_desc[] = "Provides the PRIVS command to inspect an operator's privileges";
 
@@ -175,12 +176,18 @@ mo_privs(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		server_p = server_p->servptr;
 
 	if (IsMe(server_p))
+	{
+		begin_local_response_batch();
 		show_privs(source_p, target_p);
+	}
 	else
+	{
+		begin_remote_response_batch(1);
 		sendto_one(server_p, ":%s ENCAP %s PRIVS %s",
 				get_id(source_p, server_p),
 				server_p->name,
 				use_id(target_p));
+	}
 }
 
 static void
@@ -193,5 +200,6 @@ m_privs(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		return;
 	}
 
+	begin_local_response_batch();
 	show_privs(source_p, source_p);
 }

--- a/modules/m_privs.c
+++ b/modules/m_privs.c
@@ -182,7 +182,7 @@ mo_privs(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	}
 	else
 	{
-		begin_remote_response_batch(1);
+		begin_remote_response_batch(1, server_p->name);
 		sendto_one(server_p, ":%s ENCAP %s PRIVS %s",
 				get_id(source_p, server_p),
 				server_p->name,

--- a/modules/m_scan.c
+++ b/modules/m_scan.c
@@ -47,6 +47,7 @@
 #include "parse.h"
 #include "modules.h"
 #include "logger.h"
+#include "response.h"
 
 static const char scan_desc[] =
 	"Provides the SCAN command to show users that have a mode set or cleared";
@@ -207,6 +208,9 @@ scan_umodes(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 			return;
 		}
 	}
+
+	if (list_users)
+		begin_local_response_batch();
 
 	RB_DLINK_FOREACH(tn, target_list->head)
 	{

--- a/modules/m_set.c
+++ b/modules/m_set.c
@@ -37,6 +37,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char set_desc[] = "Provides the SET command to change server parameters";
 
@@ -548,5 +549,6 @@ mo_set(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		return;
 	}
 
+	begin_local_response_batch();
 	list_quote_commands(source_p);
 }

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -1000,6 +1000,9 @@ stats_tstats (struct Client *source_p)
 		sp.is_cbr += target_p->localClient->receiveB;
 		sp.is_cti += (unsigned long long)(rb_current_time() - target_p->localClient->firsttime);
 		sp.is_cl++;
+		sp.is_cib += rb_dlink_list_length(&target_p->localClient->pending_batches);
+		sp.is_cibl += target_p->localClient->pending_batch_lines;
+		sp.is_rrb += rb_dlink_list_length(&target_p->localClient->pending_remote_responses);
 	}
 
 	RB_DLINK_FOREACH(ptr, unknown_list.head)
@@ -1053,6 +1056,11 @@ stats_tstats (struct Client *source_p)
 	sendto_one_numeric(source_p, RPL_STATSDEBUG,
 				"T :time connected %llu %llu",
 				sp.is_cti, sp.is_sti);
+	sendto_one_numeric(source_p, RPL_STATSDEBUG,
+				"T :open client batches %u lines %u",
+				sp.is_cib, sp.is_cibl);
+	sendto_one_numeric(source_p, RPL_STATSDEBUG,
+				"T :remote response batches %u", sp.is_rrb);
 }
 
 static void

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -45,6 +45,7 @@
 #include "reject.h"
 #include "whowas.h"
 #include "rb_radixtree.h"
+#include "response.h"
 #include "sslproc.h"
 #include "s_assert.h"
 
@@ -209,6 +210,7 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		/* Check the user is actually allowed to do /stats, and isnt flooding */
 		if((last_used + ConfigFileEntry.pace_wait) > rb_current_time())
 		{
+			begin_local_response_batch();
 			/* safe enough to give this on a local connect only */
 			sendto_one(source_p, form_str(RPL_LOAD2HI),
 				   me.name, source_p->name, "STATS");
@@ -220,8 +222,10 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			last_used = rb_current_time();
 	}
 
-	if(hunt_server(client_p, source_p, ":%s STATS %s :%s", 2, parc, parv) != HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s STATS %s :%s", 2, parc, parv) != HUNTED_ISME)
 		return;
+
+	begin_local_response_batch();
 
 	hook_data_int data = {
 		.client = source_p,

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -38,6 +38,7 @@
 #include "s_conf.h"
 #include "s_newconf.h"
 #include "reject.h"
+#include "response.h"
 
 static const char testline_desc[] = "Provides the ability to test I/K/D/X lines and RESVs";
 
@@ -161,20 +162,24 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 			return;
 		}
 		/* Otherwise, aconf is an exempt{} */
-		if(aconf == NULL &&
-				(duration = is_reject_ip((struct sockaddr *)&ip)))
+		if (aconf == NULL && (duration = is_reject_ip((struct sockaddr *)&ip)))
+		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_TESTLINE),
 					me.name, source_p->name,
 					'!',
 					duration / 60L,
 					host, "Reject cache");
-		if(aconf == NULL &&
-				(duration = is_throttle_ip((struct sockaddr *)&ip)))
+		}
+		if (aconf == NULL && (duration = is_throttle_ip((struct sockaddr *)&ip)))
+		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_TESTLINE),
 					me.name, source_p->name,
 					'!',
 					duration / 60L,
 					host, "Throttled");
+		}
 	}
 
 	if (username != NULL)
@@ -323,17 +328,23 @@ mo_testkline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *so
 		}
 		/* Otherwise, aconf is an exempt{} */
 		if (aconf == NULL && (duration = is_reject_ip((struct sockaddr *)&ip)))
+		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_TESTLINE),
 					me.name, source_p->name,
 					'!',
 					duration / 60L,
 					host, "Reject cache");
+		}
 		if (aconf == NULL && (duration = is_throttle_ip((struct sockaddr *)&ip)))
+		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_TESTLINE),
 					me.name, source_p->name,
 					'!',
 					duration / 60L,
 					host, "Throttled");
+		}
 	}
 
 	if (username != NULL)

--- a/modules/m_time.c
+++ b/modules/m_time.c
@@ -70,7 +70,7 @@ m_time(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	if(MyClient(source_p) && !IsFloodDone(source_p))
 		flood_endgrace(source_p);
 
-	if(hunt_server(client_p, source_p, ":%s TIME :%s", 1, parc, parv) == HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s TIME :%s", 1, parc, parv) == HUNTED_ISME)
 		sendto_one_numeric(source_p, RPL_TIME, form_str(RPL_TIME),
 				   me.name, date());
 }

--- a/modules/m_topic.c
+++ b/modules/m_topic.c
@@ -39,6 +39,7 @@
 #include "packet.h"
 #include "tgchange.h"
 #include "logger.h"
+#include "response.h"
 #include "inline/stringops.h"
 
 static const char topic_desc[] =
@@ -167,6 +168,7 @@ m_topic(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 					me.name, source_p->name, name);
 		else
 		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_TOPIC),
 					me.name, source_p->name, chptr->chname, chptr->topic);
 

--- a/modules/m_trace.c
+++ b/modules/m_trace.c
@@ -38,6 +38,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char trace_desc[] =
 	"Provides the TRACE command to trace the route to a client or server";
@@ -83,8 +84,7 @@ m_trace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 		if(parc > 2)
 		{
-			if(hunt_server(client_p, source_p, ":%s TRACE %s :%s", 2, parc, parv) !=
-					HUNTED_ISME)
+			if (hunt_server(client_p, source_p, ":%s TRACE %s :%s", 2, parc, parv) != HUNTED_ISME)
 				return;
 		}
 	}
@@ -157,6 +157,8 @@ m_trace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	wilds = strchr(tname, '*') || strchr(tname, '?');
 	dow = wilds || doall;
+
+	begin_local_response_batch();
 
 	/* specific trace */
 	if(!dow)

--- a/modules/m_users.c
+++ b/modules/m_users.c
@@ -32,6 +32,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char users_desc[] =
 	"Provides the USERS command to display connection statistics locally and globally";
@@ -54,8 +55,9 @@ DECLARE_MODULE_AV2(users, NULL, NULL, users_clist, NULL, NULL, NULL, NULL, users
 static void
 m_users(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(hunt_server(client_p, source_p, ":%s USERS :%s", 1, parc, parv) == HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s USERS :%s", 1, parc, parv) == HUNTED_ISME)
 	{
+		begin_local_response_batch();
 		sendto_one_numeric(source_p, RPL_LOCALUSERS,
 				   form_str(RPL_LOCALUSERS),
 				   (int)rb_dlink_list_length(&lclient_list),

--- a/modules/m_version.c
+++ b/modules/m_version.c
@@ -33,6 +33,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 
 static const char version_desc[] =
 	"Provides the VERSION command to display server version information";
@@ -78,10 +79,11 @@ m_version(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 		else
 			last_used = rb_current_time();
 
-		if(hunt_server(client_p, source_p, ":%s VERSION :%s", 1, parc, parv) != HUNTED_ISME)
+		if (hunt_server(client_p, source_p, ":%s VERSION :%s", 1, parc, parv) != HUNTED_ISME)
 			return;
 	}
 
+	begin_local_response_batch();
 	sendto_one_numeric(source_p, RPL_VERSION, form_str(RPL_VERSION),
 			   ircd_version, serno,
 #ifdef CUSTOM_BRANDING
@@ -99,8 +101,9 @@ m_version(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 static void
 mo_version(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(hunt_server(client_p, source_p, ":%s VERSION :%s", 1, parc, parv) == HUNTED_ISME)
+	if (hunt_server(client_p, source_p, ":%s VERSION :%s", 1, parc, parv) == HUNTED_ISME)
 	{
+		begin_local_response_batch();
 		sendto_one_numeric(source_p, RPL_VERSION, form_str(RPL_VERSION),
 				   ircd_version, serno,
 #ifdef CUSTOM_BRANDING

--- a/modules/m_who.c
+++ b/modules/m_who.c
@@ -38,6 +38,7 @@
 #include "packet.h"
 #include "s_newconf.h"
 #include "ratelimit.h"
+#include "response.h"
 #include "supported.h"
 
 #define FIELD_CHANNEL    0x0001
@@ -159,6 +160,8 @@ m_who(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 	mask = maskcopy;
 
 	collapse(mask);
+
+	begin_local_response_batch();
 
 	/* '/who *' */
 	if((*(mask + 1) == '\0') && (*mask == '*'))

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -41,6 +41,7 @@
 #include "hook.h"
 #include "s_newconf.h"
 #include "ratelimit.h"
+#include "response.h"
 #include "s_assert.h"
 
 static const char whois_desc[] =
@@ -96,6 +97,7 @@ m_whois(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			/* seeing as this is going across servers, we should limit it */
 			if((last_used + ConfigFileEntry.pace_wait_simple) > rb_current_time() || !ratelimit_client(source_p, 2))
 			{
+				begin_local_response_batch();
 				sendto_one(source_p, form_str(RPL_LOAD2HI),
 					   me.name, source_p->name, "WHOIS");
 				sendto_one_numeric(source_p, RPL_ENDOFWHOIS,
@@ -106,13 +108,14 @@ m_whois(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 				last_used = rb_current_time();
 		}
 
-		if(hunt_server(client_p, source_p, ":%s WHOIS %s :%s", 1, parc, parv) !=
-		   HUNTED_ISME)
+		if (hunt_server(client_p, source_p, ":%s WHOIS %s :%s", 1, parc, parv) != HUNTED_ISME)
 			return;
 
 		parv[1] = parv[2];
 
 	}
+
+	begin_local_response_batch();
 	do_whois(client_p, source_p, parc, parv);
 }
 

--- a/modules/m_whowas.c
+++ b/modules/m_whowas.c
@@ -37,6 +37,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "response.h"
 #include "s_newconf.h"
 
 static const char whowas_desc[] =
@@ -77,6 +78,7 @@ m_whowas(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 						ConfigFileEntry.pace_wait_simple
 				) > rb_current_time())
 		{
+			begin_local_response_batch();
 			sendto_one(source_p, form_str(RPL_LOAD2HI),
 				   me.name, source_p->name, "WHOWAS");
 			sendto_one_numeric(source_p, RPL_ENDOFWHOWAS, form_str(RPL_ENDOFWHOWAS),
@@ -92,8 +94,10 @@ m_whowas(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		max = atoi(parv[2]);
 
 	if(parc > 3)
-		if(hunt_server(client_p, source_p, ":%s WHOWAS %s %s :%s", 3, parc, parv))
+	{
+		if (hunt_server(client_p, source_p, ":%s WHOWAS %s %s :%s", 3, parc, parv) != HUNTED_ISME)
 			return;
+	}
 
 	if(!MyClient(source_p) && (max <= 0 || max > 20))
 		max = 20;
@@ -105,6 +109,8 @@ m_whowas(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	sendq_limit = get_sendq(client_p) * 9 / 10;
 	whowas_list = whowas_get_list(nick);
+
+	begin_local_response_batch();
 
 	if(whowas_list == NULL)
 	{

--- a/modules/meson.build
+++ b/modules/meson.build
@@ -1,5 +1,6 @@
 autoload_modules = [
   'cap_account_tag',
+  'cap_labeled_response',
   'cap_server_time',
   'chm_nocolour',
   'chm_noctcp',


### PR DESCRIPTION
This was broken into multiple commits for easier review as there are a number of distinct things changed.

- Expand outbound_msgbuf hook to use a different hook data. First three fields remain compatible with the original hook_data struct for a semblance of ABI compatibility. (that is, newer core with older modules. older core with new modules that use new fields will crash)
- new parse_end hook for automatic sending of labelled ACK and closing labeled-response batches
- STATS t expanded to show details about pending client-initiated and labeled-response batches
- new servonly clicap for propagation of s2s tags that must never get sent to actual clients
- new clicap flag so message tags with it as its capmask will not propagate between servers
- ENCAP ACK s2s command to signal completion of a remote batch, automatically sent by parse.c
- SAFELIST and BATCH needed to gain tracking for labeled-response
- Removal of opers@server special message target