### PR TITLE
Don't auto-expire SAFELIST batches

### DIFF
--- a/ircd/response.c
+++ b/ircd/response.c
@@ -54,7 +54,7 @@ cleanup_pending_responses(void *unused)
 	/* RB_DICTIONARY_FOREACH is not safe for deletion, so need to do this in two passes */
 	RB_DICTIONARY_FOREACH(response, &iter, pending_responses)
 	{
-		if (response->expires < now)
+		if (response->expires != 0 && response->expires < now)
 		{
 			rb_dlinkAddAlloc(response, &freelist);
 		}

--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -345,8 +345,9 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		}
 	}
 
-	/* mark it as a "remote" response so we don't terminate the batch at the end of the command handler */
+	/* mark it as a "remote" response that cannot expire so we don't terminate the batch at the end of the command handler */
 	begin_remote_response_batch(1, "");
+	outgoing_response_info->expires = 0;
 	params->response_info = outgoing_response_info;
 
 	safelist_client_instantiate(source_p, params);


### PR DESCRIPTION
Avoids use-after-free if the client takes more than 10 seconds to fully receive the LIST output.