### PR TITLE
Fix timing of free_response_batch on cliexit

### DIFF
--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1739,6 +1739,11 @@ exit_client(struct Client *client_p,	/* The local client originating the
 
 	if(MyConnect(source_p))
 	{
+		RB_DLINK_FOREACH_SAFE(ptr, nptr, source_p->localClient->pending_remote_responses.head)
+		{
+			free_response_batch(ptr->data);
+		}
+
 		/* Local clients of various types */
 		if(IsPerson(source_p))
 			ret = exit_local_client(client_p, source_p, from, comment, NULL);
@@ -1747,11 +1752,6 @@ exit_client(struct Client *client_p,	/* The local client originating the
 		/* IsUnknown || IsConnecting || IsHandShake */
 		else if(!IsReject(source_p))
 			ret = exit_unknown_client(client_p, source_p, from, comment);
-
-		RB_DLINK_FOREACH_SAFE(ptr, nptr, source_p->localClient->pending_remote_responses.head)
-		{
-			free_response_batch(ptr->data);
-		}
 	}
 	else
 	{

--- a/modules/cap_labeled_response.c
+++ b/modules/cap_labeled_response.c
@@ -196,7 +196,7 @@ cap_labeled_response_cleanup(void *unused)
 	if (outgoing_response_info != NULL)
 	{
 		/* don't try to send anything if they disconnected */
-		if (!IsIOError(outgoing_response_info->source_p))
+		if (!IsAnyDead(outgoing_response_info->source_p))
 		{
 			if (MyConnect(outgoing_response_info->source_p))
 			{


### PR DESCRIPTION
free_response_batch will no-op if MyConnect(client_p) is false. This would always be the case with the former timing, as it was called after exit_local_client which clears the MyConnect flag. Do it before instead so we can properly clean up the tracking vars (namely, the pending_responses dict, which otherwise had a use after free when firing the event to clean up a response for an exited client).

While we're at it, change the previous fix in cap_labeled_response from IsIOError to IsAnyDead to catch more cases where a client cannot receive data. This has not caused any crashes, but the expanded check includes IOError so is safe to use, and all of the statuses checked by IsAnyDead preclude the ability to send data to the client.