### PR TITLE
Automatically rehash when modules change conf

### DIFF
--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -419,6 +419,8 @@ extern unsigned long cidr_to_bitmask[];
 extern char conffilebuf[BUFSIZE + 1];
 extern int lineno;
 
+extern bool conf_changed;
+
 #define NOT_AUTHORISED  (-1)
 #define I_SOCKET_ERROR  (-2)
 #define I_LINE_FULL     (-3)

--- a/ircd/modules.c
+++ b/ircd/modules.c
@@ -571,6 +571,9 @@ load_a_module(const char *path, bool warn, int origin, bool core)
 		return false;
 	}
 
+	/* flag to determine if a rehash is needed after this module load */
+	conf_changed = false;
+
 	switch (MAPI_VERSION(*mapi_version))
 	{
 	case 1:
@@ -760,6 +763,10 @@ load_a_module(const char *path, bool warn, int origin, bool core)
 	mod->origin = origin;
 	mod->path = rb_strdup(path);
 	rb_dlinkAddTail(mod, &mod->node, &module_list);
+
+	/* queue a rehash if the conf changed */
+	if (conf_changed)
+		rehash(false);
 
 	if(warn)
 	{

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -105,6 +105,7 @@ add_top_conf(const char *name, int (*sfunc) (struct TopConf *),
 	tc->tc_entries = items;
 
 	rb_dlinkAddAlloc(tc, &conf_items);
+	conf_changed = true;
 	return 0;
 }
 
@@ -168,6 +169,7 @@ remove_top_conf(char *name)
 
 	rb_dlinkDestroy(ptr, &conf_items);
 	rb_free(tc);
+	conf_changed = true;
 
 	return 0;
 }
@@ -2553,6 +2555,7 @@ add_conf_item(const char *topconf, const char *name, int type, void (*func) (voi
 	cf->cf_arg = NULL;
 
 	rb_dlinkAddAlloc(cf, &tc->tc_items);
+	conf_changed = true;
 
 	return 0;
 }
@@ -2575,6 +2578,7 @@ remove_conf_item(const char *topconf, const char *name)
 
 	rb_dlinkDestroy(ptr, &tc->tc_items);
 	rb_free(cf);
+	conf_changed = true;
 
 	return 0;
 }

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -67,6 +67,9 @@ rb_dlink_list service_list;
 
 rb_dictionary *prop_bans_dict;
 
+/* used for automatic rehash after loading a module which changes config */
+bool conf_changed = false;
+
 /* internally defined functions */
 static void set_default_conf(void);
 static void validate_conf(void);
@@ -623,13 +626,14 @@ struct rehash_data {
 	bool sig;
 };
 
+static struct rehash_data rehash_sig = { true };
+static struct rehash_data rehash_no_sig = { false };
+
 static void
 service_rehash(void *data_)
 {
 	struct rehash_data *data = data_;
 	bool sig = data->sig;
-
-	rb_free(data);
 
 	rb_dlink_node *n;
 
@@ -675,9 +679,7 @@ service_rehash(void *data_)
 bool
 rehash(bool sig)
 {
-	struct rehash_data *data = rb_malloc(sizeof *data);
-	data->sig = sig;
-	rb_defer(service_rehash, data);
+	rb_defer_once(service_rehash, sig ? &rehash_sig : &rehash_no_sig);
 	return false;
 }
 

--- a/librb/include/rb_commio.h
+++ b/librb/include/rb_commio.h
@@ -160,6 +160,7 @@ void rb_setselect(rb_fde_t *, unsigned int type, PF * handler, void *client_data
 void rb_init_netio(void);
 int rb_select(unsigned long);
 void rb_defer(void (*)(void *), void *);
+void rb_defer_once(void (*)(void *), void *);
 int rb_fd_ssl(rb_fde_t *F);
 int rb_get_fd(rb_fde_t *F);
 const char *rb_get_ssl_strerror(rb_fde_t *F);

--- a/librb/src/commio.c
+++ b/librb/src/commio.c
@@ -2032,6 +2032,20 @@ rb_defer(void (*fn)(void *), void *data)
 	rb_dlinkAdd(defer, &defer->node, &defer_list);
 }
 
+void
+rb_defer_once(void (*fn)(void *), void *data)
+{
+	rb_dlink_node *ptr;
+	RB_DLINK_FOREACH(ptr, defer_list.head)
+	{
+		struct defer *node = ptr->data;
+		if (node->fn == fn && node->data == data)
+			return;
+	}
+
+	rb_defer(fn, data);
+}
+
 int
 rb_select(unsigned long timeout)
 {

--- a/librb/src/export-syms.txt
+++ b/librb/src/export-syms.txt
@@ -28,6 +28,7 @@ rb_current_time
 rb_current_time_tv
 rb_date
 rb_defer
+rb_defer_once
 rb_destroy_patricia
 rb_dictionary_add
 rb_dictionary_create


### PR DESCRIPTION
When loading a module that modifies config (add/remove conf items or top conf sections), we now queue a rehash operation so that new config can be immediately applied. A new rb_defer_once() function was added to deduplicate these rehash requests so that at most one rehash will occur regardless of how many modules change conf.