### PR TITLE
Fix logfile checks

### DIFF
--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -643,6 +643,7 @@ solanum_main(int argc, char * const argv[])
 	init_builtin_capabs();
 	default_server_capabs = CAP_MASK;
 
+	init_hook();
 	init_main_logfile();
 	newconf_init();
 	init_s_conf();
@@ -652,7 +653,6 @@ solanum_main(int argc, char * const argv[])
 	init_host_hash();
 	clear_hash_parse();
 	init_client();
-	init_hook();
 	init_channels();
 	initclass();
 	whowas_init();

--- a/ircd/logger.c
+++ b/ircd/logger.c
@@ -101,36 +101,34 @@ verify_logfile_access(const char *filename)
 		}
 		return;
 	}
-
-	if(access(filename, W_OK) == -1)
-	{
-		snprintf(buf, sizeof(buf), "WARNING: Access denied for logfile %s: %s", filename, strerror(errno));
-		if(testing_conf || server_state_foreground)
-			fprintf(stderr, "%s\n", buf);
-		sendto_realops_snomask(SNO_GENERAL, L_ALL, "%s", buf);
-		return;
-	}
-	return;
 }
 
 void
 init_main_logfile(void)
 {
+	char buf[512];
 	verify_logfile_access(logFileName);
 	if(log_main == NULL)
 	{
 		log_main = fopen(logFileName, "a");
+		if(log_main == NULL)
+		{
+			snprintf(buf, sizeof(buf), "WARNING: Access denied for logfile %s: %s", logFileName, strerror(errno));
+			if(testing_conf || server_state_foreground)
+				fprintf(stderr, "%s\n", buf);
+			sendto_realops_snomask(SNO_GENERAL, L_ALL, "%s", buf);
+		}
 	}
 }
 
 void
 open_logfiles(void)
 {
+	char buf[512];
 	int i;
 
 	close_logfiles();
-
-	log_main = fopen(logFileName, "a");
+	init_main_logfile();
 
 	/* log_main is handled above, so just do the rest */
 	for(i = 1; i < LAST_LOGFILE; i++)
@@ -140,6 +138,13 @@ open_logfiles(void)
 		{
 			verify_logfile_access(*log_table[i].name);
 			*log_table[i].logfile = fopen(*log_table[i].name, "a");
+			if(*log_table[i].logfile == NULL)
+			{
+				snprintf(buf, sizeof(buf), "WARNING: Access denied for logfile %s: %s", *log_table[i].name, strerror(errno));
+				if(testing_conf || server_state_foreground)
+					fprintf(stderr, "%s\n", buf);
+				sendto_realops_snomask(SNO_GENERAL, L_ALL, "%s", buf);
+			}
 		}
 	}
 }
@@ -150,7 +155,10 @@ close_logfiles(void)
 	int i;
 
 	if(log_main != NULL)
+	{
 		fclose(log_main);
+		log_main = NULL;
+	}
 
 	/* log_main is handled above, so just do the rest */
 	for(i = 1; i < LAST_LOGFILE; i++)


### PR DESCRIPTION
- Initialize hooks before the main log file, because if we send a snote due to failing to open a logfile, that calls a hook. Attempting to call a hook before hooks are initialized will cause the ircd to segfault.
- Skip access() check for the logfile itself and simply check the return value of fopen(). This fixes a TOCTTOU race where an access check succeeds but something causes the file to become inaccessible between access() and fopen(), preventing an appropriate error from being logged. Also makes my life easier with my custom SELinux policy for the ircd since access() checks for full-write access whereas my policy only allows append access for logfiles.