### PR TITLE
Add draft/multiline support

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -94,6 +94,7 @@
  * Send permanent XLINEs and RESVs to remote server  -- m_sendbans
  * Shed users from the server                        -- m_shedding
  * WebIRC support                                    -- m_webirc
+ * draft/multiline batch support                     -- multiline
  * Prevent opers from killing services               -- no_kill_services
  * Opers cannot be invisible (umode +i)              -- no_oper_invis
  * Oper override                                     -- override
@@ -157,6 +158,7 @@
 #loadmodule "extensions/m_sendbans";
 #loadmodule "extensions/m_shedding";
 #loadmodule "extensions/m_webirc";
+#loadmodule "extensions/multiline";
 #loadmodule "extensions/no_kill_services";
 #loadmodule "extensions/no_oper_invis";
 #loadmodule "extensions/override";
@@ -1526,6 +1528,16 @@ general {
 	 * requires extensions/drain to be loaded.
 	 */
 	drain_reason = "This server is not accepting connections.";
+
+	/* multiline_max_lines: Maximum number of lines accepted in a multiline batch.
+	 * requires extensions/multiline to be loaded.
+	 */
+	#multiline_max_lines = 10;
+
+	/* multiline_max_bytes: Maximum number of bytes accepted in a multiline batch.
+	 * requires extensions/multiline to be loaded.
+	 */
+	#multiline_max_bytes = 2000;
 
 	/* filter_sees_user_info: Whether the filter is given the nick!user@host of message senders.
 	 * If set to NO, the filter is given a literal "*!*@*" instead.

--- a/doc/technical/ts6.md
+++ b/doc/technical/ts6.md
@@ -310,6 +310,7 @@ Solanum supports the following server capabilities (enabled via `CAPAB`):
 | CLUSTER    | core      | legacy         | Remote (UN)RESV/(UN)XLINE (not using ENCAP)          |
 | EBMASK     | core      | recommended    | EBMASK command (burst +beIq with ts/setter data)     |
 | ECHO       | m_message | recommended    | ECHO command (for echo-message)                      |
+| ECHOB      | m_message | recommended    | solanum.chat/echo BATCH type (for echo-message)      |
 | ENCAP      | core      | required       | ENCAP command                                        |
 | EOPMOD     | core      | recommended    | STATUSMSG = prefix (+z applied to +bq), ETB command  |
 | EUID       | core      | recommended    | EUID command (UID + realhost/login info)             |
@@ -318,6 +319,7 @@ Solanum supports the following server capabilities (enabled via `CAPAB`):
 | KLN        | core      | legacy         | Remote KLINE (not using ENCAP)                       | 
 | KNOCK      | core      | optional       | KNOCK command (request invite to channel)            |
 | MLOCK      | core      | recommended    | MLOCK command (force channel modes set/unset)        |
+| MULTILN    | multiline | draft          | draft/multiline BATCH type                           |
 | QS         | core      | required       | Quit storms (no need to send recursive SQUIT)        |
 | REMOVE     | m_remove  | optional       | REMOVE command (force part)                          |
 | RSFNC      | core      | advertisement  | ENCAP RSFNC (force nick change)                      |
@@ -2777,6 +2779,7 @@ tag. Unrecognized tags are stripped and not propagated further.
 | batch                  | m_batch              | required       |
 | msgid                  | tag_message_id       | recommended    |
 | time                   | cap_server_time      | recommended    |
+| draft/multiline-concat | multiline            | draft          |
 | solanum.chat/response  | cap_labeled_response | required       |
 | +channel-context       | tag_channel_context  | optional       |
 | +reply                 | tag_reply            | optional       |
@@ -2786,6 +2789,11 @@ tag. Unrecognized tags are stripped and not propagated further.
 
 Messages with a batch tag that do not correspond to an open `BATCH` between
 the linked servers will be silently dropped.
+
+### draft/multiline-concat
+
+This tag may only be attached to a message inside of a draft/multiline batch
+and will be stripped in all other contexts.
 
 ### msgid
 
@@ -2854,4 +2862,72 @@ nest batches, and can interleave batched and non-batched messages. Open S2S
 batches do not time out automatically and will remain open until the remote
 server finishes it or disconnects.
 
-Solanum does not currently support any S2S batch types.
+Solanum currently supports the following S2S batch types:
+
+### draft/multiline
+
+- Capability: **MULTILN**
+- Source: any
+- Propagation: broadcast
+- Implementation: draft
+- Nesting: No nesting allowed
+- Syntax: `BATCH +<id> draft/multiline [<prefix>]<channel>`
+
+Sends a multiline message to the channel. A prefix of "@" or "+" additionally
+requires **CHW** while a prefix of "=" additionally requires both **CHW** and
+**EOPMOD**. Propagation of this batch in the =#channel case matches that of
+`NOTICE` with respect to special fallback cases. Inner messages must adhere
+to the requirements of the multiline message ircv3 specification, but no
+validation is performed for multiline batches received from remote servers.
+
+----
+
+- Capability: **MULTILN**
+- Source: any
+- Propagation: target
+- Implementation: draft
+- Nesting: No nesting allowed
+- Syntax: `BATCH +<id> draft/multiline <target>`
+
+Sends a multiline message to the user. Inner messages must adhere to the
+requirements of the multiline message ircv3 specification, but no validation
+is performed for multiline batches received from remote servers.
+
+Note: Special targets (user@server, $$/$# mass-messages) are not supported for
+multiline batches.
+
+Example:
+```
+:001AAAAAA BATCH +foo draft/multiline 002BBBBBB
+@batch=foo :001AAAAAA PRIVMSG 002BBBBBB :hello
+@batch=foo,draft/multiline-concat :001AAAAAA PRIVMSG 002BBBBBB : world
+:001AAAAAA BATCH -foo
+```
+
+### solanum.chat/echo
+
+- Capability: **ECHOB**
+- Source: user
+- Propagation: target
+- Implementation: recommended
+- Nesting: Allows arbitrary nested batches
+- Syntax: `BATCH +<id> solanum.chat/echo <target>`
+
+This batch type is used when a server needs to generate an echo-message for a
+`BATCH`. All inner messages of the solanum.chat/echo batch will be relayed to
+the target as-is (unlike other S2S messages, SIDs/UIDs within parameters of
+inner messages *are not replaced* with the name of the server or client). The
+prefix may be omitted on inner messages, as the target server will generate
+the appropriate prefix as if the target sent the message. If inner messages
+contain a prefix, the prefix cannot specify a fake direction and will be
+otherwise ignored.
+
+Example:
+```
+:001AAAAAA BATCH +foo solanum.chat/echo 002BBBBBB
+@batch=foo BATCH +bar draft/multiline #channel
+@batch=bar PRIVMSG #channel :hello
+@batch=bar PRIVMSG #channel :world
+@batch=foo BATCH -bar
+:001AAAAAA BATCH -foo
+```

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -54,6 +54,7 @@ extension_LTLIBRARIES =		\
   m_sendbans.la			\
   m_shedding.la			\
   m_webirc.la			\
+  multiline.la          \
   no_kill_services.la		\
   no_oper_invis.la		\
   override.la			\

--- a/extensions/meson.build
+++ b/extensions/meson.build
@@ -47,6 +47,7 @@ extension_modules = [
   'm_sendbans',
   'm_shedding',
   'm_webirc',
+  'multiline',
   'no_kill_services',
   'no_oper_invis',
   'override',

--- a/extensions/multiline.c
+++ b/extensions/multiline.c
@@ -1,0 +1,812 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * multiline.c: Implement the draft/multiline batch type
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "batch.h"
+#include "client.h"
+#include "hash.h"
+#include "modules.h"
+#include "msgbuf.h"
+#include "newconf.h"
+#include "numeric.h"
+#include "send.h"
+#include "s_assert.h"
+#include "s_conf.h"
+#include "s_newconf.h"
+#include "s_serv.h"
+#include "tgchange.h"
+
+/* the MULTILN server capability indicates support for the s2s multiline batch type
+ * since this is a proof-of-concept extension the s2s interface is UNSTABLE and may change incompatibly.
+ * Networks need to ensure all servers have the same module version to avoid potential crashes.
+ */
+static uint64_t CAP_MULTILINE;
+static uint64_t CLICAP_MULTILINE;
+static int h_multiline_message_user;
+static int h_multiline_message_channel;
+
+static const char multiline_desc[] =
+	"Allows clients to send batches containing multiple lines at once (draft/multiline batch type).";
+
+static char capdata_buf[BUFSIZE];
+static unsigned int old_max_lines = 0;
+static unsigned int old_max_bytes = 0;
+static unsigned int max_lines = 0;
+static unsigned int max_bytes = 0;
+
+static int multiline_modinit(void);
+static void multiline_moddeinit(void);
+static void process_multiline(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *);
+static void multiline_conf_info(void *);
+static void multiline_conf_store(void *);
+static void multiline_conf_update(void *);
+static void multiline_tag_allow(void *);
+static void multiline_rehash(void *);
+static const char *multiline_config(struct Client *);
+
+mapi_hfn_list_av1 multiline_hfn_list[] = {
+	{ "conf_read_start", multiline_conf_store },
+	{ "conf_read_end", multiline_conf_update },
+	{ "doing_info_conf", multiline_conf_info },
+	{ "message_tag", multiline_tag_allow },
+	{ "rehash", multiline_rehash },
+	{ NULL, NULL },
+};
+
+mapi_hlist_av1 multiline_hlist[] = {
+	{ "multiline_message_user", &h_multiline_message_user },
+	{ "multiline_message_channel", &h_multiline_message_channel },
+	{ NULL, NULL },
+};
+
+struct ClientCapability capdata_multiline = { .data = multiline_config };
+
+mapi_cap_list_av2 multiline_cap_list[] = {
+	{ MAPI_CAP_CLIENT, "draft/multiline", &capdata_multiline, &CLICAP_MULTILINE },
+	{ MAPI_CAP_SERVER, "MULTILN", NULL, &CAP_MULTILINE },
+	{ 0, NULL, NULL, NULL },
+};
+
+struct BatchHandler multiline_handler = { process_multiline, NULL, 0, NULL };
+
+static void
+conf_set_multiline_max_bytes(void *data)
+{
+	max_bytes = *(int *)data;
+}
+
+static void
+conf_set_multiline_max_lines(void *data)
+{
+	max_lines = *(int *)data;
+}
+
+static int
+multiline_modinit(void)
+{
+	if (!register_batch_handler("draft/multiline", &multiline_handler))
+		return -1;
+
+	add_conf_item("general", "multiline_max_bytes", CF_INT, conf_set_multiline_max_bytes);
+	add_conf_item("general", "multiline_max_lines", CF_INT, conf_set_multiline_max_lines);
+
+	return 1;
+}
+
+static void
+multiline_moddeinit(void)
+{
+	remove_batch_handler("draft/multiline");
+}
+
+static const char *
+multiline_config(struct Client *unused)
+{
+	return capdata_buf;
+}
+
+static void
+multiline_conf_store(void *unused)
+{
+	old_max_bytes = max_bytes;
+	old_max_lines = max_lines;
+}
+
+static void
+multiline_conf_update(void *unused)
+{
+	sprintf(capdata_buf, "max-bytes=%d,max-lines=%d", max_bytes, max_lines);
+}
+
+static void
+multiline_rehash(void *data)
+{
+	/* config rehash may have changed multiline_max_bytes or multiline_max_lines */
+	if (old_max_bytes != max_bytes || old_max_lines != max_lines)
+	{
+		/* notify cap-notify clients of the new limits */
+		sendto_local_clients_with_capability(CLICAP_CAP_NOTIFY, ":%s CAP * NEW :draft/multiline=%s",
+			me.name, capdata_buf);
+	}
+}
+
+static void
+multiline_conf_info(void *data_)
+{
+	hook_data *data = data_;
+	char max_lines_buf[24];
+	char max_bytes_buf[24];
+
+	snprintf(max_bytes_buf, sizeof(max_bytes_buf), "%d", max_bytes);
+	snprintf(max_lines_buf, sizeof(max_lines_buf), "%d", max_lines);
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"multiline_max_lines",
+		max_lines_buf,
+		"Maximum number of lines allowed in a multiline batch");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"multiline_max_bytes",
+		max_bytes_buf,
+		"Maximum number of bytes allowed in a multiline batch");
+}
+
+static void
+send_channel_batch(struct Client *client_p, struct Client *source_p,
+	struct Channel *chptr, int type, bool opmod,
+	struct Batch *batch, size_t n_tags, struct MsgTag tags[])
+{
+	rb_dlink_node *ptr;
+	char origin[USERHOST_REPLYLEN];
+	int msgid = -1;
+
+	/* figure out command and normalize to uppercase */
+	const char *command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	enum message_type msgtype = !rb_strcasecmp(command, "PRIVMSG") ? MESSAGE_TYPE_PRIVMSG : MESSAGE_TYPE_NOTICE;
+	command = (msgtype == MESSAGE_TYPE_PRIVMSG) ? "PRIVMSG" : "NOTICE";
+
+	for (size_t i = 0; i < n_tags; i++)
+	{
+		if (!strcmp(tags[i].key, "msgid"))
+		{
+			msgid = (int)i;
+			break;
+		}
+	}
+
+	snprintf(origin, sizeof(origin), IsPerson(source_p) ? "%s!%s@%s" : "%s",
+		source_p->name, source_p->username, source_p->host);
+
+	struct MsgTag inner_tags[] = {
+		{ "batch", batch->id, CLICAP_BATCH },
+		{ "draft/multiline-concat", NULL, CLICAP_MULTILINE }
+	};
+
+	int result = can_send(chptr, source_p, NULL);
+	if (result)
+	{
+		if (result != CAN_SEND_OPV && MyClient(source_p)
+			&& !IsOperGeneral(source_p) && !add_channel_target(source_p, chptr))
+		{
+			sendto_one(source_p, form_str(ERR_TARGCHANGE),
+				me.name, source_p->name, chptr->chname);
+			return;
+		}
+
+		if (result != CAN_SEND_OPV && flood_attack_channel(msgtype, source_p, chptr, chptr->chname))
+			return;
+	}
+	else if (chptr->mode.mode & MODE_OPMODERATE
+		&& (!(chptr->mode.mode & MODE_NOPRIVMSGS) || IsMember(source_p, chptr)))
+	{
+		if (MyClient(source_p) && !IsOperGeneral(source_p) && !add_channel_target(source_p, chptr))
+		{
+			sendto_one(source_p, form_str(ERR_TARGCHANGE),
+				me.name, source_p->name, chptr->chname);
+			return;
+		}
+
+		if (!flood_attack_channel(msgtype, source_p, chptr, chptr->chname))
+		{
+			opmod = true;
+			type = ONLY_CHANOPS;
+		}
+	}
+	else
+	{
+		if (msgtype != MESSAGE_TYPE_NOTICE)
+			sendto_one_numeric(source_p, ERR_CANNOTSENDTOCHAN,
+				form_str(ERR_CANNOTSENDTOCHAN), chptr->chname);
+	}
+
+	unsigned int servcaps = NOCAPS;
+	if (type != ALL_MEMBERS)
+		servcaps |= CAP_CHW;
+
+	const char *status = "";
+	if (type & CHFL_VOICE)
+		status = "+";
+	else if (type & CHFL_CHANOP)
+		status = "@";
+
+	sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+		chptr, n_tags, tags, ":%s BATCH +%s draft/multiline %s%s",
+		origin, batch->id, status, chptr->chname);
+
+	if (opmod)
+	{
+		sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | CAP_EOPMOD | servcaps, NOCAPS,
+			n_tags, tags, "BATCH +%s draft/multiline =%s",
+			batch->id, chptr->chname);
+
+		sendto_match_servs_tags(source_p->servptr, "*", CAP_MULTILINE | CAP_STAG | servcaps, CAP_EOPMOD,
+			n_tags, tags, "BATCH +%s draft/multiline @%s",
+			batch->id, chptr->chname);
+	}
+	else
+		sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+			n_tags, tags, "BATCH +%s draft/multiline %s%s",
+			batch->id, status, chptr->chname);
+
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+			chptr, concat ? 2 : 1, inner_tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		if (opmod)
+		{
+			sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | CAP_EOPMOD | servcaps, NOCAPS,
+				concat ? 2 : 1, inner_tags, "%s =%s :%s",
+				command, chptr->chname, data->msg.para[2]);
+
+			sendto_match_servs_tags(source_p->servptr, "*", CAP_MULTILINE | CAP_STAG | servcaps, CAP_EOPMOD,
+				concat ? 2 : 1, inner_tags, "NOTICE @%s :<%s:%s> %s",
+				chptr->chname, source_p->name, chptr->chname, data->msg.para[2]);
+		}
+		else
+			sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+				concat ? 2 : 1, inner_tags, "%s %s%s :%s",
+				command, status, chptr->chname, data->msg.para[2]);
+
+		/* lot of different fallback scenarios for clients who don't support both batch and multiline */
+		if (EmptyString(data->msg.para[2]))
+			continue;
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH, CLICAP_MULTILINE,
+			chptr, n_tags, tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, NOCAPS, CLICAP_BATCH,
+			chptr, n_tags, tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		if (opmod)
+		{
+			sendto_match_servs_tags(source_p, "*", CAP_EOPMOD | servcaps, CAP_MULTILINE,
+				n_tags, tags, "%s =%s :%s",
+				command, chptr->chname, data->msg.para[2]);
+
+			sendto_match_servs_tags(source_p->servptr, "*", servcaps, CAP_MULTILINE | CAP_EOPMOD,
+				n_tags, tags, "NOTICE @%s :<%s:%s> %s",
+				chptr->chname, source_p->name, chptr->chname, data->msg.para[2]);
+		}
+		else
+			sendto_match_servs_tags(source_p, "*", servcaps, CAP_MULTILINE,
+				n_tags, tags, "%s %s%s :%s",
+				command, status, chptr->chname, data->msg.para[2]);
+
+		/* msgid should only be attached to the first message of the fallback */
+		if (msgid > -1)
+			tags[msgid].capmask = NOCAPS;
+	}
+
+	sendto_channel_local_with_capability_butone(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+		chptr, ":%s BATCH -%s", origin, batch->id);
+
+	sendto_match_servs(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+		"BATCH -%s", batch->id);
+
+	/* send an echo-message */
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+	{
+		if (msgid > -1)
+			tags[msgid].capmask = CLICAP_MESSAGE_TAGS;
+
+		/* echo the incoming batch tag rather than our synthesized one */
+		inner_tags[0].value = batch->tag;
+
+		sendto_one_tags(source_p, NOCAPS, NOCAPS, n_tags, tags,
+			":%s BATCH +%s draft/multiline %s%s",
+			origin, batch->tag, status, chptr->chname);
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+			sendto_one_tags(source_p, NOCAPS, NOCAPS, concat ? 2 : 1, inner_tags,
+				":%s %s %s%s :%s",
+				origin, command, status, chptr->chname, data->msg.para[2]);
+		}
+
+		sendto_one(source_p, ":%s BATCH -%s", origin, batch->tag);
+	}
+}
+
+static void
+send_private_batch(struct Client *client_p, struct Client *source_p,
+	struct Client *target_p,
+	struct Batch *batch, size_t n_tags, struct MsgTag tags[])
+{
+	rb_dlink_node *ptr;
+	char origin[USERHOST_REPLYLEN];
+	int msgid = -1;
+
+	/* figure out command and normalize to uppercase */
+	const char *command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	enum message_type msgtype = !rb_strcasecmp(command, "PRIVMSG") ? MESSAGE_TYPE_PRIVMSG : MESSAGE_TYPE_NOTICE;
+	command = (msgtype == MESSAGE_TYPE_PRIVMSG) ? "PRIVMSG" : "NOTICE";
+
+	for (size_t i = 0; i < n_tags; i++)
+	{
+		if (!strcmp(tags[i].key, "msgid"))
+		{
+			msgid = (int)i;
+			break;
+		}
+	}
+
+	snprintf(origin, sizeof(origin), IsPerson(source_p) ? "%s!%s@%s" : "%s",
+		get_id(source_p, target_p), source_p->username, source_p->host);
+
+	struct MsgTag inner_tags[] = {
+		{ "batch", batch->id, CLICAP_BATCH },
+		{ "draft/multiline-concat", NULL, CLICAP_MULTILINE },
+	};
+
+	if ((MyClient(target_p) && IsClientCapable(target_p, CLICAP_MULTILINE | CLICAP_BATCH))
+		|| (!MyClient(target_p) && IsServerCapable(target_p->from, CAP_MULTILINE)))
+	{
+		sendto_one_tags(target_p, NOCAPS, NOCAPS, n_tags, tags,
+			":%s BATCH +%s draft/multiline %s",
+			origin, batch->id, target_p->name);
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+			sendto_one_tags(target_p, NOCAPS, NOCAPS, concat ? 2: 1, inner_tags,
+				"%s %s %s :%s",
+				origin, command, get_id(target_p, target_p), data->msg.para[2]);
+		}
+
+		sendto_one(target_p, ":%s BATCH -%s", origin, batch->id);
+	}
+	else
+	{
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			if (EmptyString(data->msg.para[2]))
+				continue;
+
+			sendto_one_tags(target_p, NOCAPS, NOCAPS,
+				n_tags, tags, "%s %s %s :%s",
+				origin, command, get_id(target_p, target_p), data->msg.para[2]);
+
+			/* msgid should only be attached to the first message of the fallback */
+			if (msgid > -1)
+				tags[msgid].capmask = NOCAPS;
+		}
+	}
+
+	uint64_t CAP_ECHO = capability_get(serv_capindex, "ECHO", NULL);
+	uint64_t CAP_ECHOB = capability_get(serv_capindex, "ECHOB", NULL);
+	s_assert(CAP_ECHO != 0 && CAP_ECHOB != 0);
+	/* we'll get a remote echo if the target server supports ECHO but not MULTILINE **OR** if it supports both ECHOB and MULTILINE */
+	if (MyClient(target_p)
+		|| (IsServerCapable(target_p->from, CAP_ECHO) && NotServerCapable(target_p->from, CAP_MULTILINE))
+		|| IsServerCapable(target_p->from, CAP_ECHOB | CAP_MULTILINE))
+	{
+		/* echo the incoming batch tag rather than our synthesized one */
+		inner_tags[0].value = batch->tag;
+
+		/* send an echo batch here since the target's server won't send one */
+		const char *echo_prefix = MyClient(source_p) ? origin : get_id(target_p, source_p);
+		uint64_t serv_cap = NOCAPS;
+		if (MyClient(source_p))
+		{
+			if (NotClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+				return;
+
+			sendto_one_tags(source_p, NOCAPS, NOCAPS, n_tags, tags,
+				":%s BATCH +%s draft/multiline %s",
+				echo_prefix, batch->tag, target_p->name);
+		}
+		else if (!MyClient(source_p))
+		{
+			char echo_batch_id[16];
+			generate_batch_id(echo_batch_id, sizeof(echo_batch_id));
+			struct MsgTag echo_batch = { "batch", echo_batch_id, CLICAP_BATCH };
+
+			serv_cap = CAP_ECHOB;
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 0, NULL,
+				":%s BATCH +%s solanum.chat/echo %s",
+				echo_prefix, batch->id, use_id(source_p));
+
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 1, &echo_batch,
+				":%s BATCH +%s draft/multiline %s",
+				echo_prefix, batch->tag, target_p->name);
+		}
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+			sendto_one_tags(source_p, serv_cap, NOCAPS, concat ? 2 : 1, inner_tags,
+				":%s %s %s :%s",
+				echo_prefix, command, target_p->name, data->msg.para[2]);
+		}
+
+		sendto_one_tags(source_p, serv_cap, NOCAPS, 0, NULL,
+			":%s BATCH -%s", echo_prefix, batch->tag);
+	}
+}
+
+static void
+process_multiline(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *unused)
+{
+	const char *target, *chtarget;
+	struct Client *target_p = NULL;
+	struct Channel *chptr = NULL;
+	int type = ALL_MEMBERS;
+	enum message_type msgtype;
+	bool opmod = false;
+	unsigned int bytes = 0;
+	char *combined, *pos;
+	const char *command;
+	rb_dlink_node *ptr;
+
+	/* do they have the caps? */
+	if (MyClient(source_p) && !IsClientCapable(source_p, CLICAP_MULTILINE | CLICAP_BATCH))
+	{
+		sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batches require both the batch and draft/multiline capabilities",
+			me.name);
+		return;
+	}
+
+	/* nested? */
+	if (msgbuf_get_tag(&batch->start->msg, "batch") != NULL)
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batches cannot be nested inside other batches",
+				me.name);
+		return;
+	}
+
+	/* too many lines? */
+	if (MyConnect(source_p) && batch->len > max_lines)
+	{
+		sendto_one(source_p, ":%s FAIL BATCH MULTILINE_MAX_LINES %d :multiline batch contains too many lines",
+			me.name, max_lines);
+		return;
+	}
+
+	/* get the target from the initial BATCH message */
+	if (batch->start->msg.n_para < 4)
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch is missing a target",
+				me.name);
+		return;
+	}
+
+	target = chtarget = batch->start->msg.para[3];
+	/* statusmsg/eopmod? */
+	if (*target == '@')
+	{
+		type = ONLY_CHANOPS;
+		++chtarget;
+	}
+	else if (*target == '+')
+	{
+		type = ONLY_CHANOPSVOICED;
+		++chtarget;
+	}
+	else if (*target == '=' && IsServer(client_p))
+	{
+		type = ONLY_CHANOPS;
+		++chtarget;
+		opmod = true;
+	}
+
+	if (EmptyString(chtarget))
+	{
+		sendto_one(source_p, form_str(ERR_NORECIPIENT),
+			me.name, source_p->name, "BATCH");
+		return;
+	}
+
+	/* Unlike m_message we do not support messages sent to username@server or broadcasts with '$' */
+	if (IsChanPrefix(*chtarget))
+	{
+		/* remote servers can't message local channels */
+		if (IsServer(client_p) && *chtarget == '&')
+			return;
+
+		chptr = find_channel(chtarget);
+		if (chptr == NULL)
+		{
+			sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+				form_str(ERR_NOSUCHNICK), chtarget);
+			return;
+		}
+
+		if (type != ALL_MEMBERS && !opmod)
+		{
+			struct membership *msptr = find_channel_membership(chptr, source_p);
+			if (!IsServer(source_p) && !IsService(source_p) && !is_chanop_voiced(msptr))
+			{
+				sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+					get_id(&me, source_p),
+					get_id(source_p, source_p),
+					target);
+				return;
+			}
+		}
+	}
+	else if (type != ALL_MEMBERS)
+	{
+		/* given a statusmsg prefix but what follows isn't a valid channel name */
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+			form_str(ERR_NOSUCHNICK), target);
+		return;
+	}
+	else
+	{
+		target_p = MyClient(source_p) ? find_named_client(target) : find_client(target);
+		if (target_p == NULL)
+		{
+			sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+				form_str(ERR_NOSUCHNICK), target);
+			return;
+		}
+	}
+
+	/* received from remote server, send it along without repeating validation/hooks */
+	if (IsServer(client_p))
+	{
+		if (target_p != NULL)
+			send_private_batch(client_p, source_p, target_p, batch, batch->start->msg.n_tags, batch->start->msg.tags);
+		else if (chptr != NULL)
+			send_channel_batch(client_p, source_p, chptr, type, opmod, batch, batch->start->msg.n_tags, batch->start->msg.tags);
+
+		return;
+	}
+
+	/* determine if this is a PRIVMSG or a NOTICE batch */
+	command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	if (!rb_strcasecmp("PRIVMSG", command))
+	{
+		msgtype = MESSAGE_TYPE_PRIVMSG;
+	}
+	else if (!rb_strcasecmp("NOTICE", command))
+	{
+		msgtype = MESSAGE_TYPE_NOTICE;
+	}
+	else
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands",
+				me.name);
+		return;
+	}
+
+	/* If extensions/tag_message_id is loaded, save off the first generated msgid
+	 * since calling the privmsg_user/privmsg_channel hooks are what generates msgids and we do that
+	 * once for each line of the batch.
+	 */
+	char msgid[BUFSIZE] = {0};
+	const char *generated_msgid;
+	bool have_msgid = false;
+
+	/* Validate the rest of the batch before sending any text out.
+	 * We need to ensure it stays under max-bytes, commands are valid, targets match,
+	 * and then give hooks a chance to filter or modify the message.
+	 */
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		if (rb_strcasecmp(command, data->msg.cmd) != 0)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands",
+				me.name);
+			return;
+		}
+
+		if (irccmp(target, data->msg.para[1]) != 0)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID_TARGET %s %s :mismatched target within multiline batch",
+				me.name, target, data->msg.para[1]);
+			return;
+		}
+
+		const char *text = data->msg.para[2];
+		if (*text == '\x01')
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch cannot contain CTCP",
+				me.name);
+			return;
+		}
+
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+		if (EmptyString(text) && concat)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :cannot send blank line with draft/multiline-concat",
+				me.name);
+			return;
+		}
+
+		bool text_changed = false;
+		if (target_p != NULL)
+		{
+			hook_data_privmsg_user hdata = { msgtype, source_p, target_p, text, 0, &data->msg };
+			call_hook(h_privmsg_user, &hdata);
+			if (hdata.approved != 0)
+			{
+				/* assume the hook took care of sending the user any appropriate error message */
+				return;
+			}
+
+			if (text != hdata.text)
+			{
+				text = hdata.text;
+				text_changed = true;
+			}
+		}
+		else
+		{
+			hook_data_privmsg_channel hdata = { msgtype, source_p, chptr, text, 0, &data->msg };
+			call_hook(h_privmsg_channel, &hdata);
+			if (hdata.approved != 0)
+			{
+				/* assume the hook took care of sending the user any appropriate error message */
+				return;
+			}
+
+			if (text != hdata.text)
+			{
+				text = hdata.text;
+				text_changed = true;
+			}
+		}
+
+		if (text_changed)
+		{
+			/* save off updated text in the original MsgBuf */
+			size_t newlen = strlen(text) + 1;
+			char *tmp = rb_malloc(data->datalen + newlen);
+			memcpy(tmp, data->data, data->datalen);
+			strcpy(tmp + data->datalen, text);
+			data->msg.para[2] = tmp + data->datalen;
+			rb_free(data->data);
+			data->data = tmp;
+			data->datalen += newlen;
+		}
+
+		if (!have_msgid && (generated_msgid = msgbuf_get_tag(&data->msg, "msgid")) != NULL)
+		{
+			have_msgid = true;
+			rb_strlcpy(msgid, generated_msgid, sizeof(msgid));
+		}
+
+		size_t len = strlen(text);
+		bytes += len;
+		/* Add a byte for the newline if this isn't the first message and we lack the multiline-concat tag */
+		if (ptr != batch->messages.head && !concat)
+			bytes++;
+
+		if (bytes > max_bytes)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_MAX_BYTES %d :multiline batch contains too many bytes",
+				me.name, max_bytes);
+			return;
+		}
+
+		/* duplicated here because text may have changed after hooks */
+		if (len == 0 && concat)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :cannot send blank line with draft/multiline-concat",
+				me.name);
+			return;
+		}
+	}
+
+	combined = pos = rb_malloc(bytes + 1);
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		const char *text = data->msg.para[2];
+		size_t len = strlen(text);
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+		if (ptr != batch->messages.head && !concat)
+			*pos++ = '\n';
+
+		strcpy(pos, text);
+		pos += len;
+	}
+
+	/* at this point we have the full combined text,
+	 * make a dummy msgbuf with only tags defined in case hooks want to add more
+	 */
+	struct MsgBuf batch_msgbuf = { 0 };
+	if (have_msgid)
+		msgbuf_append_tag(&batch_msgbuf, "msgid", msgid, CLICAP_MESSAGE_TAGS);
+
+	if (target_p != NULL)
+	{
+		hook_data_privmsg_user hdata = { msgtype, source_p, target_p, combined, 0, &batch_msgbuf };
+		call_hook(h_multiline_message_user, &hdata);
+		rb_free(combined);
+		if (hdata.approved != 0)
+		{
+			/* assume the hook took care of sending the user any appropriate error message */
+			return;
+		}
+
+		send_private_batch(client_p, source_p, target_p, batch, batch_msgbuf.n_tags, batch_msgbuf.tags);
+	}
+	else if (chptr != NULL)
+	{
+		hook_data_privmsg_channel hdata = { msgtype, source_p, chptr, combined, 0, &batch_msgbuf };
+		call_hook(h_multiline_message_channel, &hdata);
+		rb_free(combined);
+		if (hdata.approved != 0)
+		{
+			/* assume the hook took care of sending the user any appropriate error message */
+			return;
+		}
+
+		send_channel_batch(client_p, source_p, chptr, type, opmod, batch, batch_msgbuf.n_tags, batch_msgbuf.tags);
+	}
+}
+
+static void
+multiline_tag_allow(void *data_)
+{
+	hook_data_message_tag *data = data_;
+	if (!strcmp(data->key, "draft/multiline-concat"))
+	{
+		data->capmask = CLICAP_MULTILINE;
+		data->approved = MESSAGE_TAG_ALLOW;
+	}
+}
+
+DECLARE_MODULE_AV2(multiline, multiline_modinit, multiline_moddeinit, NULL, NULL, multiline_hfn_list, multiline_cap_list, NULL, multiline_desc);

