### PR TITLE
Fix missing send_multiline_reset in clicap_generate

### DIFF
--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -167,7 +167,10 @@ clicap_generate(struct Client *source_p, const char *subcmd, int flags)
 			(source_p->flags & FLAGS_CLICAP_DATA) ? str_cont : str_final);
 
 	/* shortcut, nothing to do */
-	if (flags == -1 || !multiline_ret) {
+	if (flags == -1 || !multiline_ret)
+	{
+		/* Currently safe to call if send_multiline_init failed. */
+		send_multiline_reset();
 		sendto_one(source_p, ":%s CAP %s %s %s",
 				me.name,
 				EmptyString(source_p->name) ? "*" : source_p->name,


### PR DESCRIPTION
The portion of clicap_generate outside the loop should probably be reworked to avoid needlessly calling `send_multiline_init`, but this is the minimum change necessary to fix the bug (control flow escaping a function without clearing the cached target).