### PR TITLE
include/serno.h.SH: correct check for git directory

### DIFF
--- a/include/serno.h.SH
+++ b/include/serno.h.SH
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ -d .git ]; then
+if [ -d ../.git ]; then
   revh=$(git rev-list -1 --no-commit-header --date=format:%Y%m%d --format=%cd-%h HEAD 2>/dev/null || true)
   datecode=$(git rev-list -1 --no-commit-header --format=%ct HEAD 2>/dev/null || true)
   if [ -n "$revh" ] && [ -n "$datecode" ]; then


### PR DESCRIPTION
Commit 6ba61b33f7ec557c02c1 split this logic up from the top level `Makefile.am` but then failed to adjust the path to the directory in the check

The result is that all builds now use a datecode of 0 and a revision of "unknown"