--- a/extensions/multiline.c
+++ b/extensions/multiline.c
@@ -1,0 +1,865 @@
+/*
+ * Solanum: a slightly advanced ircd
+ * multiline.c: Implement the draft/multiline batch type
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "stdinc.h"
+#include "batch.h"
+#include "client.h"
+#include "hash.h"
+#include "modules.h"
+#include "msgbuf.h"
+#include "newconf.h"
+#include "numeric.h"
+#include "send.h"
+#include "s_assert.h"
+#include "s_conf.h"
+#include "s_newconf.h"
+#include "s_serv.h"
+#include "tgchange.h"
+
+/* the MULTILN server capability indicates support for the s2s multiline batch type */
+static uint64_t CAP_MULTILINE;
+static uint64_t CLICAP_MULTILINE;
+static int h_multiline_message_user;
+static int h_multiline_message_channel;
+
+static const char multiline_desc[] =
+	"Allows clients to send batches containing multiple lines at once (draft/multiline batch type).";
+
+static char capdata_buf[BUFSIZE];
+static unsigned int old_max_lines = 0;
+static unsigned int old_max_bytes = 0;
+static unsigned int max_lines = 0;
+static unsigned int max_bytes = 0;
+
+static int multiline_modinit(void);
+static void multiline_moddeinit(void);
+static void process_multiline(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *);
+static void multiline_conf_info(void *);
+static void multiline_conf_store(void *);
+static void multiline_conf_update(void *);
+static void multiline_tag_allow(void *);
+static void multiline_rehash(void *);
+static const char *multiline_config(struct Client *);
+
+mapi_hfn_list_av1 multiline_hfn_list[] = {
+	{ "conf_read_start", multiline_conf_store },
+	{ "conf_read_end", multiline_conf_update },
+	{ "doing_info_conf", multiline_conf_info },
+	{ "message_tag", multiline_tag_allow },
+	{ "rehash", multiline_rehash },
+	{ NULL, NULL },
+};
+
+mapi_hlist_av1 multiline_hlist[] = {
+	{ "multiline_message_user", &h_multiline_message_user },
+	{ "multiline_message_channel", &h_multiline_message_channel },
+	{ NULL, NULL },
+};
+
+struct ClientCapability capdata_multiline = { .data = multiline_config };
+
+mapi_cap_list_av2 multiline_cap_list[] = {
+	{ MAPI_CAP_CLIENT, "draft/multiline", &capdata_multiline, &CLICAP_MULTILINE },
+	{ MAPI_CAP_SERVER, "MULTILN", NULL, &CAP_MULTILINE },
+	{ 0, NULL, NULL, NULL },
+};
+
+struct BatchHandler multiline_handler = { process_multiline, NULL, 0, NULL };
+
+static void
+conf_set_multiline_max_bytes(void *data)
+{
+	max_bytes = *(int *)data;
+}
+
+static void
+conf_set_multiline_max_lines(void *data)
+{
+	max_lines = *(int *)data;
+}
+
+static int
+multiline_modinit(void)
+{
+	if (!register_batch_handler("draft/multiline", &multiline_handler))
+		return -1;
+
+	/* for forward compatibility, accept unprefixed multiline over S2S links too */
+	if (!register_batch_handler("multiline", &multiline_handler))
+	{
+		remove_batch_handler("draft/multiline");
+		return -1;
+	}
+
+	add_conf_item("general", "multiline_max_bytes", CF_INT, conf_set_multiline_max_bytes);
+	add_conf_item("general", "multiline_max_lines", CF_INT, conf_set_multiline_max_lines);
+
+	return 1;
+}
+
+static void
+multiline_moddeinit(void)
+{
+	remove_batch_handler("draft/multiline");
+	remove_batch_handler("multiline");
+}
+
+static const char *
+multiline_config(struct Client *unused)
+{
+	return capdata_buf;
+}
+
+static void
+multiline_conf_store(void *unused)
+{
+	old_max_bytes = max_bytes;
+	old_max_lines = max_lines;
+}
+
+static void
+multiline_conf_update(void *unused)
+{
+	sprintf(capdata_buf, "max-bytes=%d,max-lines=%d", max_bytes, max_lines);
+}
+
+static void
+multiline_rehash(void *data)
+{
+	/* config rehash may have changed multiline_max_bytes or multiline_max_lines */
+	if (old_max_bytes != max_bytes || old_max_lines != max_lines)
+	{
+		/* notify cap-notify clients of the new limits */
+		sendto_local_clients_with_capability(CLICAP_CAP_NOTIFY, ":%s CAP * NEW :draft/multiline=%s",
+			me.name, capdata_buf);
+	}
+}
+
+static void
+multiline_conf_info(void *data_)
+{
+	hook_data *data = data_;
+	char max_lines_buf[24];
+	char max_bytes_buf[24];
+
+	snprintf(max_bytes_buf, sizeof(max_bytes_buf), "%d", max_bytes);
+	snprintf(max_lines_buf, sizeof(max_lines_buf), "%d", max_lines);
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"multiline_max_lines",
+		max_lines_buf,
+		"Maximum number of lines allowed in a multiline batch");
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"multiline_max_bytes",
+		max_bytes_buf,
+		"Maximum number of bytes allowed in a multiline batch");
+}
+
+static void
+send_channel_batch(struct Client *client_p, struct Client *source_p,
+	struct Channel *chptr, int type, bool opmod,
+	struct Batch *batch, size_t n_tags, struct MsgTag tags[])
+{
+	rb_dlink_node *ptr;
+	char origin[USERHOST_REPLYLEN];
+	int msgid = -1;
+
+	/* figure out command and normalize to uppercase */
+	const char *command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	enum message_type msgtype = !rb_strcasecmp(command, "PRIVMSG") ? MESSAGE_TYPE_PRIVMSG : MESSAGE_TYPE_NOTICE;
+	command = (msgtype == MESSAGE_TYPE_PRIVMSG) ? "PRIVMSG" : "NOTICE";
+
+	for (size_t i = 0; i < n_tags; i++)
+	{
+		if (!strcmp(tags[i].key, "msgid"))
+		{
+			msgid = (int)i;
+			break;
+		}
+	}
+
+	snprintf(origin, sizeof(origin), IsPerson(source_p) ? "%s!%s@%s" : "%s",
+		source_p->name, source_p->username, source_p->host);
+
+	struct MsgTag inner_tags[] = {
+		{ "batch", batch->id, CLICAP_BATCH },
+		{ "draft/multiline-concat", NULL, CLICAP_MULTILINE }
+	};
+
+	int result = can_send(chptr, source_p, NULL);
+	if (result)
+	{
+		if (result != CAN_SEND_OPV && MyClient(source_p)
+			&& !IsOperGeneral(source_p) && !add_channel_target(source_p, chptr))
+		{
+			sendto_one(source_p, form_str(ERR_TARGCHANGE),
+				me.name, source_p->name, chptr->chname);
+			return;
+		}
+
+		if (result != CAN_SEND_OPV && flood_attack_channel(msgtype, source_p, chptr, chptr->chname))
+			return;
+	}
+	else if (chptr->mode.mode & MODE_OPMODERATE
+		&& (!(chptr->mode.mode & MODE_NOPRIVMSGS) || IsMember(source_p, chptr)))
+	{
+		if (MyClient(source_p) && !IsOperGeneral(source_p) && !add_channel_target(source_p, chptr))
+		{
+			sendto_one(source_p, form_str(ERR_TARGCHANGE),
+				me.name, source_p->name, chptr->chname);
+			return;
+		}
+
+		if (!flood_attack_channel(msgtype, source_p, chptr, chptr->chname))
+		{
+			opmod = true;
+			type = ONLY_CHANOPS;
+		}
+	}
+	else
+	{
+		if (msgtype != MESSAGE_TYPE_NOTICE)
+			sendto_one_numeric(source_p, ERR_CANNOTSENDTOCHAN,
+				form_str(ERR_CANNOTSENDTOCHAN), chptr->chname);
+		return;
+	}
+
+	unsigned int servcaps = NOCAPS;
+	if (type != ALL_MEMBERS)
+		servcaps |= CAP_CHW;
+
+	const char *status = "";
+	if (type & CHFL_VOICE)
+		status = "+";
+	else if (type & CHFL_CHANOP)
+		status = "@";
+
+	sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+		chptr, n_tags, tags, ":%s BATCH +%s draft/multiline %s%s",
+		origin, batch->id, status, chptr->chname);
+
+	if (opmod)
+	{
+		sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | CAP_EOPMOD | servcaps, NOCAPS,
+			n_tags, tags, "BATCH +%s draft/multiline =%s",
+			batch->id, chptr->chname);
+
+		sendto_match_servs_tags(source_p->servptr, "*", CAP_MULTILINE | CAP_STAG | servcaps, CAP_EOPMOD,
+			n_tags, tags, "BATCH +%s draft/multiline @%s",
+			batch->id, chptr->chname);
+	}
+	else
+		sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+			n_tags, tags, "BATCH +%s draft/multiline %s%s",
+			batch->id, status, chptr->chname);
+
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+			chptr, concat ? 2 : 1, inner_tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		if (opmod)
+		{
+			sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | CAP_EOPMOD | servcaps, NOCAPS,
+				concat ? 2 : 1, inner_tags, "%s =%s :%s",
+				command, chptr->chname, data->msg.para[2]);
+
+			sendto_match_servs_tags(source_p->servptr, "*", CAP_MULTILINE | CAP_STAG | servcaps, CAP_EOPMOD,
+				concat ? 2 : 1, inner_tags, "NOTICE @%s :<%s:%s> %s",
+				chptr->chname, source_p->name, chptr->chname, data->msg.para[2]);
+		}
+		else
+			sendto_match_servs_tags(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+				concat ? 2 : 1, inner_tags, "%s %s%s :%s",
+				command, status, chptr->chname, data->msg.para[2]);
+
+		/* lot of different fallback scenarios for clients who don't support both batch and multiline */
+		if (EmptyString(data->msg.para[2]))
+			continue;
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, CLICAP_BATCH, CLICAP_MULTILINE,
+			chptr, n_tags, tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		sendto_channel_local_with_capability_butone_tags(source_p, type, NOCAPS, CLICAP_BATCH,
+			chptr, n_tags, tags, ":%s %s %s%s :%s",
+			origin, command, status, chptr->chname, data->msg.para[2]);
+
+		if (opmod)
+		{
+			sendto_match_servs_tags(source_p, "*", CAP_EOPMOD | servcaps, CAP_MULTILINE,
+				n_tags, tags, "%s =%s :%s",
+				command, chptr->chname, data->msg.para[2]);
+
+			sendto_match_servs_tags(source_p->servptr, "*", servcaps, CAP_MULTILINE | CAP_EOPMOD,
+				n_tags, tags, "NOTICE @%s :<%s:%s> %s",
+				chptr->chname, source_p->name, chptr->chname, data->msg.para[2]);
+		}
+		else
+			sendto_match_servs_tags(source_p, "*", servcaps, CAP_MULTILINE,
+				n_tags, tags, "%s %s%s :%s",
+				command, status, chptr->chname, data->msg.para[2]);
+
+		/* msgid should only be attached to the first message of the fallback */
+		if (msgid > -1)
+			tags[msgid].capmask = NOCAPS;
+	}
+
+	sendto_channel_local_with_capability_butone(source_p, type, CLICAP_BATCH | CLICAP_MULTILINE, NOCAPS,
+		chptr, ":%s BATCH -%s", origin, batch->id);
+
+	sendto_match_servs(source_p, "*", CAP_MULTILINE | CAP_STAG | servcaps, NOCAPS,
+		"BATCH -%s", batch->id);
+
+	/* send an echo-message */
+	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+	{
+		if (msgid > -1)
+			tags[msgid].capmask = CLICAP_MESSAGE_TAGS;
+
+		/* echo the incoming batch tag rather than our synthesized one */
+		inner_tags[0].value = batch->tag;
+
+		sendto_one_tags(source_p, NOCAPS, NOCAPS, n_tags, tags,
+			":%s BATCH +%s draft/multiline %s%s",
+			origin, batch->tag, status, chptr->chname);
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+			sendto_one_tags(source_p, NOCAPS, NOCAPS, concat ? 2 : 1, inner_tags,
+				":%s %s %s%s :%s",
+				origin, command, status, chptr->chname, data->msg.para[2]);
+		}
+
+		sendto_one(source_p, ":%s BATCH -%s", origin, batch->tag);
+	}
+}
+
+static void
+send_private_batch(struct Client *client_p, struct Client *source_p,
+	struct Client *target_p,
+	struct Batch *batch, size_t n_tags, struct MsgTag tags[])
+{
+	rb_dlink_node *ptr;
+	char origin[USERHOST_REPLYLEN];
+	int msgid = -1;
+
+	/* figure out command and normalize to uppercase */
+	const char *command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	enum message_type msgtype = !rb_strcasecmp(command, "PRIVMSG") ? MESSAGE_TYPE_PRIVMSG : MESSAGE_TYPE_NOTICE;
+	command = (msgtype == MESSAGE_TYPE_PRIVMSG) ? "PRIVMSG" : "NOTICE";
+
+	for (size_t i = 0; i < n_tags; i++)
+	{
+		if (!strcmp(tags[i].key, "msgid"))
+		{
+			msgid = (int)i;
+			break;
+		}
+	}
+
+	snprintf(origin, sizeof(origin), IsPerson(source_p) ? "%s!%s@%s" : "%s",
+		get_id(source_p, target_p), source_p->username, source_p->host);
+
+	struct MsgTag inner_tags[] = {
+		{ "batch", batch->id, CLICAP_BATCH },
+		{ "draft/multiline-concat", NULL, CLICAP_MULTILINE },
+	};
+
+	if ((MyClient(target_p) && IsClientCapable(target_p, CLICAP_MULTILINE | CLICAP_BATCH))
+		|| (!MyClient(target_p) && IsServerCapable(target_p->from, CAP_MULTILINE)))
+	{
+		sendto_one_tags(target_p, NOCAPS, NOCAPS, n_tags, tags,
+			":%s BATCH +%s draft/multiline %s",
+			origin, batch->id, target_p->name);
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+			sendto_one_tags(target_p, NOCAPS, NOCAPS, concat ? 2: 1, inner_tags,
+				":%s %s %s :%s",
+				origin, command, get_id(target_p, target_p), data->msg.para[2]);
+		}
+
+		sendto_one(target_p, ":%s BATCH -%s", origin, batch->id);
+	}
+	else
+	{
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			if (EmptyString(data->msg.para[2]))
+				continue;
+
+			sendto_one_tags(target_p, NOCAPS, NOCAPS,
+				n_tags, tags, ":%s %s %s :%s",
+				origin, command, get_id(target_p, target_p), data->msg.para[2]);
+
+			/* msgid should only be attached to the first message of the fallback */
+			if (msgid > -1)
+				tags[msgid].capmask = NOCAPS;
+		}
+	}
+
+	uint64_t CAP_ECHO = capability_get(serv_capindex, "ECHO", NULL);
+	uint64_t CAP_ECHOB = capability_get(serv_capindex, "ECHOB", NULL);
+	s_assert(CAP_ECHO != 0 && CAP_ECHOB != 0);
+	/* we'll get a remote echo if the target server supports ECHO but not MULTILINE **OR** if it supports both ECHOB and MULTILINE */
+	if (MyClient(target_p)
+		|| (IsServerCapable(target_p->from, CAP_ECHO) && NotServerCapable(target_p->from, CAP_MULTILINE))
+		|| IsServerCapable(target_p->from, CAP_ECHOB | CAP_MULTILINE))
+	{
+		char echo_batch_id[16];
+		generate_batch_id(echo_batch_id, sizeof(echo_batch_id));
+		struct MsgTag echo_batch = { "batch", echo_batch_id, CLICAP_BATCH };
+
+		/* echo the incoming batch tag rather than our synthesized one */
+		inner_tags[0].value = batch->tag;
+
+		/* send an echo batch here since the target's server won't send one */
+		const char *echo_prefix = MyClient(source_p) ? origin : get_id(target_p, source_p);
+		uint64_t serv_cap = NOCAPS;
+		if (MyClient(source_p))
+		{
+			if (NotClientCapable(source_p, CLICAP_ECHO_MESSAGE))
+				return;
+
+			sendto_one_tags(source_p, NOCAPS, NOCAPS, n_tags, tags,
+				":%s BATCH +%s draft/multiline %s",
+				echo_prefix, batch->tag, target_p->name);
+		}
+		else
+		{
+			serv_cap = CAP_ECHOB;
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 0, NULL,
+				":%s BATCH +%s solanum.chat/echo %s",
+				echo_prefix, echo_batch_id, use_id(source_p));
+
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 1, &echo_batch,
+				":%s BATCH +%s draft/multiline %s",
+				echo_prefix, batch->tag, target_p->name);
+		}
+
+		RB_DLINK_FOREACH(ptr, batch->messages.head)
+		{
+			struct BatchMessage *data = ptr->data;
+			bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+
+			sendto_one_tags(source_p, serv_cap, NOCAPS, concat ? 2 : 1, inner_tags,
+				":%s %s %s :%s",
+				echo_prefix, command, target_p->name, data->msg.para[2]);
+		}
+
+		if (MyClient(source_p))
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 0, NULL,
+				":%s BATCH -%s", echo_prefix, batch->tag);
+		else
+		{
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 1, &echo_batch,
+				":%s BATCH -%s", echo_prefix, batch->tag);
+
+			sendto_one_tags(source_p, serv_cap, NOCAPS, 0, NULL,
+				":%s BATCH -%s", echo_prefix, echo_batch_id);
+		}
+	}
+}
+
+static void
+process_multiline(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *unused)
+{
+	const char *target, *chtarget;
+	struct Client *target_p = NULL;
+	struct Channel *chptr = NULL;
+	int type = ALL_MEMBERS;
+	enum message_type msgtype;
+	bool opmod = false;
+	unsigned int bytes = 0;
+	char *combined, *pos;
+	const char *command;
+	rb_dlink_node *ptr;
+
+	/* do they have the caps? */
+	if (MyClient(source_p) && !IsClientCapable(source_p, CLICAP_MULTILINE | CLICAP_BATCH))
+	{
+		sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batches require both the batch and draft/multiline capabilities",
+			me.name);
+		return;
+	}
+
+	/* unprefixed and is a local client? (only allow unprefixed multiline over s2s links) */
+	if (MyClient(source_p) && !strcmp(batch->type, "multiline"))
+	{
+		sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+				me.name, batch->tag, batch->type);
+		return;
+	}
+
+	/* nested? */
+	if (msgbuf_get_tag(&batch->start->msg, "batch") != NULL)
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batches cannot be nested inside other batches",
+				me.name);
+		return;
+	}
+
+	/* empty? */
+	if (batch->len == 0)
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batches cannot be empty",
+				me.name);
+		return;
+	}
+
+	/* too many lines? */
+	if (MyConnect(source_p) && batch->len > max_lines)
+	{
+		sendto_one(source_p, ":%s FAIL BATCH MULTILINE_MAX_LINES %d :multiline batch contains too many lines",
+			me.name, max_lines);
+		return;
+	}
+
+	/* get the target from the initial BATCH message */
+	if (batch->start->msg.n_para < 4)
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch is missing a target",
+				me.name);
+		return;
+	}
+
+	target = chtarget = batch->start->msg.para[3];
+	/* statusmsg/eopmod? */
+	if (*target == '@')
+	{
+		type = ONLY_CHANOPS;
+		++chtarget;
+	}
+	else if (*target == '+')
+	{
+		type = ONLY_CHANOPSVOICED;
+		++chtarget;
+	}
+	else if (*target == '=' && IsServer(client_p))
+	{
+		type = ONLY_CHANOPS;
+		++chtarget;
+		opmod = true;
+	}
+
+	if (EmptyString(chtarget))
+	{
+		sendto_one(source_p, form_str(ERR_NORECIPIENT),
+			me.name, source_p->name, "BATCH");
+		return;
+	}
+
+	/* Unlike m_message we do not support messages sent to username@server or broadcasts with '$' */
+	if (IsChanPrefix(*chtarget))
+	{
+		/* remote servers can't message local channels */
+		if (IsServer(client_p) && *chtarget == '&')
+			return;
+
+		chptr = find_channel(chtarget);
+		if (chptr == NULL)
+		{
+			sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+				form_str(ERR_NOSUCHNICK), chtarget);
+			return;
+		}
+
+		if (type != ALL_MEMBERS && !opmod)
+		{
+			struct membership *msptr = find_channel_membership(chptr, source_p);
+			if (!IsServer(source_p) && !IsService(source_p) && !is_chanop_voiced(msptr))
+			{
+				sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+					get_id(&me, source_p),
+					get_id(source_p, source_p),
+					target);
+				return;
+			}
+		}
+	}
+	else if (type != ALL_MEMBERS)
+	{
+		/* given a statusmsg prefix but what follows isn't a valid channel name */
+		sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+			form_str(ERR_NOSUCHNICK), target);
+		return;
+	}
+	else
+	{
+		target_p = MyClient(source_p) ? find_named_client(target) : find_client(target);
+		if (target_p == NULL)
+		{
+			sendto_one_numeric(source_p, ERR_NOSUCHNICK,
+				form_str(ERR_NOSUCHNICK), target);
+			return;
+		}
+	}
+
+	/* received from remote server, send it along without repeating validation/hooks */
+	if (IsServer(client_p))
+	{
+		if (target_p != NULL)
+			send_private_batch(client_p, source_p, target_p, batch, batch->start->msg.n_tags, batch->start->msg.tags);
+		else if (chptr != NULL)
+			send_channel_batch(client_p, source_p, chptr, type, opmod, batch, batch->start->msg.n_tags, batch->start->msg.tags);
+
+		return;
+	}
+
+	/* determine if this is a PRIVMSG or a NOTICE batch */
+	command = ((struct BatchMessage *)batch->messages.head->data)->msg.cmd;
+	if (!rb_strcasecmp("PRIVMSG", command))
+	{
+		msgtype = MESSAGE_TYPE_PRIVMSG;
+		/* if the privmsg_user/privmsg_channel hook adjusts the text, the original will be a dangling pointer;
+		 * just make it a constant at this point since we know what it's supposed to be */
+		command = "PRIVMSG";
+	}
+	else if (!rb_strcasecmp("NOTICE", command))
+	{
+		msgtype = MESSAGE_TYPE_NOTICE;
+		command = "NOTICE";
+	}
+	else
+	{
+		if (MyClient(source_p))
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands",
+				me.name);
+		return;
+	}
+
+	/* If extensions/tag_message_id is loaded, save off the first generated msgid
+	 * since calling the privmsg_user/privmsg_channel hooks are what generates msgids and we do that
+	 * once for each line of the batch.
+	 */
+	char msgid[BUFSIZE] = {0};
+	const char *generated_msgid;
+	bool have_msgid = false;
+	bool have_content = false;
+
+	/* Validate the rest of the batch before sending any text out.
+	 * We need to ensure it stays under max-bytes, commands are valid, targets match,
+	 * and then give hooks a chance to filter or modify the message.
+	 */
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		if (rb_strcasecmp(command, data->msg.cmd) != 0)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands",
+				me.name);
+			return;
+		}
+
+		if (irccmp(target, data->msg.para[1]) != 0)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID_TARGET %s %s :mismatched target within multiline batch",
+				me.name, target, data->msg.para[1]);
+			return;
+		}
+
+		const char *text = data->msg.para[2];
+		if (*text == '\x01')
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch cannot contain CTCP",
+				me.name);
+			return;
+		}
+
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+		if (EmptyString(text) && concat)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :cannot send blank line with draft/multiline-concat",
+				me.name);
+			return;
+		}
+
+		bool text_changed = false;
+		if (target_p != NULL)
+		{
+			hook_data_privmsg_user hdata = { msgtype, source_p, target_p, text, 0, &data->msg };
+			call_hook(h_privmsg_user, &hdata);
+			if (hdata.approved != 0)
+			{
+				/* assume the hook took care of sending the user any appropriate error message */
+				return;
+			}
+
+			if (text != hdata.text)
+			{
+				text = hdata.text;
+				text_changed = true;
+			}
+		}
+		else
+		{
+			hook_data_privmsg_channel hdata = { msgtype, source_p, chptr, text, 0, &data->msg };
+			call_hook(h_privmsg_channel, &hdata);
+			if (hdata.approved != 0)
+			{
+				/* assume the hook took care of sending the user any appropriate error message */
+				return;
+			}
+
+			if (text != hdata.text)
+			{
+				text = hdata.text;
+				text_changed = true;
+			}
+		}
+
+		if (!have_msgid && (generated_msgid = msgbuf_get_tag(&data->msg, "msgid")) != NULL)
+		{
+			have_msgid = true;
+			rb_strlcpy(msgid, generated_msgid, sizeof(msgid));
+		}
+
+		size_t len = strlen(text);
+		bytes += len;
+		/* Add a byte for the newline if this isn't the first message and we lack the multiline-concat tag */
+		if (ptr != batch->messages.head && !concat)
+			bytes++;
+
+		if (bytes > max_bytes)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_MAX_BYTES %d :multiline batch contains too many bytes",
+				me.name, max_bytes);
+			return;
+		}
+
+		/* duplicated here because text may have changed after hooks */
+		if (len == 0 && concat)
+		{
+			sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :cannot send blank line with draft/multiline-concat",
+				me.name);
+			return;
+		}
+
+		if (len > 0)
+			have_content = true;
+
+		if (text_changed)
+		{
+			/* save off updated text */
+			data->msg.para[2] = text;
+			ptr->data = allocate_batch_message(&data->msg);
+			rb_free(data->data);
+			rb_free(data);
+		}
+	}
+
+	if (!have_content)
+	{
+		sendto_one(source_p, ":%s FAIL BATCH MULTILINE_INVALID :multiline batch cannot consist solely of blank lines",
+			me.name);
+		return;
+	}
+
+	combined = pos = rb_malloc(bytes + 1);
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		struct BatchMessage *data = ptr->data;
+		const char *text = data->msg.para[2];
+		size_t len = strlen(text);
+		bool concat = msgbuf_get_tag(&data->msg, "draft/multiline-concat") != NULL;
+		if (ptr != batch->messages.head && !concat)
+			*pos++ = '\n';
+
+		strcpy(pos, text);
+		pos += len;
+	}
+
+	/* at this point we have the full combined text,
+	 * make a dummy msgbuf with only tags defined in case hooks want to add more
+	 */
+	struct MsgBuf batch_msgbuf = { 0 };
+	if (have_msgid)
+		msgbuf_append_tag(&batch_msgbuf, "msgid", msgid, CLICAP_MESSAGE_TAGS);
+
+	if (target_p != NULL)
+	{
+		hook_data_privmsg_user hdata = { msgtype, source_p, target_p, combined, 0, &batch_msgbuf };
+		call_hook(h_multiline_message_user, &hdata);
+		rb_free(combined);
+		if (hdata.approved != 0)
+		{
+			/* assume the hook took care of sending the user any appropriate error message */
+			return;
+		}
+
+		send_private_batch(client_p, source_p, target_p, batch, batch_msgbuf.n_tags, batch_msgbuf.tags);
+	}
+	else if (chptr != NULL)
+	{
+		hook_data_privmsg_channel hdata = { msgtype, source_p, chptr, combined, 0, &batch_msgbuf };
+		call_hook(h_multiline_message_channel, &hdata);
+		rb_free(combined);
+		if (hdata.approved != 0)
+		{
+			/* assume the hook took care of sending the user any appropriate error message */
+			return;
+		}
+
+		send_channel_batch(client_p, source_p, chptr, type, opmod, batch, batch_msgbuf.n_tags, batch_msgbuf.tags);
+	}
+}
+
+static void
+multiline_tag_allow(void *data_)
+{
+	hook_data_message_tag *data = data_;
+	if (!strcmp(data->key, "draft/multiline-concat"))
+	{
+		data->capmask = CLICAP_MULTILINE;
+		data->approved = MESSAGE_TAG_ALLOW;
+	}
+
+	/* forward-compat: remap unprefixed multiline-concat to draft over S2S links */
+	if (!strcmp(data->key, "multiline-concat")
+		&& !MyClient(data->source)
+		&& msgbuf_get_tag(data->message, "draft/multiline-concat") == NULL)
+	{
+		data->key = "draft/multiline-concat";
+		data->capmask = CLICAP_MULTILINE;
+		data->approved = MESSAGE_TAG_ALLOW;
+	}
+}
+
+DECLARE_MODULE_AV2(multiline, multiline_modinit, multiline_moddeinit, NULL, NULL, multiline_hfn_list, multiline_cap_list, NULL, multiline_desc);

