### PR TITLE
Clean up include/stdinc.h and librb/include/rb_lib.h

### DIFF
--- a/authd/authd.c
+++ b/authd/authd.c
@@ -25,7 +25,7 @@
 
 #define MAXPARA 10
 
-static void error_cb(rb_helper *helper) __attribute__((noreturn));
+static void error_cb(rb_helper *helper) __noreturn;
 static void handle_reload(int parc, char *parv[]);
 static void handle_stat(int parc, char *parv[]);
 static void handle_options(int parc, char *parv[]);

--- a/authd/res.c
+++ b/authd/res.c
@@ -224,9 +224,6 @@ static void start_resolver(void)
  */
 void init_resolver(void)
 {
-#ifdef HAVE_SRAND48
-	srand48(rb_current_time());
-#endif
 	start_resolver();
 }
 

--- a/bandb/bandb.c
+++ b/bandb/bandb.c
@@ -237,7 +237,7 @@ parse_request(rb_helper *helper)
 
 
 static void
-error_cb(rb_helper *helper) __attribute__((noreturn));
+error_cb(rb_helper *helper) __noreturn;
 
 static void
 error_cb(rb_helper *helper)
@@ -282,7 +282,7 @@ setup_signals(void)
 
 
 static void
-db_error_cb(const char *errstr) __attribute__((noreturn));
+db_error_cb(const char *errstr) __noreturn;
 
 static void
 db_error_cb(const char *errstr)

--- a/bandb/bantool.c
+++ b/bandb/bantool.c
@@ -118,7 +118,7 @@ static void db_reclaim_slack(void);
 static void export_config(const char *conf, int id);
 static void import_config(const char *conf, int id);
 static void check_schema(void);
-static void print_help(int i_exit) __attribute__((noreturn));
+static void print_help(int i_exit) __noreturn;
 static void wipe_schema(void);
 static void drop_dupes(const char *user, const char *host, const char *t);
 

