### PR TITLE
Add implementation of draft react spec

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,30 @@ AC_CHECK_HEADER(netinet/sctp.h, [
 
 fi
 
+
+AC_ARG_ENABLE(icu,
+AC_HELP_STRING([--disable-icu],[Disable ICU support]),
+[icu=$enableval],[icu=yes])
+
+AS_IF([test "$icu" = yes], [
+	save_CPPFLAGS="$CPPFLAGS"
+	save_LIBS="$LIBS"
+	PKG_CHECK_MODULES([ICU], [icu-uc >= 70], [], [icu=no])
+	CPPFLAGS="$CPPFLAGS $ICU_CFLAGS"
+	LIBS="$LIBS $ICU_LIBS"
+	AC_CHECK_HEADERS([unicode/ustring.h unicode/uchar.h],
+	[
+	    AC_DEFINE(HAVE_LIBICU, 1, [Define to 1 if libicu is available.])
+	], [icu=no])
+])
+
+AS_IF([test "$icu" = no], [
+	CPPFLAGS="$save_CPPFLAGS"
+	LIBS="$save_LIBS"
+])
+
+AM_CONDITIONAL([HAVE_ICU], [test "$icu" = "yes"])
+
 dnl Check for shared sqlite
 dnl ======================
 PKG_CHECK_MODULES(SQLITE, [sqlite3], [], AC_ERROR([sqlite3 is required]))
@@ -656,6 +680,7 @@ Configuration of ${BRANDING_NAME}-${BRANDING_VERSION}:
 
 	OpenSSL            : $openssl
 	SCTP               : $sctp
+	ICU                : $icu
 
 	Nickname length    : $NICKLEN
 	Topic length       : $TOPICLEN

--- a/configure.ac
+++ b/configure.ac
@@ -316,6 +316,30 @@ AC_CHECK_HEADER(netinet/sctp.h, [
 
 fi
 
+
+AC_ARG_ENABLE(icu,
+AC_HELP_STRING([--disable-icu],[Disable ICU support]),
+[icu=$enableval],[icu=yes])
+
+AS_IF([test "$icu" = yes], [
+	save_CPPFLAGS="$CPPFLAGS"
+	save_LIBS="$LIBS"
+	PKG_CHECK_MODULES([ICU], [icu-uc >= 70], [], [icu=no])
+	CPPFLAGS="$CPPFLAGS $ICU_CFLAGS"
+	LIBS="$LIBS $ICU_LIBS"
+	AC_CHECK_HEADERS([unicode/ustring.h unicode/uchar.h],
+	[
+	    AC_DEFINE(HAVE_LIBICU, 1, [Define to 1 if libicu is available.])
+	], [icu=no])
+])
+
+AS_IF([test "$icu" = no], [
+	CPPFLAGS="$save_CPPFLAGS"
+	LIBS="$save_LIBS"
+])
+
+AM_CONDITIONAL([HAVE_ICU], [test "$icu" = "yes"])
+
 dnl Check for shared sqlite
 dnl ======================
 PKG_CHECK_MODULES(SQLITE, [sqlite3], [], AC_ERROR([sqlite3 is required]))
@@ -648,6 +672,7 @@ Configuration of ${BRANDING_NAME}-${BRANDING_VERSION}:
 
 	OpenSSL            : $openssl
 	SCTP               : $sctp
+	ICU                : $icu
 
 	Nickname length    : $NICKLEN
 	Topic length       : $TOPICLEN

--- a/configure.ac
+++ b/configure.ac
@@ -279,9 +279,10 @@ AC_ARG_ENABLE(hyperscan,
 AC_HELP_STRING([--disable-hyperscan],[Disable hyperscan support]),
 [hyperscan=$enableval],[hyperscan=yes])
 
+save_CPPFLAGS="$CPPFLAGS"
+save_LIBS="$LIBS"
+
 AS_IF([test "$hyperscan" = yes], [
-	save_CPPFLAGS="$CPPFLAGS"
-	save_LIBS="$LIBS"
 	PKG_CHECK_MODULES([HS], [libhs >= 4], [], [hyperscan=no])
 	CPPFLAGS="$CPPFLAGS $HS_CFLAGS"
 	LIBS="$LIBS $HS_LIBS"
@@ -321,9 +322,10 @@ AC_ARG_ENABLE(icu,
 AC_HELP_STRING([--disable-icu],[Disable ICU support]),
 [icu=$enableval],[icu=yes])
 
+save_CPPFLAGS="$CPPFLAGS"
+save_LIBS="$LIBS"
+
 AS_IF([test "$icu" = yes], [
-	save_CPPFLAGS="$CPPFLAGS"
-	save_LIBS="$LIBS"
 	PKG_CHECK_MODULES([ICU], [icu-uc >= 70], [], [icu=no])
 	CPPFLAGS="$CPPFLAGS $ICU_CFLAGS"
 	LIBS="$LIBS $ICU_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -287,9 +287,10 @@ AC_ARG_ENABLE(hyperscan,
 AC_HELP_STRING([--disable-hyperscan],[Disable hyperscan support]),
 [hyperscan=$enableval],[hyperscan=yes])
 
+save_CPPFLAGS="$CPPFLAGS"
+save_LIBS="$LIBS"
+
 AS_IF([test "$hyperscan" = yes], [
-	save_CPPFLAGS="$CPPFLAGS"
-	save_LIBS="$LIBS"
 	PKG_CHECK_MODULES([HS], [libhs >= 4], [], [hyperscan=no])
 	CPPFLAGS="$CPPFLAGS $HS_CFLAGS"
 	LIBS="$LIBS $HS_LIBS"
@@ -329,9 +330,10 @@ AC_ARG_ENABLE(icu,
 AC_HELP_STRING([--disable-icu],[Disable ICU support]),
 [icu=$enableval],[icu=yes])
 
+save_CPPFLAGS="$CPPFLAGS"
+save_LIBS="$LIBS"
+
 AS_IF([test "$icu" = yes], [
-	save_CPPFLAGS="$CPPFLAGS"
-	save_LIBS="$LIBS"
 	PKG_CHECK_MODULES([ICU], [icu-uc >= 70], [], [icu=no])
 	CPPFLAGS="$CPPFLAGS $ICU_CFLAGS"
 	LIBS="$LIBS $ICU_LIBS"

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -107,6 +107,7 @@
  * Remote oper up notices                            -- sno_globaloper
  * +channel-context client tag support               -- tag_channel_context
  * message-id support                                -- tag_message_id
+ * +draft/(un)react client tag support               -- tag_react
  * +reply client tag support                         -- tag_reply
  * +typing client tag support                        -- tag_typing
  * Allows you to hide your idle time (umode +I)      -- umode_hide_idle_time
@@ -172,6 +173,7 @@
 #loadmodule "extensions/sno_globalnickchange";
 #loadmodule "extensions/tag_channel_context";
 #loadmodule "extensions/tag_message_id";
+#loadmodule "extensions/tag_react";
 #loadmodule "extensions/tag_reply";
 #loadmodule "extensions/tag_typing";
 #loadmodule "extensions/umode_hide_idle_time";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -105,6 +105,7 @@
  * Remote oper up notices                            -- sno_globaloper
  * +channel-context client tag support               -- tag_channel_context
  * message-id support                                -- tag_message_id
+ * +draft/(un)react client tag support               -- tag_react
  * +reply client tag support                         -- tag_reply
  * +typing client tag support                        -- tag_typing
  * Allows you to hide your idle time (umode +I)      -- umode_hide_idle_time
@@ -168,6 +169,7 @@
 #loadmodule "extensions/sno_globalnickchange";
 #loadmodule "extensions/tag_channel_context";
 #loadmodule "extensions/tag_message_id";
+#loadmodule "extensions/tag_react";
 #loadmodule "extensions/tag_reply";
 #loadmodule "extensions/tag_typing";
 #loadmodule "extensions/umode_hide_idle_time";

--- a/doc/technical/ts6.md
+++ b/doc/technical/ts6.md
@@ -2781,6 +2781,8 @@ tag. Unrecognized tags are stripped and not propagated further.
 | +channel-context       | tag_channel_context  | optional       |
 | +reply                 | tag_reply            | optional       |
 | +typing                | tag_typing           | optional       |
+| +draft/react           | tag_react            | draft          |
+| +draft/unreact         | tag_react            | draft          |
 
 ### batch
 
@@ -2834,6 +2836,16 @@ sends.
 ### +channel-context
 
 The +channel-context client-only tag is forwarded as-is between servers.
+
+### +draft/react
+
+The +draft/react client-only tag is forwarded as-is between servers. If a
+message contains this tag but lacks the +reply tag, it will be stripped.
+
+### +draft/unreact
+
+The +draft/unreact client-only tag is forwarded as-is between servers. If a
+message contains this tag but lacks the +reply tag, it will be stripped.
 
 ### +reply
 

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -80,3 +80,7 @@ extension_LTLIBRARIES =		\
 if HAVE_HYPERSCAN
     extension_LTLIBRARIES += filter.la
 endif
+
+if HAVE_ICU
+    extension_LTLIBRARIES += tag_react.la
+endif

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -75,3 +75,7 @@ extension_LTLIBRARIES =		\
 if HAVE_HYPERSCAN
     extension_LTLIBRARIES += filter.la
 endif
+
+if HAVE_ICU
+    extension_LTLIBRARIES += tag_react.la
+endif

--- a/extensions/meson.build
+++ b/extensions/meson.build
@@ -92,3 +92,14 @@ if have_hyperscan
     install_dir: moduledir / 'extensions'
   )
 endif
+
+if have_icu
+  shared_module('tag_react',
+    'tag_react.c',
+    name_prefix: '',
+    name_suffix: 'so',
+    dependencies: [libircd_dep, librb_dep, global_include_dep, icu_dep],
+    install: true,
+    install_dir: moduledir / 'extensions'
+  )
+endif

--- a/extensions/meson.build
+++ b/extensions/meson.build
@@ -87,3 +87,14 @@ if have_hyperscan
     install_dir: moduledir / 'extensions'
   )
 endif
+
+if have_icu
+  shared_module('tag_react',
+    'tag_react.c',
+    name_prefix: '',
+    name_suffix: 'so',
+    dependencies: [libircd_dep, librb_dep, global_include_dep, icu_dep],
+    install: true,
+    install_dir: moduledir / 'extensions'
+  )
+endif

--- a/extensions/tag_react.c
+++ b/extensions/tag_react.c
@@ -1,0 +1,131 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * tag_react.c: implement the IRCv3 +draft/react and +draft/unreact client tags
+ *
+ * Copyright (c) 2025 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "client_tags.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "parse.h"
+#include "inline/stringops.h"
+
+#include <unicode/uchar.h>
+#include <unicode/ustring.h>
+
+static const char tag_react_desc[] = "Provides support for the +draft/react and +draft/unreact client tags.";
+static void tag_react_allow(void *);
+static void tag_react_outgoing(void *);
+
+mapi_hfn_list_av1 tag_react_hfnlist[] = {
+	{ "message_tag", tag_react_allow },
+	{ "outbound_msgbuf", tag_react_outgoing },
+	{ NULL, NULL }
+};
+
+static int
+modinit(void)
+{
+	add_client_tag("draft/react");
+	add_client_tag("draft/unreact");
+	return 0;
+}
+
+static void
+moddeinit(void)
+{
+	remove_client_tag("draft/react");
+	remove_client_tag("draft/unreact");
+}
+
+static void
+tag_react_allow(void *data_)
+{
+	hook_data_message_tag *data = data_;
+	if (IsClient(data->client) && NotClientCapable(data->client, CLICAP_MESSAGE_TAGS))
+		return;
+
+	if (strcmp("+draft/react", data->key) != 0 && strcmp("+draft/unreact", data->key) != 0)
+		return;
+
+	/* Reaction requires a value */
+	if (EmptyString(data->value))
+		return;
+
+	/* Don't filter server-sent messages */
+	if (IsServer(data->client))
+	{
+		data->approved = MESSAGE_TAG_ALLOW;
+		data->capmask = CLICAP_MESSAGE_TAGS;
+		return;
+	}
+
+	UChar value[BUFSIZE];
+	int32_t len = 0;
+
+	/* destCapacity is in elements, not bytes. Subtract 1 to ensure that the trailing NULL can be written */
+	UErrorCode err = U_ZERO_ERROR;
+	u_strFromUTF8(value, BUFSIZE - 1, &len, data->value, -1, &err);
+	value[BUFSIZE - 1] = 0;
+
+	/* invalid UTF-8 or too long */
+	if (err != U_ZERO_ERROR)
+		return;
+
+	/* Validate that the string is a single emoji (limited to those recommended for general interchange).
+	 * From testing, this returns false if the string contains multiple emoji or contains any non-emoji characters
+	 * but successfully returns true for complex emoji consisting of multiple combining marks and characters
+	 */
+	if (u_stringHasBinaryProperty(value, len, UCHAR_RGI_EMOJI))
+	{
+		data->approved = MESSAGE_TAG_ALLOW;
+		data->capmask = CLICAP_MESSAGE_TAGS;
+	}
+}
+
+static void
+tag_react_outgoing(void *data_)
+{
+	hook_data_outbound_msgbuf *data = data_;
+	struct MsgBuf *msgbuf = data->msgbuf;
+
+	bool has_reply = msgbuf_get_tag(msgbuf, "+reply") != NULL;
+	bool has_react = msgbuf_get_tag(msgbuf, "+draft/react") != NULL;
+
+	for (int i = 0; i < msgbuf->n_tags; i++)
+	{
+		const char *key = msgbuf->tags[i].key;
+		/* strip (un)react from outgoing messages that lack a reply */
+		if (!has_reply && (!strcmp(key, "+draft/react") || !strcmp(key, "+draft/unreact")))
+			msgbuf->tags[i].capmask = NOCAPS;
+		/* strip unreact if we already have a react (messages must not contain both) */
+		else if (has_react && !strcmp(key, "+draft/unreact"))
+			msgbuf->tags[i].capmask = NOCAPS;
+	}
+}
+
+DECLARE_MODULE_AV2(tag_react, modinit, moddeinit, NULL, NULL, tag_react_hfnlist, NULL, NULL, tag_react_desc);

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ endif
 hyperscan_dep = dependency('libhs', version: '>=4', required: get_option('hyperscan'))
 have_hyperscan = hyperscan_dep.found()
 
+icu_dep = dependency('icu-uc', version: '>=70', required: get_option('icu'))
+have_icu = icu_dep.found()
+
 sctp_dep = cc.find_library('sctp', has_headers: ['netinet/sctp.h'], required: get_option('sctp'))
 have_sctp = sctp_dep.found()
 
@@ -152,6 +155,9 @@ endif
 if have_hyperscan
   conf_data.set('HAVE_HYPERSCAN', 1)
 endif
+if have_icu
+  conf_data.set('HAVE_LIBICU', 1)
+endif
 
 # TLS backend defines
 if have_openssl
@@ -264,6 +270,7 @@ summary({
   'TLS backend': tls_backend,
   'SCTP': have_sctp,
   'Hyperscan': have_hyperscan,
+  'ICU': have_icu,
   'OPER CHGHOST': get_option('oper_chghost'),
 }, section: 'Features')
 

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ endif
 hyperscan_dep = dependency('libhs', version: '>=4', required: get_option('hyperscan'))
 have_hyperscan = hyperscan_dep.found()
 
+icu_dep = dependency('icu-uc', version: '>=70', required: get_option('icu'))
+have_icu = icu_dep.found()
+
 sctp_dep = cc.find_library('sctp', has_headers: ['netinet/sctp.h'], required: get_option('sctp'))
 have_sctp = sctp_dep.found()
 
@@ -152,6 +155,9 @@ endif
 if have_hyperscan
   conf_data.set('HAVE_HYPERSCAN', 1)
 endif
+if have_icu
+  conf_data.set('HAVE_LIBICU', 1)
+endif
 
 # Performance
 if get_option('profile')
@@ -259,6 +265,7 @@ summary({
   'TLS backend': tls_backend,
   'SCTP': have_sctp,
   'Hyperscan': have_hyperscan,
+  'ICU': have_icu,
   'OPER CHGHOST': get_option('oper_chghost'),
 }, section: 'Features')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,6 +25,8 @@ option('sctp', type: 'feature', value: 'auto',
   description: 'Enable SCTP support')
 option('hyperscan', type: 'feature', value: 'auto',
   description: 'Enable hyperscan regex support')
+option('icu', type: 'feature', value: 'auto',
+  description: 'Enable ICU unicode support')
 option('oper_chghost', type: 'boolean', value: false,
   description: 'Enable CHGHOST command for operators')
 


### PR DESCRIPTION
For +draft/react, we limit the reaction to a single emoji (potentially including modifiers) for easier moderation (since this doesn't go through spamfilter). Additionally, the +draft/unreact tag was implemented as a means for users to easily remove their reactions. This dependence on emoji brings in a new dependency on libicu.