--- a/modules/core/m_batch.c
+++ b/modules/core/m_batch.c
@@ -86,6 +86,18 @@ reset_global_context(void)
 	incoming_message = saved_global_context.incoming_message;
 }
 
+static bool
+valid_batch_tag(const char *tag)
+{
+	for (; *tag != '\0'; tag++)
+	{
+		if (!IsIdChar(*tag) && *tag != '-')
+			return false;
+	}
+
+	return true;
+}
+
 static void
 batch_timeout(void *arg)
 {
@@ -291,7 +303,7 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		return;
 	}
 
-	if ((!adding && *parv[1] != '-') || EmptyString(parv[1] + 1))
+	if ((!adding && *parv[1] != '-') || EmptyString(parv[1] + 1) || !valid_batch_tag(parv[1] + 1))
 	{
 		if (IsClient(source_p))
 			sendto_one(source_p, ":%s FAIL BATCH INVALID_REFTAG %s :Invalid reference tag",

--- a/modules/core/m_batch.c
+++ b/modules/core/m_batch.c
@@ -34,6 +34,8 @@
 #include "batch.h"
 #include "response.h"
 
+#define HasBatchFlag(x, y) (((x)->flags & (y)) == (y))
+
 static const char batch_desc[] =
 	"Provides the BATCH command for client-initiated or propagated batches";
 
@@ -209,7 +211,7 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 	handler->handler(client_p, source_p, batch, handler->userdata);
 
 	/* handle child batches */
-	if (!(handler->flags & BATCH_FLAG_SKIP_CHILDREN))
+	if (!HasBatchFlag(handler, BATCH_FLAG_SKIP_CHILDREN))
 	{
 		RB_DLINK_FOREACH_SAFE(ptr, next_ptr, batch->children.head)
 		{
@@ -331,14 +333,6 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 			return;
 		}
 
-		if (get_batch_handler(parv[2]) == NULL)
-		{
-			if (IsClient(source_p))
-				sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
-					me.name, parv[1], parv[2]);
-			return;
-		}
-
 		if (parent != NULL)
 		{
 			const struct BatchHandler *parent_handler = get_batch_handler(parent->type);
@@ -351,7 +345,15 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 				return;
 			}
 
-			bool allowed = (parent_handler->flags & BATCH_FLAG_ALLOW_ALL) == BATCH_FLAG_ALLOW_ALL;
+			if (!HasBatchFlag(parent_handler, BATCH_FLAG_SKIP_CHILDREN) && get_batch_handler(parv[2]) == NULL)
+			{
+				if (IsClient(source_p))
+					sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+						me.name, parv[1], parv[2]);
+				return;
+			}
+
+			bool allowed = HasBatchFlag(parent_handler, BATCH_FLAG_ALLOW_ALL);
 			const char *error = NULL;
 			if (!allowed && parent_handler->child_allowed != NULL)
 				allowed = parent_handler->child_allowed(client_p, source_p, parent, msgbuf, parent_handler->userdata, &error);
@@ -368,6 +370,13 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 				}
 				return;
 			}