--- a/configure.ac
+++ b/configure.ac
@@ -123,16 +123,15 @@ AC_DEFINE_DIR([PKGLIBEXECDIR], [pkglibexecdir], [Directory where binaries the IR
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_STDBOOL
-
-AC_CHECK_HEADERS([crypt.h sys/param.h sys/syslog.h sys/epoll.h machine/endian.h])
+AS_IF([test "x$ac_cv_header_stdbool_h" = "xno"], [
+    AC_MSG_ERROR([stdbool.h is required])
+])
+AC_CHECK_HEADERS([crypt.h strings.h sys/param.h])
 
 dnl Stuff that the memory manager (imalloc) depends on
 dnl ==================================================
 
 AC_C_CONST
-if test "$ac_cv_header_machine_endian_h" = "no" ; then
-    AC_C_BIGENDIAN
-fi
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 AC_CHECK_SIZEOF(short)
@@ -162,20 +161,13 @@ fi
 
 AC_SUBST(CRYPT_LIB)
 
-AC_C_BIGENDIAN
-
 dnl Check for stdarg.h - if we can't find it, halt configure
 AC_CHECK_HEADER(stdarg.h, , [AC_MSG_ERROR([** stdarg.h could not be found - solanum will not compile without it **])])
-AC_CHECK_FUNCS([strlcat strlcpy])
 
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T
 
 AC_CHECK_TYPES([uintptr_t])
-
-dnl check for various functions...
-
-AC_FUNC_ALLOCA
 
 dnl OpenSSL support
 AC_MSG_CHECKING(for OpenSSL)

--- a/include/ircd.h
+++ b/include/ircd.h
@@ -103,6 +103,6 @@ extern bool ircd_ssl_ok;
 extern bool ircd_zlib_ok;
 extern int maxconnections;
 
-void ircd_shutdown(const char *reason) __attribute__((noreturn));
+void ircd_shutdown(const char *reason) __noreturn;
 
 #endif

--- a/include/ircd_defs.h
+++ b/include/ircd_defs.h
@@ -37,25 +37,6 @@
 
 #include "defaults.h"
 
-/* For those unfamiliar with GNU format attributes, a is the 1 based
- * argument number of the format string, and b is the 1 based argument
- * number of the variadic ... */
-#ifdef __GNUC__
-#define AFP(a,b) __attribute__((format (printf, a, b)))
-#else
-#define AFP(a,b)
-#endif
-
-/*
- * This ensures that __attribute__((deprecated)) is not used in for example
- * sun CC, since it's a GNU-specific extension. -nenolod
- */
-#ifdef __GNUC__
-#define IRC_DEPRECATED __attribute__((deprecated))
-#else
-#define IRC_DEPRECATED
-#endif
-
 #ifndef MAX
 #define MAX(a, b)	((a) > (b) ? (a) : (b))
 #endif

--- a/include/ircd_getopt.h
+++ b/include/ircd_getopt.h
@@ -37,7 +37,7 @@ struct lgetopt
 
 extern struct lgetopt myopts[];
 
-void usage(const char *) __attribute__((noreturn));
+void usage(const char *) __noreturn;
 void parseargs(int *, char * const **, struct lgetopt *);
 
 #endif /* __GETOPT_H_INCLUDED__ */

--- a/include/restart.h
+++ b/include/restart.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_restart_h
 #define INCLUDED_restart_h
 
-void restart(const char *) __attribute__((noreturn));
-void server_reboot(void) __attribute__((noreturn));
+void restart(const char *) __noreturn;
+void server_reboot(void) __noreturn;
 
 #endif

--- a/include/stdinc.h
+++ b/include/stdinc.h
@@ -21,122 +21,38 @@
  *
  */
 
+#ifndef INCLUDED_stdinc_h
+#define INCLUDED_stdinc_h 1
+
 #include "rb_lib.h"
 #include "ircd_defs.h"  /* Needed for some reasons here -- dwr */
 
-/* AIX requires this to be the first thing in the file.  */
-#ifdef __GNUC__
-#undef alloca
-#define alloca __builtin_alloca
-#else
-# ifdef _MSC_VER
-#  include <malloc.h>
-#  define alloca _alloca
-# else
-#  if HAVE_ALLOCA_H
-#   include <alloca.h>
-#  else
-#   ifdef _AIX
- #pragma alloca
-#   else
-#    ifndef alloca /* predefined by HP cc +Olibcalls */
-char *alloca ();
-#    endif
-#   endif
-#  endif
-# endif
-#endif
-
-
-#ifdef HAVE_STDLIB_H
+#include <stdbool.h>
 #include <stdlib.h>
-#endif
-#ifdef STRING_WITH_STRINGS
-# include <string.h>
-# include <strings.h>
-#else
-# ifdef HAVE_STRING_H
-#  include <string.h>
-# else
-#  ifdef HAVE_STRINGS_H
-#   include <strings.h>
-#  endif
-# endif
-#endif
 
-#include <stddef.h>
-
-#ifdef HAVE_STDBOOL_H
-# include <stdbool.h>
-#else
-# ifndef HAVE__BOOL
-#  ifdef __cplusplus
-typedef bool _Bool;
-#  else
-#   define _Bool signed char
-#  endif
-# endif
-# define bool _Bool
-# define false 0
-# define true 1
-# define __bool_true_false_are_defined 1
-#endif
-
-
-#include <stdint.h>
-#include <assert.h>
-#include <stdio.h>
-#include <time.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <signal.h>
 #include <dirent.h>
-#include <ctype.h>
-
-#include <limits.h>
+#include <errno.h>
+#include <string.h>
+#ifdef HAVE_STRINGS_H
+#  include <strings.h>
+#endif
 #include <unistd.h>
-#include <sys/time.h>
-#include <sys/types.h>
+
 #include <sys/file.h>
 #include <sys/resource.h>
-
 #include <sys/stat.h>
+#include <sys/time.h>
 
 #ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
+#  include <sys/param.h>
 #endif
 
-#include <errno.h>
-#include <sys/uio.h>
-
-#if defined(__INTEL_COMPILER) || defined(__GNUC__)
-# ifdef __unused
-#  undef __unused
-# endif
-# ifdef __printf
-#  undef __printf
-# endif
-# ifdef __noreturn
-#  undef __noreturn
-# endif
-
-# define __unused __attribute__((__unused__))
-# define __printf(x) __attribute__((__format__ (__printf__, x, x + 1)))
-# define __noreturn __attribute__((__noreturn__))
+#if defined(strdupa)
+#  define LOCAL_COPY(s)         strdupa(s)
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)
+#  define LOCAL_COPY(s)         __extension__({ char *_s = alloca(strlen(s) + 1); strcpy(_s, s); _s; })
 #else
-# define __unused
-# define __printf
-# define __noreturn
+#  define LOCAL_COPY(s)         strcpy(alloca(strlen(s) + 1), s) /* XXX Is that allowed? */
 #endif
 
-
-
-#ifdef strdupa
-#define LOCAL_COPY(s) strdupa(s)
-#else
-#if defined(__INTEL_COMPILER) || defined(__GNUC__)
-# define LOCAL_COPY(s) __extension__({ char *_s = alloca(strlen(s) + 1); strcpy(_s, s); _s; })
-#else
-# define LOCAL_COPY(s) strcpy(alloca(strlen(s) + 1), s) /* XXX Is that allowed? */
-#endif /* defined(__INTEL_COMPILER) || defined(__GNUC__) */
-#endif /* strdupa */
+#endif /* !INCLUDED_stdinc_h */

--- a/ircd/bandbi.c
+++ b/ircd/bandbi.c
@@ -47,7 +47,7 @@
 #include "operhash.h"
 
 static void
-bandb_handle_failure(rb_helper *helper, char **parv, int parc) __attribute__((noreturn));
+bandb_handle_failure(rb_helper *helper, char **parv, int parc) __noreturn;
 
 static char bandb_add_letter[LAST_BANDB_TYPE] = {
 	'K', 'D', 'X', 'R'

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -67,7 +67,7 @@
 #include "response.h"
 
 static void
-ircd_die_cb(const char *str) __attribute__((noreturn));
+ircd_die_cb(const char *str) __noreturn;
 
 /* /quote set variables */
 struct SetOptions GlobalSetOptions;

--- a/ircd/ircd_signal.c
+++ b/ircd/ircd_signal.c
@@ -55,7 +55,7 @@ sigchld_handler(int sig)
  * sigterm_handler - exit the server
  */
 static void
-sigterm_handler(int sig) __attribute__((noreturn));
+sigterm_handler(int sig) __noreturn;
 
 static void
 sigterm_handler(int sig)

--- a/librb/configure.ac
+++ b/librb/configure.ac
@@ -400,10 +400,6 @@ AC_CONFIG_COMMANDS([include/librb-config.h],
 
 _______EOF
 
-if test "x$rb_alloca_h" = "xyes"; then
-	echo '#define RB_HAVE_ALLOCA_H 1' >> $outfile
-fi
-
 echo '#include <stdlib.h>' >> $outfile
 echo '#include <stddef.h>' >> $outfile
 echo '#include <string.h>' >> $outfile
@@ -453,11 +449,6 @@ fi
 ],[
 	if test x$ac_cv_header_memory_h = xyes; then
 		rb_header_memory_h=yes
-	fi
-	if test "x${ac_cv_working_alloca_h+set}" = xset ; then
-		rb_alloca_h="$ac_cv_working_alloca_h"
-	else
-		rb_alloc_h="$ac_cv_header_alloca_h"
 	fi
 	if test x$ac_cv_member_struct_sockaddr_sa_len = xyes; then
 		rb_sockaddr_sa_len=yes

--- a/librb/include/rb_lib.h
+++ b/librb/include/rb_lib.h
@@ -2,90 +2,79 @@
 #define RB_LIB_H 1
 
 #include <librb-config.h>
-#include <stdio.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <assert.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <ctype.h>
 
-#ifdef __GNUC__
-#undef alloca
-#define alloca __builtin_alloca
-#else
-# ifdef _MSC_VER
-#  include <malloc.h>
-#  define alloca _alloca
-# else
-#  if RB_HAVE_ALLOCA_H
-#   include <alloca.h>
-#  else
-#   ifdef _AIX
-#pragma alloca
-#   else
-#    ifndef alloca		/* predefined by HP cc +Olibcalls */
-char *alloca();
-#    endif
-#   endif
+#include <stddef.h>
+#include <sys/types.h>
+
+#if defined(HAVE_ALLOCA_H)
+#  include <alloca.h>
+#elif !defined(alloca)
+#  if defined(__GNUC__)
+#    define alloca              __builtin_alloca
+#  elif defined(_AIX)
+#    define alloca              __alloca
+#  elif !defined(HAVE_ALLOCA)
+void *alloca(size_t);
 #  endif
-# endif
-#endif /* __GNUC__ */
+#endif
 
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <assert.h>
+#include <ctype.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <time.h>
+
+#ifdef rb_likely
+#  undef rb_likely
+#endif
+#ifdef rb_unlikely
+#  undef rb_unlikely
+#endif
 #ifdef __GNUC__
-
-#ifdef rb_likely
-#undef rb_likely
-#endif
-#ifdef rb_unlikely
-#undef rb_unlikely
-#endif
-
-#if __GNUC__ == 2 && __GNUC_MINOR__ < 96
-# define __builtin_expect(x, expected_value) (x)
-#endif
-
-#define rb_likely(x)       __builtin_expect(!!(x), 1)
-#define rb_unlikely(x)     __builtin_expect(!!(x), 0)
-
-#else /* !__GNUC__ */
-
-#define UNUSED(x) x
-
-#ifdef rb_likely
-#undef rb_likely
-#endif
-#ifdef rb_unlikely
-#undef rb_unlikely
-#endif
-#define rb_likely(x)	(x)
-#define rb_unlikely(x)	(x)
-#endif
-
-#ifndef HOSTIPLEN
-#define HOSTIPLEN	53
+#  define rb_likely(x)          __builtin_expect(!!(x), 1)
+#  define rb_unlikely(x)        __builtin_expect(!!(x), 0)
+#else
+#  define rb_likely(x)          (x)
+#  define rb_unlikely(x)        (x)
 #endif
 
 
 /* For those unfamiliar with GNU format attributes, a is the 1 based
  * argument number of the format string, and b is the 1 based argument
  * number of the variadic ... */
-#ifdef __GNUC__
-#define AFP(a,b) __attribute__((format (printf, a, b)))
+#if __has_attribute(__format__)
+#  define AFP(a, b)             __attribute__((__format__(printf, a, b)))
 #else
-#define AFP(a,b)
+#  define AFP(a, b)
+#endif
+
+#if __has_attribute(__noreturn__)
+#  define __noreturn            __attribute__((__noreturn__))
+#else
+#  define __noreturn
+#endif
+
+#if __has_attribute(__unused__)
+#  define __unused              __attribute__((__unused__))
+#else
+#  define __unused
 #endif
 
 
 #ifdef __GNUC__
-#define slrb_assert(expr)	(							\
+#  define slrb_assert(expr)	(							\
 			rb_likely((expr)) || (						\
 				rb_lib_log( 						\
 				"file: %s line: %d (%s): Assertion failed: (%s)",	\
 				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr), 0) 	\
 			)
 #else
-#define slrb_assert(expr)	(							\
+#  define slrb_assert(expr)	(							\
 			rb_likely((expr)) || (						\
 				rb_lib_log( 						\
 				"file: %s line: %d: Assertion failed: (%s)",		\
@@ -95,27 +84,28 @@ char *alloca();
 
 /* evaluates to true if assertion fails */
 #ifdef SOFT_ASSERT
-#define lrb_assert(expr) 	(!slrb_assert(expr))
+#  define lrb_assert(expr) 	(!slrb_assert(expr))
 #else
-#define lrb_assert(expr)	(assert(slrb_assert(expr)), 0)
+#  define lrb_assert(expr)	(assert(slrb_assert(expr)), 0)
 #endif
 
 #ifdef RB_SOCKADDR_HAS_SA_LEN
-#define ss_len sa_len
+#  define ss_len sa_len
 #endif
 
 #define GET_SS_FAMILY(x) (((const struct sockaddr *)(x))->sa_family)
 #define SET_SS_FAMILY(x, y) ((((struct sockaddr *)(x))->sa_family) = y)
+
 #ifdef RB_SOCKADDR_HAS_SA_LEN
-#define SET_SS_LEN(x, y)	do {							\
+#  define SET_SS_LEN(x, y)	do {							\
 					struct sockaddr *_storage;		\
 					_storage = ((struct sockaddr *)(x));\
 					_storage->sa_len = (y);				\
 				} while (0)
-#define GET_SS_LEN(x) (((struct sockaddr *)(x))->sa_len)
+#  define GET_SS_LEN(x) (((struct sockaddr *)(x))->sa_len)
 #else /* !RB_SOCKADDR_HAS_SA_LEN */
-#define SET_SS_LEN(x, y) (((struct sockaddr *)(x))->sa_family = ((struct sockaddr *)(x))->sa_family)
-#define GET_SS_LEN(x) (((struct sockaddr *)(x))->sa_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
+#  define SET_SS_LEN(x, y) (((struct sockaddr *)(x))->sa_family = ((struct sockaddr *)(x))->sa_family)
+#  define GET_SS_LEN(x) (((struct sockaddr *)(x))->sa_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
 #endif
 
 #define GET_SS_PORT(x) (((struct sockaddr *)(x))->sa_family == AF_INET ? ((struct sockaddr_in *)(x))->sin_port : ((struct sockaddr_in6 *)(x))->sin6_port)
@@ -127,24 +117,20 @@ char *alloca();
 					} \
 				} while (0)
 
+#ifndef HOSTIPLEN
+#  define HOSTIPLEN     53
+#endif
+
 #ifndef INADDRSZ
-#define INADDRSZ 4
+#  define INADDRSZ      4
 #endif
 
 #ifndef IN6ADDRSZ
-#define IN6ADDRSZ 16
+#  define IN6ADDRSZ     16
 #endif
 
 #ifndef INT16SZ
-#define INT16SZ 2
-#endif
-
-#ifndef UINT16_MAX
-#define UINT16_MAX (65535U)
-#endif
-
-#ifndef UINT32_MAX
-#define UINT32_MAX (4294967295U)
+#  define INT16SZ       2
 #endif
 
 
@@ -155,14 +141,14 @@ typedef void die_cb(const char *buffer);
 char *rb_ctime(const time_t, char *, size_t);
 char *rb_date(const time_t, char *, size_t);
 void rb_lib_log(const char *, ...);
-void rb_lib_restart(const char *, ...) __attribute__((noreturn));
+void rb_lib_restart(const char *, ...) __noreturn;
 void rb_lib_die(const char *, ...);
 void rb_set_time(void);
 const char *rb_lib_version(void);
 
 void rb_lib_init(log_cb * xilog, restart_cb * irestart, die_cb * idie, int closeall, int maxfds,
 		 size_t dh_size, size_t fd_heap_size);
-void rb_lib_loop(long delay) __attribute__((noreturn));
+void rb_lib_loop(long delay) __noreturn;
 
 time_t rb_current_time(void);
 const struct timeval *rb_current_time_tv(void);
@@ -184,7 +170,6 @@ int rb_setenv(const char *, const char *, int);
 
 pid_t rb_waitpid(pid_t pid, int *status, int options);
 pid_t rb_getpid(void);
-//unsigned int rb_geteuid(void);
 
 
 #include <rb_tools.h>

--- a/librb/meson.build
+++ b/librb/meson.build
@@ -44,37 +44,43 @@ librb_conf_data = configuration_data()
 rt_dep = cc.find_library('rt', required: false)
 
 librb_checks = {
-  'HAVE_CRYPT_H': cc.has_header('crypt.h'),
-  'HAVE_SYS_POLL_H': cc.has_header('sys/poll.h'),
-  'HAVE_SYS_EPOLL_H': cc.has_header('sys/epoll.h'),
-  'HAVE_SYS_SELECT_H': cc.has_header('sys/select.h'),
-  'HAVE_SYS_DEVPOLL_H': cc.has_header('sys/devpoll.h'),
-  'HAVE_SYS_EVENT_H': cc.has_header('sys/event.h'),
-  'HAVE_PORT_H': cc.has_header('port.h'),
-  'HAVE_SYS_SIGNALFD_H': cc.has_header('sys/signalfd.h'),
-  'HAVE_SYS_TIMERFD_H': cc.has_header('sys/timerfd.h'),
-  'TIME_WITH_SYS_TIME': cc.has_header('time.h'),
-  'HAVE_GETEXECNAME': cc.has_function('getexecname'),
-  'HAVE_STRLCPY': cc.has_function('strlcpy'),
-  'HAVE_STRLCAT': cc.has_function('strlcat'),
-  'HAVE_STRCASESTR': cc.has_function('strcasestr'),
-  'HAVE_SIGNALFD': cc.has_function('signalfd'),
+  'HAVE_ALLOCA_H': cc.check_header('alloca.h'),
+  'HAVE_CRYPT_H': cc.check_header('crypt.h'),
+  'HAVE_PORT_H': cc.check_header('port.h'),
+  'HAVE_SYS_DEVPOLL_H': cc.check_header('sys/devpoll.h'),
+  'HAVE_SYS_EPOLL_H': cc.check_header('sys/epoll.h'),
+  'HAVE_SYS_EVENT_H': cc.check_header('sys/event.h'),
+  'HAVE_SYS_POLL_H': cc.check_header('sys/poll.h'),
+  'HAVE_SYS_SELECT_H': cc.check_header('sys/select.h'),
+  'HAVE_SYS_SIGNALFD_H': cc.check_header('sys/signalfd.h'),
+  'HAVE_SYS_TIMERFD_H': cc.check_header('sys/timerfd.h'),
+
   'HAVE_ARC4RANDOM': cc.has_function('arc4random'),
-  'HAVE_KEVENT': cc.has_function('kevent', prefix: '#include <sys/event.h>'),
-  'HAVE_PORT_CREATE': cc.has_function('port_create', prefix: '#include <port.h>'),
-  'HAVE_EPOLL_CTL': cc.has_function('epoll_ctl', prefix: '#include <sys/epoll.h>'),
-  'HAVE_TIMERFD_CREATE': cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>'),
   'HAVE_DLINFO': cc.has_function('dlinfo', dependencies: dl_dep),
+  'HAVE_EPOLL_CTL': cc.has_function('epoll_ctl', prefix: '#include <sys/epoll.h>'),
+  'HAVE_GETEXECNAME': cc.has_function('getexecname'),
+  'HAVE_KEVENT': cc.has_function('kevent', prefix: '#include <sys/event.h>'),
   'HAVE_NANOSLEEP': cc.has_function('nanosleep', dependencies: rt_dep),
+  'HAVE_PORT_CREATE': cc.has_function('port_create', prefix: '#include <port.h>'),
+  'HAVE_SIGNALFD': cc.has_function('signalfd'),
+  'HAVE_STRCASESTR': cc.has_function('strcasestr'),
+  'HAVE_STRLCAT': cc.has_function('strlcat'),
+  'HAVE_STRLCPY': cc.has_function('strlcpy'),
   'HAVE_TIMER_CREATE': cc.has_function('timer_create', dependencies: rt_dep, prefix: '#include <time.h>'),
+  'HAVE_TIMERFD_CREATE': cc.has_function('timerfd_create', prefix: '#include <sys/timerfd.h>'),
+
   'HAVE_DEVPOLL': fs.exists('/dev/poll'),
-  'SOCKADDR_IN_HAS_LEN': cc.has_member('struct sockaddr', 'sa_len', prefix: '#include <sys/types.h>\n#include <sys/socket.h>'),
+  'RB_SOCKADDR_HAS_SA_LEN': cc.has_member('struct sockaddr', 'sa_len', prefix: '#include <sys/types.h>\n#include <sys/socket.h>'),
 }
 foreach define, found : librb_checks
   if found
     librb_conf_data.set(define, 1)
   endif
 endforeach
+
+if host_machine.endian() == 'big'
+  conf_data.set('WORDS_BIGENDIAN', 1)
+endif
 
 # TLS backend configuration (passed from parent)
 if have_openssl

--- a/librb/src/balloc.c
+++ b/librb/src/balloc.c
@@ -57,7 +57,7 @@
 #include <librb_config.h>
 #include <rb_lib.h>
 
-static void _rb_bh_fail(const char *reason, const char *file, int line) __attribute__((noreturn));
+static void _rb_bh_fail(const char *reason, const char *file, int line) __noreturn;
 
 static uintptr_t offset_pad;
 

--- a/meson.build
+++ b/meson.build
@@ -153,17 +153,6 @@ if have_hyperscan
   conf_data.set('HAVE_HYPERSCAN', 1)
 endif
 
-# TLS backend defines
-if have_openssl
-  conf_data.set('HAVE_OPENSSL', 1)
-endif
-if have_mbedtls
-  conf_data.set('HAVE_MBEDTLS', 1)
-endif
-if have_gnutls
-  conf_data.set('HAVE_GNUTLS', 1)
-endif
-
 # Performance
 if get_option('profile')
   conf_data.set('SOLANUM_PROFILE', 1)
@@ -189,13 +178,8 @@ conf_data.set('AWAY_HEAP_SIZE', 512)
 
 # System checks
 system_checks = {
-  'HAVE_CRYPT_H': cc.has_header('crypt.h'),
-  'HAVE_SYS_PARAM_H': cc.has_header('sys/param.h'),
-  'HAVE_SYS_SYSLOG_H': cc.has_header('sys/syslog.h'),
-  'HAVE_SYS_EPOLL_H': cc.has_header('sys/epoll.h'),
-  'HAVE_MACHINE_ENDIAN_H': cc.has_header('machine/endian.h'),
-  'HAVE_STRLCAT': cc.has_function('strlcat'),
-  'HAVE_STRLCPY': cc.has_function('strlcpy'),
+  'HAVE_STRINGS_H': cc.check_header('strings.h'),
+  'HAVE_SYS_PARAM_H': cc.check_header('sys/param.h'),
 }
 foreach define, found : system_checks
   if found
@@ -203,8 +187,12 @@ foreach define, found : system_checks
   endif
 endforeach
 
-if not cc.has_header('stdarg.h')
+if not cc.check_header('stdarg.h')
   error('stdarg.h is required')
+endif
+
+if not cc.check_header('stdbool.h')
+  error('stdbool.h is required')
 endif
 
 conf_data.set_quoted('PATH_DEVNULL', '/dev/null')

--- a/tools/mkpasswd.c
+++ b/tools/mkpasswd.c
@@ -39,8 +39,8 @@ static char *make_bf_salt_para(int, char *);
 static char *generate_random_salt(char *, int);
 static char *generate_poor_salt(char *, int);
 
-static void full_usage(void) __attribute__((noreturn));
-static void brief_usage(void) __attribute__((noreturn));
+static void full_usage(void) __noreturn;
+static void brief_usage(void) __noreturn;
 
 static char saltChars[] = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
        /* 0 .. 63, ascii - 64 */


### PR DESCRIPTION
- Unconditionally require `stdbool.h` in IRCd

  We are a C99 project anyway (`configure.ac` and `meson.build` both require a C99 compiler), so this header will always be present

  This removes the awful hack defining `bool`, `true`, and `false` in its absense, which was creating build errors when using meson, because `meson.build` did not set the `HAVE_STDBOOL_H` macro

- Modernise definition of `alloca(3)` according to GNU guidance

  This was in both librb and IRCd, while it only needs to be in the former

- Fix missing endianness check in `librb/meson.build`

  IRCd and librb both use the `WORDS_BIGENDIAN` macro, which was only being set by their `configure.ac` (with the `AC_C_BIGENDIAN` M4 macro)

  Since IRCd's `stdinc.h` includes librb's `rb_lib.h`, which then includes librb's `librb-config.h`, which would have the macro defined there, we only need to check for it in librb, so we can remove the endianness check from IRCd's `configure.ac` and don't need to add it to IRCd's `meson.build`

- Use `__has_attribute` to detect whether compiler attributes are available

  This is supported by gcc (5+), clang (2.9+), and ICC (17+)

- Add a `__noreturn` macro for `__attribute__((__noreturn__))` and adjust the codebase to use that

- Remove inclusion of headers that are only used by librb

- Remove inclusion of headers that are included in `rb_lib.h` because `stdinc.h` includes `rb_lib.h` anyway

- Remove the checks for headers and functions from the IRCd `configure.ac` and `meson.build` that are only used by librb

- Alphabetise checks for headers and functions (by the name of the macro they define) in the `meson.build` files

- Use `check_header()` instead of `has_header()` in meson to see if it is actually possible to compile code using the header

- Remove dead code using `srand48(3)` which has never been compiled because neither build system has ever set the `HAVE_SRAND48` macro and the surrounding code makes no use of this libc RNG

- Remove the TLS defines from IRCd's `meson.build` because librb's `meson.build` already defines them and IRCd pulls those in