+		}
+		else if (get_batch_handler(parv[2]) == NULL)
+		{
+			if (IsClient(source_p))
+				sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+					me.name, parv[1], parv[2]);
+			return;
 		}
 
 		batch = batch_init(msgbuf);

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -34,6 +34,7 @@
 #include "channel.h"
 #include "match.h"
 #include "hash.h"
+#include "batch.h"
 #include "class.h"
 #include "msg.h"
 #include "packet.h"
@@ -74,11 +75,13 @@ static void m_tagmsg(struct MsgBuf *, struct Client *, struct Client *, int, con
 static void m_echo(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 
 static void echo_msg(struct Client *, struct Client *, enum message_type, const char *text, struct MsgBuf *msgbuf_p);
+static void process_echo_batch(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *);
 
 static void expire_tgchange(void *unused);
 static struct ev_entry *expire_tgchange_event;
 
 static uint64_t CAP_ECHO;
+static uint64_t CAP_ECHOB;
 
 struct entity
 {
@@ -92,9 +95,14 @@ struct entity
 	int flags;
 };
 
+struct BatchHandler echo_batch_handler = { process_echo_batch, NULL, BATCH_FLAG_SKIP_CHILDREN | BATCH_FLAG_ALLOW_ALL, NULL };
+
 static int
 modinit(void)
 {
+	if (!register_batch_handler("solanum.chat/echo", &echo_batch_handler))
+		return -1;
+
 	expire_tgchange_event = rb_event_addish("expire_tgchange", expire_tgchange, NULL, 300);
 	expire_tgchange(NULL);
 	return 0;
@@ -103,6 +111,7 @@ modinit(void)
 static void
 moddeinit(void)
 {
+	remove_batch_handler("solanum.chat/echo");
 	rb_event_delete(expire_tgchange_event);
 }
 
@@ -127,6 +136,7 @@ mapi_clist_av1 message_clist[] = { &privmsg_msgtab, &notice_msgtab, &echo_msgtab
 
 mapi_cap_list_av2 message_cap_list[] = {
 	{ MAPI_CAP_SERVER, "ECHO", NULL, &CAP_ECHO },
+	{ MAPI_CAP_SERVER, "ECHOB", NULL, &CAP_ECHOB },
 	{ 0, NULL, NULL, NULL }
 };
 
@@ -959,6 +969,57 @@ echo_msg(struct Client *source_p, struct Client *target_p,
 		shortname[msgtype],
 		use_id(target_p),
 		text);
+}
+
+static void
+process_echo_batch(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *unused)
+{
+	struct MsgBuf *msgbuf = &batch->start->msg;
+	char params[BUFSIZE];
+	char prefix[USERHOST_REPLYLEN];
+	rb_dlink_node *ptr;
+
+	if (msgbuf->n_para < 4)
+		return;
+
+	struct Client *target_p = find_person(msgbuf->para[3]);
+	if (target_p == NULL)
+		return;
+
+	if (!MyClient(target_p))
+	{
+		if (NotServerCapable(target_p->from, CAP_ECHOB))
+			return;
+
+		/* don't give a prefix in the batch contents to save a bit of bandwidth on s2s links */
+		*prefix = '\0';
+		msgbuf_unparse_para(params, sizeof(params), msgbuf);
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, ":%s BATCH %s",
+			use_id(source_p), params);
+	}
+	else
+		snprintf(prefix, sizeof(prefix), ":%s!%s@%s ",
+			target_p->name, target_p->username, target_p->host);
+
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		msgbuf = &((struct BatchMessage *)ptr->data)->msg;
+		msgbuf_unparse_para(params, sizeof(params), msgbuf);
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, "%s%s %s",
+			prefix, msgbuf->cmd, params);
+	}
+
+	RB_DLINK_FOREACH(ptr, batch->children.head)
+	{
+		process_echo_batch(client_p, source_p, ptr->data, unused);
+	}
+
+	if (!MyClient(target_p))
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, ":%s BATCH -%s",
+			use_id(source_p), batch->tag);
 }
 
 /*

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -34,6 +34,7 @@
 #include "channel.h"
 #include "match.h"
 #include "hash.h"
+#include "batch.h"
 #include "class.h"
 #include "msg.h"
 #include "packet.h"
@@ -74,11 +75,13 @@ static void m_tagmsg(struct MsgBuf *, struct Client *, struct Client *, int, con
 static void m_echo(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
 
 static void echo_msg(struct Client *, struct Client *, enum message_type, const char *text, struct MsgBuf *msgbuf_p);
+static void process_echo_batch(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *);
 
 static void expire_tgchange(void *unused);
 static struct ev_entry *expire_tgchange_event;
 
 static uint64_t CAP_ECHO;
+static uint64_t CAP_ECHOB;
 
 struct entity
 {
@@ -92,9 +95,14 @@ struct entity
 	int flags;
 };
 
+struct BatchHandler echo_batch_handler = { process_echo_batch, NULL, BATCH_FLAG_SKIP_CHILDREN | BATCH_FLAG_ALLOW_ALL, NULL };
+
 static int
 modinit(void)
 {
+	if (!register_batch_handler("solanum.chat/echo", &echo_batch_handler))
+		return -1;
+
 	expire_tgchange_event = rb_event_addish("expire_tgchange", expire_tgchange, NULL, 300);
 	expire_tgchange(NULL);
 	return 0;
@@ -103,6 +111,7 @@ modinit(void)
 static void
 moddeinit(void)
 {
+	remove_batch_handler("solanum.chat/echo");
 	rb_event_delete(expire_tgchange_event);
 }
 
@@ -127,6 +136,7 @@ mapi_clist_av1 message_clist[] = { &privmsg_msgtab, &notice_msgtab, &echo_msgtab
 
 mapi_cap_list_av2 message_cap_list[] = {
 	{ MAPI_CAP_SERVER, "ECHO", NULL, &CAP_ECHO },
+	{ MAPI_CAP_SERVER, "ECHOB", NULL, &CAP_ECHOB },
 	{ 0, NULL, NULL, NULL }
 };
 
@@ -959,6 +969,65 @@ echo_msg(struct Client *source_p, struct Client *target_p,
 		shortname[msgtype],
 		use_id(target_p),
 		text);
+}
+
+static void
+process_echo_batch(struct Client *client_p, struct Client *source_p, struct Batch *batch, void *unused)
+{
+	struct MsgBuf *msgbuf = &batch->start->msg;
+	char params[BUFSIZE];
+	char prefix[USERHOST_REPLYLEN];
+	rb_dlink_node *ptr;
+
+	/* only allow this batch over s2s links */
+	if (!IsServer(client_p))
+	{
+		sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+			me.name, batch->tag, batch->type);
+		return;
+	}
+
+	if (msgbuf->n_para < 4)
+		return;
+
+	struct Client *target_p = find_person(msgbuf->para[3]);
+	if (target_p == NULL)
+		return;
+
+	if (!MyClient(target_p))
+	{
+		if (NotServerCapable(target_p->from, CAP_ECHOB))
+			return;
+
+		/* don't give a prefix in the batch contents to save a bit of bandwidth on s2s links */
+		*prefix = '\0';
+		msgbuf_unparse_para(params, sizeof(params), msgbuf);
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, ":%s BATCH %s",
+			use_id(source_p), params);
+	}
+	else
+		snprintf(prefix, sizeof(prefix), ":%s!%s@%s ",
+			target_p->name, target_p->username, target_p->host);
+
+	RB_DLINK_FOREACH(ptr, batch->messages.head)
+	{
+		msgbuf = &((struct BatchMessage *)ptr->data)->msg;
+		msgbuf_unparse_para(params, sizeof(params), msgbuf);
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, "%s%s %s",
+			prefix, msgbuf->cmd, params);
+	}
+
+	RB_DLINK_FOREACH(ptr, batch->children.head)
+	{
+		process_echo_batch(client_p, source_p, ptr->data, unused);
+	}
+
+	if (!MyClient(target_p))
+		sendto_one_tags(target_p, NOCAPS, NOCAPS,
+			msgbuf->n_tags, msgbuf->tags, ":%s BATCH -%s",
+			use_id(source_p), batch->tag);
 }
 
 /*

--- a/modules/m_batch.c
+++ b/modules/m_batch.c
@@ -34,6 +34,8 @@
 #include "batch.h"
 #include "response.h"
 
+#define HasBatchFlag(x, y) (((x)->flags & (y)) == (y))
+
 static const char batch_desc[] =
 	"Provides the BATCH command for client-initiated or propagated batches";
 
@@ -203,7 +205,7 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 	handler->handler(client_p, source_p, batch, handler->userdata);
 
 	/* handle child batches */
-	if (!(handler->flags & BATCH_FLAG_SKIP_CHILDREN))
+	if (!HasBatchFlag(handler, BATCH_FLAG_SKIP_CHILDREN))
 	{
 		RB_DLINK_FOREACH_SAFE(ptr, next_ptr, batch->children.head)
 		{
@@ -319,14 +321,6 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 			return;
 		}
 
-		if (get_batch_handler(parv[2]) == NULL)
-		{
-			if (IsClient(source_p))
-				sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
-					me.name, parv[1], parv[2]);
-			return;
-		}
-
 		if (parent != NULL)
 		{
 			const struct BatchHandler *parent_handler = get_batch_handler(parent->type);
@@ -339,7 +333,15 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 				return;
 			}
 
-			bool allowed = (parent_handler->flags & BATCH_FLAG_ALLOW_ALL) == BATCH_FLAG_ALLOW_ALL;
+			if (!HasBatchFlag(parent_handler, BATCH_FLAG_SKIP_CHILDREN) && get_batch_handler(parv[2]) == NULL)
+			{
+				if (IsClient(source_p))
+					sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+						me.name, parv[1], parv[2]);
+				return;
+			}
+
+			bool allowed = HasBatchFlag(parent_handler, BATCH_FLAG_ALLOW_ALL);
 			const char *error = NULL;
 			if (!allowed && parent_handler->child_allowed != NULL)
 				allowed = parent_handler->child_allowed(client_p, source_p, parent, msgbuf, parent_handler->userdata, &error);
@@ -356,6 +358,13 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 				}
 				return;
 			}
+		}
+		else if (get_batch_handler(parv[2]) == NULL)
+		{
+			if (IsClient(source_p))
+				sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
+					me.name, parv[1], parv[2]);
+			return;
 		}
 
 		batch = batch_init(msgbuf);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,7 @@ check_PROGRAMS = runtests \
 	misc \
 	msgbuf_parse1 \
 	msgbuf_unparse1 \
+	multiline1 \
 	hostmask1 \
 	labeled_response1 \
 	privilege1 \
@@ -15,6 +16,7 @@ check_PROGRAMS = runtests \
 	send_multiline1 \
 	serv_connect1 \
 	substitution1
+test_extensions = multiline
 AM_CFLAGS=$(WARNFLAGS)
 AM_CPPFLAGS = $(DEFAULT_INCLUDES) -I../librb/include -I..
 AM_LDFLAGS = -no-install
@@ -41,11 +43,13 @@ check-local: $(check_PROGRAMS) \
 	../bandb/bandb \
 	../ssld/ssld \
 	$(patsubst ../modules/%.c,../modules/.libs/%.so,$(wildcard ../modules/*.c)) \
-	$(patsubst ../modules/core/%.c,../modules/core/.libs/%.so,$(wildcard ../modules/core/*.c))
+	$(patsubst ../modules/core/%.c,../modules/core/.libs/%.so,$(wildcard ../modules/core/*.c)) \
+	$(patsubst %,../extensions/.libs/%.so,$(test_extensions))
 
-	rm -rf runtime/modules && mkdir -p runtime/modules/autoload
+	rm -rf runtime/modules && mkdir -p runtime/modules/autoload runtime/modules/extensions
 	for f in ../modules/core/.libs/*.so; do ln -s "../../../modules/core/.libs/$${f##*/}" "runtime/modules/$${f##*/}"; done
 	for f in ../modules/.libs/*.so; do ln -s "../../../../modules/.libs/$${f##*/}" "runtime/modules/autoload/$${f##*/}"; done
+	for f in ../extensions/.libs/*.so; do ln -s "../../../../extensions/.libs/$${f##*/}" "runtime/modules/extensions/$${f##*/}"; done
 
 	ASAN_OPTIONS="${ASAN_OPTIONS}:detect_leaks=false" ./runtests -l $(abs_top_srcdir)/tests/TESTS
 

--- a/tests/make_test_runtime.sh
+++ b/tests/make_test_runtime.sh
@@ -10,6 +10,7 @@ OUTPUT=$(realpath -s $3)/runtime
 
 rm -rf $OUTPUT
 mkdir -p $OUTPUT/modules/autoload
+mkdir -p $OUTPUT/modules/extensions
 mkdir $OUTPUT/bin
 mkdir $OUTPUT/help
 
@@ -33,6 +34,13 @@ done
 modules=$(grep -Pazo '(?s)autoload_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')")
 echo $modules | tr ' ' '\n' | while read link; do
   ln -s "$BUILDROOT/modules/$link.so" "$OUTPUT/modules/autoload/$link.so"
+done
+
+extensions=$(grep -Pazo '(?s)extension_modules = \[.*?\]' $SOURCEROOT/extensions/meson.build | grep -Pao "(?<=')[^']+(?=')")
+echo $extensions | tr ' ' '\n' | while read link; do
+  if test -e "$BUILDROOT/extensions/$link.so"; then
+    ln -s "$BUILDROOT/extensions/$link.so" "$OUTPUT/modules/extensions/$link.so"
+  fi
 done
 
 cp $SOURCEROOT/tests/*.conf $3

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,7 @@ test_programs = {
   'misc': 'misc.c',
   'msgbuf_parse1': 'msgbuf_parse1.c',
   'msgbuf_unparse1': 'msgbuf_unparse1.c',
+  'multiline1': 'multiline1.c',
   'hostmask1': 'hostmask1.c',
   'labeled_response1': 'labeled_response1.c',
   'privilege1': 'privilege1.c',

--- a/tests/multiline1.c
+++ b/tests/multiline1.c
@@ -1,0 +1,905 @@
+/*
+ * multiline1.c: Test the draft/multiline batch type
+ *
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA
+ */
+
+#include "stdinc.h"
+#include "tap/basic.h"
+
+#include "batch.h"
+#include "capability.h"
+#include "channel.h"
+#include "client.h"
+#include "hash.h"
+#include "ircd_util.h"
+#include "client_util.h"
+#include "modules.h"
+#include "s_serv.h"
+
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+
+static uint64_t CLICAP_MULTILINE;
+static uint64_t CAP_MULTILINE;
+static uint64_t CAP_ECHOB;
+
+static struct Client *user;
+static struct Client *server;
+static struct Client *remote;
+static struct Client *server2;
+static struct Client *remote2;
+static struct Client *server3;
+static struct Client *remote3;
+static struct Channel *channel;
+static struct Channel *lchannel;
+
+static struct Client *local_chan_o;
+static struct Client *local_chan_ov;
+static struct Client *local_chan_v;
+static struct Client *local_chan_p;
+static struct Client *local_no_chan;
+
+static struct Client *remote_chan_o;
+static struct Client *remote_chan_ov;
+static struct Client *remote_chan_v;
+static struct Client *remote_chan_p;
+
+static struct Client *remote2_chan_p;
+static struct Client *remote2_no_chan;
+
+static char batch1[BATCH_ID_LEN];
+static char batch2[BATCH_ID_LEN];
+static char batch3[BATCH_ID_LEN];
+static char batch4[BATCH_ID_LEN];
+static char batch5[BATCH_ID_LEN];
+
+static void standard_init(void)
+{
+	user = make_local_person_id(TEST_NICK, TEST_ID);
+	server = make_remote_server_full(&me, TEST_SERVER_NAME, TEST_SERVER_ID);
+	remote = make_remote_person_id(server, TEST_REMOTE_NICK, TEST_REMOTE_ID);
+	server2 = make_remote_server_full(&me, TEST_SERVER2_NAME, TEST_SERVER2_ID);
+	remote2 = make_remote_person_id(server2, TEST_REMOTE2_NICK, TEST_REMOTE2_ID);
+	server3 = make_remote_server_full(&me, TEST_SERVER3_NAME, TEST_SERVER3_ID);
+	remote3 = make_remote_person_id(server3, TEST_REMOTE3_NICK, TEST_REMOTE3_ID);
+
+	SetServerCap(server, CAP_STAG | CAP_ENCAP);
+	SetServerCap(server2, CAP_STAG | CAP_ENCAP);
+	SetServerCap(server3, CAP_STAG | CAP_ENCAP);
+
+	local_chan_o = make_local_person_id("LChanOp", TEST_ME_ID "90001");
+	local_chan_ov = make_local_person_id("LChanOpVoice", TEST_ME_ID "90002");
+	local_chan_v = make_local_person_id("LChanVoice", TEST_ME_ID "90003");
+	local_chan_p = make_local_person_id("LChanPeon", TEST_ME_ID "90004");
+	local_no_chan = make_local_person_id("LNoChan", TEST_ME_ID "90005");
+
+	remote_chan_o = make_remote_person_id(server, "RChanOp", TEST_SERVER_ID "90101");
+	remote_chan_ov = make_remote_person_id(server, "RChanOpVoice", TEST_SERVER_ID "90102");
+	remote_chan_v = make_remote_person_id(server, "RChanVoice", TEST_SERVER_ID "90103");
+	remote_chan_p = make_remote_person_id(server, "RChanPeon", TEST_SERVER_ID "90104");
+
+	remote2_chan_p = make_remote_person_id(server2, "R2ChanPeon", TEST_SERVER2_ID "90204");
+	remote2_no_chan = make_remote_person_id(server2, "R2NoChan", TEST_SERVER2_ID "90205");
+
+	channel = make_channel();
+
+	add_user_to_channel(channel, local_chan_o, CHFL_CHANOP);
+	add_user_to_channel(channel, local_chan_ov, CHFL_CHANOP | CHFL_VOICE);
+	add_user_to_channel(channel, local_chan_v, CHFL_VOICE);
+	add_user_to_channel(channel, local_chan_p, CHFL_PEON);
+
+	add_user_to_channel(channel, remote_chan_o, CHFL_CHANOP);
+	add_user_to_channel(channel, remote_chan_ov, CHFL_CHANOP | CHFL_VOICE);
+	add_user_to_channel(channel, remote_chan_v, CHFL_VOICE);
+	add_user_to_channel(channel, remote_chan_p, CHFL_PEON);
+
+	add_user_to_channel(channel, remote2_chan_p, CHFL_PEON);
+
+	lchannel = get_or_create_channel(&me, "&test", NULL);
+
+	add_user_to_channel(lchannel, user, CHFL_PEON);
+	add_user_to_channel(lchannel, remote, CHFL_PEON);
+	add_user_to_channel(lchannel, remote2, CHFL_PEON);
+	add_user_to_channel(lchannel, remote3, CHFL_PEON);
+
+	/* for consistent batch IDs */
+	srand(0);
+}
+
+static void standard_free(void)
+{
+	remove_remote_person(remote2_chan_p);
+	remove_remote_person(remote2_no_chan);
+
+	remove_remote_person(remote_chan_o);
+	remove_remote_person(remote_chan_ov);
+	remove_remote_person(remote_chan_v);
+	remove_remote_person(remote_chan_p);
+
+	remove_local_person(local_chan_o);
+	remove_local_person(local_chan_ov);
+	remove_local_person(local_chan_v);
+	remove_local_person(local_chan_p);
+	remove_local_person(local_no_chan);
+
+	remove_remote_person(remote3);
+	remove_remote_server(server3);
+	remove_remote_person(remote2);
+	remove_remote_server(server2);
+	remove_remote_person(remote);
+	remove_remote_server(server);
+
+	if (user != NULL)
+		remove_local_person(user);
+}
+
+static void
+local_private(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_p, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +private draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :one" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -private" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH +%s draft/multiline %s" CRLF,
+		user->name, user->username, user->host, batch1, local_chan_p->name);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s!%s@%s PRIVMSG %s :one" CRLF,
+		batch1, user->name, user->username, user->host, local_chan_p->name);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s!%s@%s PRIVMSG %s :" CRLF,
+		batch1, user->name, user->username, user->host, local_chan_p->name);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH -%s" CRLF,
+		user->name, user->username, user->host, batch1);
+	is_client_sendq(expected, local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_private__fallback(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +private draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :one" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -private" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :one" CRLF,
+		user->name, user->username, user->host, local_chan_p->name);
+	is_client_sendq(expected, local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_private__fallback__batch_only(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_p, CLICAP_BATCH);
+
+	snprintf(line, sizeof(line), "BATCH +private draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :one" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -private" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :one" CRLF,
+		user->name, user->username, user->host, local_chan_p->name);
+	is_client_sendq(expected, local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_private__fallback__multiline_only(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_p, CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +private draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :one" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=private PRIVMSG %s :" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -private" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :one" CRLF,
+		user->name, user->username, user->host, local_chan_p->name);
+	is_client_sendq(expected, local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_channel(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(local_chan_o, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_p, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(local_chan_o, "BATCH +channel draft/multiline " TEST_CHANNEL CRLF);
+	client_util_parse(local_chan_o, "@batch=channel PRIVMSG " TEST_CHANNEL " :one" CRLF);
+	client_util_parse(local_chan_o, "@batch=channel;draft/multiline-concat PRIVMSG " TEST_CHANNEL " :two" CRLF);
+	client_util_parse(local_chan_o, "BATCH -channel" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH +%s draft/multiline %s" CRLF,
+		local_chan_o->name, local_chan_o->username, local_chan_o->host, batch1, TEST_CHANNEL);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s!%s@%s PRIVMSG %s :one" CRLF,
+		batch1, local_chan_o->name, local_chan_o->username, local_chan_o->host, TEST_CHANNEL);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s;draft/multiline-concat :%s!%s@%s PRIVMSG %s :two" CRLF,
+		batch1, local_chan_o->name, local_chan_o->username, local_chan_o->host, TEST_CHANNEL);
+	is_client_sendq_one(expected, local_chan_p, MSG);
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH -%s" CRLF,
+		local_chan_o->name, local_chan_o->username, local_chan_o->host, batch1);
+	is_client_sendq(expected, local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_channel__denied(void)
+{
+	char line[BUFSIZE];
+
+	standard_init();
+	add_user_to_channel(channel, user, CHFL_PEON);
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_o, CLICAP_BATCH | CLICAP_MULTILINE);
+	channel->mode.mode |= MODE_MODERATED;
+
+	client_util_parse(user, "BATCH +denied draft/multiline " TEST_CHANNEL CRLF);
+	snprintf(line, sizeof(line), "@batch=denied PRIVMSG %s :one" CRLF,
+		channel->chname);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -denied" CRLF);
+
+	is_client_sendq(":" TEST_ME_NAME " 404 " TEST_NICK " " TEST_CHANNEL " :Cannot send to nick/channel" CRLF, user, MSG);
+	is_client_sendq_empty(local_chan_o, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__mixed_commands(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+	SetClientCap(local_chan_p, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +mixed draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=mixed PRIVMSG %s :first" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=mixed NOTICE %s :second" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -mixed" CRLF);
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__mismatched_target(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +target draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=target PRIVMSG other :first" CRLF);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -target" CRLF);
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID_TARGET %s other :mismatched target within multiline batch" CRLF,
+		me.name, local_chan_p->name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__blank_concat(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +blank draft/multiline %s" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=blank PRIVMSG %s :first" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=blank;draft/multiline-concat PRIVMSG %s :" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -blank" CRLF);
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :cannot send blank line with draft/multiline-concat" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__empty_batch(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +empty draft/multiline " TEST_NICK CRLF);
+	client_util_parse(user, "BATCH -empty" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batches cannot be empty" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__blank_lines(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +blanklines draft/multiline %s" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=blanklines PRIVMSG %s :" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, line);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -blanklines" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batch cannot consist solely of blank lines" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__missing_target(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +missing draft/multiline" CRLF);
+	snprintf(line, sizeof(line), "@batch=missing PRIVMSG %s :hi" CRLF,
+		local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -missing" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batch is missing a target" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__max_lines(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +lines draft/multiline %s" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :one" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :two" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :three" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :four" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :five" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=lines PRIVMSG %s :six" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -lines" CRLF);
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_MAX_LINES 5 :multiline batch contains too many lines" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__max_bytes(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), "BATCH +bytes draft/multiline %s" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=bytes PRIVMSG %s :1234567890123456789012345" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=bytes PRIVMSG %s :12345678901234567890123456" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -bytes" CRLF);
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_MAX_BYTES 50 :multiline batch contains too many bytes" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__non_message_command(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +command draft/multiline " TEST_CHANNEL CRLF);
+	client_util_parse(user, "@batch=command JOIN " TEST_CHANNEL CRLF);
+	client_util_parse(user, "BATCH -command" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batch must only have either PRIVMSG or NOTICE commands" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__nested(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +outer draft/multiline " TEST_CHANNEL CRLF);
+	client_util_parse(user, "@batch=outer BATCH +inner draft/multiline " TEST_CHANNEL CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH INVALID_NESTING +inner draft/multiline draft/multiline :The parent batch type does not allow this type to be nested under it" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__timeout(void)
+{
+	struct Batch *batch;
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +timeout draft/multiline " TEST_CHANNEL CRLF);
+	batch = user->localClient->pending_batches.head->data;
+	batch->expires = 1;
+	rb_run_one_event_for_tests("batch-timeout");
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH TIMEOUT timeout :Batch timed out" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+	standard_free();
+}
+
+static void
+local_validation__missing_caps(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+
+	client_util_parse(user, "BATCH +missing draft/multiline " TEST_NICK CRLF);
+	client_util_parse(user, "@batch=missing PRIVMSG " TEST_NICK " :one" CRLF);
+	client_util_parse(user, "BATCH -missing" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH MULTILINE_INVALID :multiline batches require both the batch and draft/multiline capabilities" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__s2s_echo_batch(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+
+	snprintf(line, sizeof(line), "BATCH +echo solanum.chat/echo %s" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	snprintf(line, sizeof(line), "@batch=echo PRIVMSG %s :spoofed" CRLF, local_chan_p->name);
+	client_util_parse(user, line);
+	client_util_parse(user, "BATCH -echo" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH UNKNOWN_TYPE echo solanum.chat/echo :Unrecognized batch type" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+	is_client_sendq_empty(local_chan_p, MSG);
+
+	standard_free();
+}
+
+static void
+local_validation__invalid_reference_tag(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	client_util_parse(user, "BATCH +bad/tag draft/multiline " TEST_NICK CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s FAIL BATCH INVALID_REFTAG +bad/tag :Invalid reference tag" CRLF,
+		me.name);
+	is_client_sendq(expected, user, MSG);
+	is_int(0, rb_dlink_list_length(&user->localClient->pending_batches), MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_local(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), ":%s BATCH +remote draft/multiline %s" CRLF, remote->id, user->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote :%s PRIVMSG %s :first" CRLF, remote->id, user->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote;draft/multiline-concat :%s PRIVMSG %s :second" CRLF, remote->id, user->id);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_REMOTE_ID " BATCH -remote" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH +%s draft/multiline %s" CRLF,
+		remote->name, remote->username, remote->host, batch1, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s!%s@%s PRIVMSG %s :first" CRLF,
+		batch1, remote->name, remote->username, remote->host, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s;draft/multiline-concat :%s!%s@%s PRIVMSG %s :second" CRLF,
+		batch1, remote->name, remote->username, remote->host, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH -%s" CRLF,
+		remote->name, remote->username, remote->host, batch1);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_local__echo_batch(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE | CAP_ECHOB);
+	SetClientCap(user, CLICAP_BATCH | CLICAP_MULTILINE);
+
+	snprintf(line, sizeof(line), ":%s BATCH +remote draft/multiline %s" CRLF, remote->id, user->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote :%s PRIVMSG %s :first" CRLF, remote->id, user->id);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_REMOTE_ID " BATCH -remote" CRLF);
+
+	drain_client_sendq(user);
+	snprintf(expected, sizeof(expected), ":%s BATCH +%s solanum.chat/echo %s" CRLF,
+		user->id, batch2, remote->id);
+	is_client_sendq_one(expected, server, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s BATCH +remote draft/multiline %s" CRLF,
+		batch2, user->id, user->name);
+	is_client_sendq_one(expected, server, MSG);
+	snprintf(expected, sizeof(expected), "@batch=remote :%s PRIVMSG %s :first" CRLF,
+		user->id, user->name);
+	is_client_sendq_one(expected, server, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s BATCH -remote" CRLF,
+		batch2, user->id);
+	is_client_sendq_one(expected, server, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, user->id, batch2);
+	is_client_sendq(expected, server, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_remote(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+	SetServerCap(server2, CAP_MULTILINE);
+
+	snprintf(line, sizeof(line), ":%s BATCH +remote draft/multiline %s" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote :%s PRIVMSG %s :first" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote;draft/multiline-concat :%s PRIVMSG %s :second" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_REMOTE_ID " BATCH -remote" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH +%s draft/multiline %s" CRLF,
+		remote->id, remote->username, remote->host, batch1, remote2->name);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s!%s@%s PRIVMSG %s :first" CRLF,
+		batch1, remote->id, remote->username, remote->host, remote2->id);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s;draft/multiline-concat :%s!%s@%s PRIVMSG %s :second" CRLF,
+		batch1, remote->id, remote->username, remote->host, remote2->id);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), ":%s!%s@%s BATCH -%s" CRLF,
+		remote->id, remote->username, remote->host, batch1);
+	is_client_sendq(expected, server2, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_remote__fallback(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+
+	snprintf(line, sizeof(line), ":%s BATCH +remote draft/multiline %s" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote :%s PRIVMSG %s :first" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=remote;draft/multiline-concat :%s PRIVMSG %s :second" CRLF, remote->id, remote2->id);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_REMOTE_ID " BATCH -remote" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :first" CRLF,
+		remote->id, remote->username, remote->host, remote2->id);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :second" CRLF,
+		remote->id, remote->username, remote->host, remote2->id);
+	is_client_sendq(expected, server2, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_opmod_channel(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+	SetServerCap(server2, CAP_MULTILINE | CAP_CHW | CAP_EOPMOD);
+	channel->mode.mode |= MODE_OPMODERATE;
+
+	snprintf(line, sizeof(line), ":%s BATCH +opmod draft/multiline =%s" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=opmod :%s PRIVMSG =%s :one" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=opmod;draft/multiline-concat :%s PRIVMSG =%s :two" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_SERVER_ID "90104 BATCH -opmod" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s BATCH +%s draft/multiline =%s" CRLF, remote_chan_p->id, batch1, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s PRIVMSG =%s :one" CRLF, batch1, remote_chan_p->id, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s;draft/multiline-concat :%s PRIVMSG =%s :two" CRLF, batch1, remote_chan_p->id, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, remote_chan_p->id, batch1);
+	is_client_sendq(expected, server2, MSG);
+	is_client_sendq_empty(server3, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_opmod_channel__no_eopmod(void)
+{
+	char expected[BUFSIZE];
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+	SetServerCap(server2, CAP_MULTILINE | CAP_CHW);
+	channel->mode.mode |= MODE_OPMODERATE;
+
+	snprintf(line, sizeof(line), ":%s BATCH +opmod draft/multiline =%s" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=opmod :%s PRIVMSG =%s :one" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=opmod;draft/multiline-concat :%s PRIVMSG =%s :two" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_SERVER_ID "90104 BATCH -opmod" CRLF);
+
+	snprintf(expected, sizeof(expected), ":%s BATCH +%s draft/multiline @%s" CRLF, server->id, batch1, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s NOTICE @%s :<%s:%s> one" CRLF,
+		batch1, server->id, TEST_CHANNEL, remote_chan_p->name, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s;draft/multiline-concat :%s NOTICE @%s :<%s:%s> two" CRLF,
+		batch1, server->id, TEST_CHANNEL, remote_chan_p->name, TEST_CHANNEL);
+	is_client_sendq_one(expected, server2, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, remote_chan_p->id, batch1);
+	is_client_sendq(expected, server2, MSG);
+	is_client_sendq_empty(server3, MSG);
+
+	standard_free();
+}
+
+static void
+remote_to_opmod_channel__no_chw(void)
+{
+	char line[BUFSIZE];
+
+	standard_init();
+	SetServerCap(server, CAP_MULTILINE);
+	SetServerCap(server2, CAP_MULTILINE | CAP_EOPMOD);
+	channel->mode.mode |= MODE_OPMODERATE;
+
+	snprintf(line, sizeof(line), ":%s BATCH +opmod draft/multiline =%s" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	snprintf(line, sizeof(line), "@batch=opmod :%s PRIVMSG =%s :one" CRLF, remote_chan_p->id, TEST_CHANNEL);
+	client_util_parse(server, line);
+	client_util_parse(server, ":" TEST_SERVER_ID "90104 BATCH -opmod" CRLF);
+
+	is_client_sendq_empty(server2, MSG);
+	is_client_sendq_empty(server3, MSG);
+
+	standard_free();
+}
+
+int
+main(int argc, char *argv[])
+{
+	plan_lazy();
+
+	ircd_util_init(__FILE__);
+	client_util_init();
+
+	/* so we don't need to check the @time tag on S2S links due to STAG being enabled */
+	ok(unload_one_module("cap_server_time", false), MSG);
+
+	CLICAP_MULTILINE = capability_get(cli_capindex, "draft/multiline", NULL);
+	CAP_MULTILINE = capability_get(serv_capindex, "MULTILN", NULL);
+	CAP_ECHOB = capability_get(serv_capindex, "ECHOB", NULL);
+	ok(CLICAP_MULTILINE != 0, "draft/multiline client capability is loaded");
+	ok(CAP_MULTILINE != 0, "MULTILN server capability is loaded");
+	ok(CAP_ECHOB != 0, "ECHOB server capability is loaded");
+
+	srand(0);
+	generate_batch_id(batch1, sizeof(batch1));
+	generate_batch_id(batch2, sizeof(batch2));
+	generate_batch_id(batch3, sizeof(batch3));
+	generate_batch_id(batch4, sizeof(batch4));
+	generate_batch_id(batch5, sizeof(batch5));
+
+	local_private();
+	local_private__fallback();
+	local_private__fallback__batch_only();
+	local_private__fallback__multiline_only();
+	local_channel();
+	local_channel__denied();
+	local_validation__mixed_commands();
+	local_validation__mismatched_target();
+	local_validation__blank_concat();
+	local_validation__empty_batch();
+	local_validation__blank_lines();
+	local_validation__missing_target();
+	local_validation__max_lines();
+	local_validation__max_bytes();
+	local_validation__non_message_command();
+	local_validation__nested();
+	local_validation__timeout();
+	local_validation__missing_caps();
+	local_validation__s2s_echo_batch();
+	local_validation__invalid_reference_tag();
+	remote_to_local();
+	remote_to_local__echo_batch();
+	remote_to_remote();
+	remote_to_remote__fallback();
+	remote_to_opmod_channel();
+	remote_to_opmod_channel__no_eopmod();
+	remote_to_opmod_channel__no_chw();
+
+	client_util_free();
+	ircd_util_free();
+	return 0;
+}

--- a/tests/multiline1.conf
+++ b/tests/multiline1.conf
@@ -1,0 +1,50 @@
+loadmodule "extensions/multiline";
+
+serverinfo {
+	sid = "0AA";
+	name = "me.test";
+	description = "Test server";
+	network_name = "Test network";
+};
+
+class "default" {
+	ping_time = 1000 minutes;
+	connectfreq = 1000 minutes;
+	number_per_ident = 1000;
+	number_per_ip = 1000;
+	number_per_ip_global = 1000;
+	cidr_ipv4_bitlen = 24;
+	cidr_ipv6_bitlen = 64;
+	number_per_cidr = 1000;
+	max_number = 1000;
+	sendq = 4 megabytes;
+};
+
+connect "remote.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote2.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote3.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+auth {
+	user = "*@*";
+	class = "default";
+};
+
+general {
+	ping_cookie = no;
+	multiline_max_lines = 5;
+	multiline_max_bytes = 50;
+};


### PR DESCRIPTION
This includes two components:

- A new core s2s batch type solanum.chat/echo controlled by the `ECHOB` server capability. Used for echo-message support for batched messages. Note that unlike normal commands, the contents of an echo batch are sent to the client as-is (e.g. no parsing/substitution of UIDs/SIDs). Limited validation is still performed to ensure the prefix/origin is not coming from a fake direction. The echo batch parameters contain the origin instead which will be sent to the target client rather than any origin inside of the batch messages.
- The draft/multiline extension. This is currently explicitly unstable due to the s2s batch changing from draft/multiline to unprefixed multiline once the spec is ratified. The `MULTILN` server capability will switch meaning as well come ratification time. This is an implementation detail and could be adjusted if desired (to e.g. just use unprefixed multiline for s2s batches even right now which would allow better mixed-version support in the future).