### PR TITLE
Update labeled-response code

### DIFF
--- a/include/batch.h
+++ b/include/batch.h
@@ -98,6 +98,6 @@ void remove_batch_handler(const char *type);
 void generate_batch_id(char *buf, size_t size);
 struct Batch *batch_init(struct MsgBuf *start);
 struct BatchMessage *allocate_batch_message(struct MsgBuf *msg);
-void batch_free(struct Batch *batch);
+void batch_free(struct Batch *batch, struct ResponseInfo *resume);
 
 #endif /* INCLUDED_batch_h */

--- a/include/response.h
+++ b/include/response.h
@@ -22,6 +22,13 @@
 #ifndef INCLUDED_response_h
 #define INCLUDED_response_h
 
+/* indicates the ResponseInfo is statically allocated and free_response_batch should no-op on it */
+#define RESPONSE_FLAG_STATIC    0x01
+/* indicates that the label tag has already been sent for this ResponseInfo */
+#define RESPONSE_FLAG_SENT      0x02
+/* indicates that the ResponseInfo should not automatically expire */
+#define RESPONSE_FLAG_NO_EXPIRE 0x04
+
 struct Client;
 
 struct ResponseInfo
@@ -30,20 +37,20 @@ struct ResponseInfo
 	struct Client *client_p;
 	/* client to send the labeled-response to */
 	struct Client *source_p;
-	/* client-specified label; empty string if none specified or source_p is remote */
-	char label[65];
-	/* the batch id of the response batch; empty string if not batched */
-	char batch[20];
+	/* client-specified label; NULL if none specified or source_p is remote */
+	char *label;
+	/* the batch id of the response batch; NULL if not batched */
+	char *batch;
 	/* number of remote servers we are expecting to receive responses from */
 	int remote_response;
-	/* if remote_response is nonzero, time that we stop waiting for a remote response and close the batch */
+	/* time that we stop waiting for a remote response and close the batch */
 	time_t expires;
-	/* whether a response has already been sent to the local client */
-	bool sent;
-	/* while this is >0, outgoing messages will not be tagged with label/batch even if they otherwise would */
-	int skip_tags;
+	/* the node in source_p->localClient->pending_remote_responses (may be NULL) */
+	rb_dlink_node *remote_node;
 	/* for remote batches, the server mask dictating which servers we are expecting responses from */
-	char mask[HOSTLEN + 1];
+	char *mask;
+	/* miscellaneous flags for this ResponseInfo */
+	uint32_t flags;
 };
 
 /* state of an outgoing labeled-response */
@@ -65,11 +72,28 @@ void begin_local_response_batch(void);
  */
 void begin_remote_response_batch(int server_count, const char *mask);
 
+/* Resume an already-began response batch (generally saved away somewhere else).
+ * The previously active response is returned (NULL if no previously active response).
+ * Any caller making use of this function *MUST* call resume_response_batch or free_response_batch,
+ * passing the returned pointer, to restore global state after processing for this response is completed.
+ */
+struct ResponseInfo *resume_response_batch(struct ResponseInfo *response);
+
+/* Suspend any currently active response, returning it for later resumption */
+static inline struct ResponseInfo *
+suspend_response_batch(void)
+{
+	return resume_response_batch(NULL);
+}
+
 /* Get details for a labeled-response batch with the specified batch ID */
 struct ResponseInfo *get_remote_response_batch(const char *batch);
 
-/* Free memory and clean up references to a pending labeled-response batch */
-void free_response_batch(struct ResponseInfo *response);
+/* Free memory and clean up references to a pending labeled-response batch.
+ * The second parameter is used to update global state to point away from the freed response;
+ * pass the return value of resume_response_batch() if that was called previously, or NULL otherwise.
+ */
+void free_response_batch(struct ResponseInfo *response, struct ResponseInfo *resume);
 
 /* Count the number of servers matching a given glob mask and capabilities, except for servers in the direction of one
  * This helps provide an accurate count for begin_remote_response_batch() when broadcasting to multiple servers

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -54,6 +54,7 @@ extern uint64_t serv_clicapmask;
 #define CLICAP_FLAGS_STICKY    0x001
 #define CLICAP_FLAGS_PRIORITY  0x002
 #define CLICAP_FLAGS_NOPROP    0x004
+#define CLICAP_FLAGS_INVISIBLE 0x008
 
 struct ClientCapability {
 	bool (*visible)(struct Client *);		/* whether or not to display the capability.  set to NULL or true return value = displayed */
@@ -63,6 +64,7 @@ struct ClientCapability {
 
 /* builtin client capabilities */
 extern uint64_t CLICAP_SERVONLY;           /* for s2s-only message tag propagation; no client ever has this cap */
+extern uint64_t CLICAP_RECEIVE_LABEL;
 extern uint64_t CLICAP_MULTI_PREFIX;
 extern uint64_t CLICAP_ACCOUNT_NOTIFY;
 extern uint64_t CLICAP_EXTENDED_JOIN;
@@ -74,6 +76,7 @@ extern uint64_t CLICAP_ECHO_MESSAGE;
 extern uint64_t CLICAP_MESSAGE_TAGS;
 extern uint64_t CLICAP_BATCH;
 extern uint64_t CLICAP_NO_IMPLICIT_NAMES;
+extern uint64_t CLICAP_LABELED_RESPONSE;
 
 /*
  * XXX: this is kind of ugly, but this allows us to have backwards

--- a/ircd/batch.c
+++ b/ircd/batch.c
@@ -88,7 +88,7 @@ batch_init(struct MsgBuf *start)
 }
 
 void
-batch_free(struct Batch *batch)
+batch_free(struct Batch *batch, struct ResponseInfo *resume)
 {
 	rb_dlink_node *ptr, *next_ptr;
 
@@ -104,10 +104,10 @@ batch_free(struct Batch *batch)
 	{
 		struct Batch *child = ptr->data;
 		rb_dlinkDestroy(ptr, &batch->children);
-		batch_free(child);
+		batch_free(child, resume);
 	}
 
-	free_response_batch(batch->response_info);
+	free_response_batch(batch->response_info, resume);
 	rb_free(batch->start->data);
 	rb_free(batch->start);
 	rb_free(batch);

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1741,7 +1741,7 @@ exit_client(struct Client *client_p,	/* The local client originating the
 	{
 		RB_DLINK_FOREACH_SAFE(ptr, nptr, source_p->localClient->pending_remote_responses.head)
 		{
-			free_response_batch(ptr->data);
+			free_response_batch(ptr->data, outgoing_response_info);
 		}
 
 		/* Local clients of various types */

--- a/ircd/response.c
+++ b/ircd/response.c
@@ -54,7 +54,7 @@ cleanup_pending_responses(void *unused)
 	/* RB_DICTIONARY_FOREACH is not safe for deletion, so need to do this in two passes */
 	RB_DICTIONARY_FOREACH(response, &iter, pending_responses)
 	{
-		if (response->expires != 0 && response->expires < now)
+		if (!(response->flags & RESPONSE_FLAG_NO_EXPIRE) && response->expires < now)
 		{
 			rb_dlinkAddAlloc(response, &freelist);
 		}
@@ -67,14 +67,14 @@ cleanup_pending_responses(void *unused)
 			sendto_one(response->source_p, ":%s BATCH -%s", me.name, response->batch);
 		rb_dlinkDestroy(ptr, &freelist);
 		rb_dictionary_delete(pending_responses, response->batch);
-		free_response_batch(response);
+		free_response_batch(response, outgoing_response_info);
 	}
 }
 
 void
 init_response(void)
 {
-	pending_responses = rb_dictionary_create("pending remote labeled responses", response_cmp);
+	pending_responses = rb_dictionary_create("remote labeled responses", response_cmp);
 
 	rb_event_addish("cleanup_pending_responses", &cleanup_pending_responses, NULL, 10);
 }
@@ -88,7 +88,9 @@ begin_local_response_batch(void)
 	if (!EmptyString(outgoing_response_info->batch))
 		return;
 
-	generate_batch_id(outgoing_response_info->batch, sizeof(outgoing_response_info->batch));
+	char *batch_id = rb_malloc(BATCH_ID_LEN);
+	generate_batch_id(batch_id, BATCH_ID_LEN);
+	outgoing_response_info->batch = batch_id;
 	sendto_one(outgoing_response_info->source_p, ":%s BATCH +%s labeled-response",
 		me.name, outgoing_response_info->batch);
 }
@@ -99,14 +101,19 @@ begin_remote_response_batch(int server_count, const char *mask)
 	if (outgoing_response_info == NULL || !MyConnect(outgoing_response_info->source_p))
 		return;
 
+	rb_dlink_node *node = rb_make_rb_dlink_node();
+	outgoing_response_info->remote_node = node;
+
 	if (EmptyString(outgoing_response_info->batch))
 	{
 		/* creating a new response batch */
-		generate_batch_id(outgoing_response_info->batch, sizeof(outgoing_response_info->batch));
+		char *batch_id = rb_malloc(BATCH_ID_LEN);
+		generate_batch_id(batch_id, BATCH_ID_LEN);
+		outgoing_response_info->batch = batch_id;
 		outgoing_response_info->remote_response = server_count;
-		rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
+		outgoing_response_info->mask = rb_strdup(mask);
 		outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
-		rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
+		rb_dlinkAdd(outgoing_response_info, node, &outgoing_response_info->source_p->localClient->pending_remote_responses);
 		rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
 		sendto_one(outgoing_response_info->source_p, ":%s BATCH +%s labeled-response",
 			me.name, outgoing_response_info->batch);
@@ -117,9 +124,9 @@ begin_remote_response_batch(int server_count, const char *mask)
 		s_assert(outgoing_response_info->remote_response == 0);
 
 		outgoing_response_info->remote_response += server_count;
-		rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
+		outgoing_response_info->mask = rb_strdup(mask);
 		outgoing_response_info->expires = rb_current_time() + RESPONSE_EXPIRY;
-		rb_dlinkAddAlloc(outgoing_response_info, &outgoing_response_info->source_p->localClient->pending_remote_responses);
+		rb_dlinkAdd(outgoing_response_info, node, &outgoing_response_info->source_p->localClient->pending_remote_responses);
 		rb_dictionary_add(pending_responses, outgoing_response_info->batch, outgoing_response_info);
 	}
 }
@@ -130,29 +137,58 @@ get_remote_response_batch(const char *batch)
 	return rb_dictionary_retrieve(pending_responses, batch);
 }
 
-void
-free_response_batch(struct ResponseInfo *response)
+struct ResponseInfo *
+resume_response_batch(struct ResponseInfo *response)
 {
-	rb_dlink_node *ptr, *nptr;
+	struct ResponseInfo *saved = outgoing_response_info;
+	/* already set? no need to mess with clicaps if so */
+	if (outgoing_response_info == response)
+		return saved;
 
+	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p))
+		ClearClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
+
+	outgoing_response_info = response;
+	if (response != NULL && MyClient(response->source_p) && IsClientCapable(response->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH))
+		SetClientCap(response->source_p, CLICAP_RECEIVE_LABEL);
+
+	return saved;
+}
+
+void
+free_response_batch(struct ResponseInfo *response, struct ResponseInfo *resume)
+{
+	bool do_resume = response == outgoing_response_info;
 	if (response == NULL)
 		return;
 
+	if (response == resume)
+		resume = NULL;
+
 	if (MyConnect(response->source_p))
 	{
-		RB_DLINK_FOREACH_SAFE(ptr, nptr, response->source_p->localClient->pending_remote_responses.head)
-		{
-			if (ptr->data == response)
-			{
-				rb_dlinkDestroy(ptr, &response->source_p->localClient->pending_remote_responses);
-				break;
-			}
-		}
+		ClearClientCap(response->source_p, CLICAP_RECEIVE_LABEL);
 
-		rb_dictionary_delete(pending_responses, response->batch);
+		if (response->remote_node != NULL)
+			rb_dlinkDestroy(response->remote_node, &response->source_p->localClient->pending_remote_responses);
 	}
 
-	rb_free(response);
+	rb_dictionary_delete(pending_responses, response->batch);
+
+	if (!(response->flags & RESPONSE_FLAG_STATIC))
+	{
+		rb_free(response->batch);
+		rb_free(response->label);
+		rb_free(response->mask);
+		rb_free(response);
+	}
+
+	if (do_resume)
+	{
+		outgoing_response_info = resume;
+		if (resume != NULL && MyClient(resume->source_p) && IsClientCapable(resume->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH))
+			SetClientCap(resume->source_p, CLICAP_RECEIVE_LABEL);
+	}
 }
 
 int

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -93,6 +93,7 @@ uint64_t CAP_EBMASK;
 uint64_t CAP_STAG;
 
 uint64_t CLICAP_SERVONLY;
+uint64_t CLICAP_RECEIVE_LABEL;
 uint64_t CLICAP_MULTI_PREFIX;
 uint64_t CLICAP_ACCOUNT_NOTIFY;
 uint64_t CLICAP_EXTENDED_JOIN;
@@ -104,6 +105,7 @@ uint64_t CLICAP_ECHO_MESSAGE;
 uint64_t CLICAP_MESSAGE_TAGS;
 uint64_t CLICAP_BATCH;
 uint64_t CLICAP_NO_IMPLICIT_NAMES;
+uint64_t CLICAP_LABELED_RESPONSE;
 
 /*
  * initialize our builtin capability table. --nenolod
@@ -112,6 +114,8 @@ void
 init_builtin_capabs(void)
 {
 	static struct ClientCapability high_priority = {.flags = CLICAP_FLAGS_PRIORITY};
+	static struct ClientCapability invisible_noprop = {.flags = CLICAP_FLAGS_NOPROP | CLICAP_FLAGS_INVISIBLE};
+
 	serv_capindex = capability_index_create("server capabilities");
 
 	/* These two are not set via CAPAB/GCAP keywords. */
@@ -147,6 +151,7 @@ init_builtin_capabs(void)
 	cli_capindex = capability_index_create("client capabilities");
 
 	CLICAP_SERVONLY = capability_put_anonymous(cli_capindex);
+	CLICAP_RECEIVE_LABEL = capability_put(cli_capindex, "?receive_label", &invisible_noprop);
 	CLICAP_MULTI_PREFIX = capability_put(cli_capindex, "multi-prefix", &high_priority);
 	CLICAP_ACCOUNT_NOTIFY = capability_put(cli_capindex, "account-notify", &high_priority);
 	CLICAP_EXTENDED_JOIN = capability_put(cli_capindex, "extended-join", &high_priority);
@@ -158,6 +163,7 @@ init_builtin_capabs(void)
 	CLICAP_MESSAGE_TAGS = capability_put(cli_capindex, "message-tags", NULL);
 	CLICAP_BATCH = capability_put(cli_capindex, "batch", &high_priority);
 	CLICAP_NO_IMPLICIT_NAMES = capability_put(cli_capindex, "no-implicit-names", NULL);
+	CLICAP_LABELED_RESPONSE = capability_put(cli_capindex, "labeled-response", NULL);
 }
 
 static CNCB serv_connect_callback;

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -8,7 +8,6 @@ auto_load_moddir=@moduledir@/autoload
 
 auto_load_mod_LTLIBRARIES = \
   cap_account_tag.la \
-  cap_labeled_response.la \
   cap_server_time.la \
   chm_nocolour.la \
   chm_noctcp.la \
@@ -18,7 +17,6 @@ auto_load_mod_LTLIBRARIES = \
   m_admin.la \
   m_alias.la \
   m_away.la \
-  m_batch.la \
   m_cap.la \
   m_capab.la \
   m_certfp.la \
@@ -82,7 +80,9 @@ auto_load_mod_LTLIBRARIES = \
   sno_routing.la
 
 module_LTLIBRARIES = \
+  core/cap_labeled_response.la \
   core/m_ban.la \
+  core/m_batch.la \
   core/m_die.la \
   core/m_error.la \
   core/m_join.la \

--- a/modules/core/cap_labeled_response.c
+++ b/modules/core/cap_labeled_response.c
@@ -27,11 +27,11 @@
 #include "s_serv.h"
 
 #define IsMeOrServer(x) (IsMe(x) || IsServer(x))
+#define ResponseSent(x) ((x)->flags & RESPONSE_FLAG_SENT)
 
 static const char cap_labeled_response_desc[] =
 	"Provides the labeled-response client capability";
 
-static bool cap_receive_label_visible(struct Client *);
 static void cap_labeled_response_incoming(void *);
 static void cap_labeled_response_process(void *);
 static void cap_labeled_response_cleanup(void *);
@@ -39,16 +39,6 @@ static void me_ack(struct MsgBuf *, struct Client *, struct Client *, int, const
 
 static const char *serv_response_tag = "solanum.chat/response";
 static char response_tag_buf[BUFSIZE];
-/* other modules may modify outgoing_response_info, so keep track of who we add CLICAP_RECEIVE_LABEL to here */
-static struct Client *label_eligible = NULL;
-
-static uint64_t CLICAP_LABELED_RESPONSE;
-static uint64_t CLICAP_RECEIVE_LABEL;
-
-static struct ClientCapability capdata_receive_label = {
-	.visible = cap_receive_label_visible,
-	.flags = CLICAP_FLAGS_NOPROP,
-};
 
 struct Message ack_msgtab = {
 	"ACK", 0, 0, 0, 0,
@@ -57,12 +47,6 @@ struct Message ack_msgtab = {
 
 mapi_clist_av1 cap_labeled_response_clist[] = { &ack_msgtab, NULL };
 
-mapi_cap_list_av2 cap_labeled_response_cap_list[] = {
-	{ MAPI_CAP_CLIENT, "?receive_label", &capdata_receive_label, &CLICAP_RECEIVE_LABEL },
-	{ MAPI_CAP_CLIENT, "labeled-response", NULL, &CLICAP_LABELED_RESPONSE },
-	{ 0, NULL, NULL, NULL },
-};
-
 mapi_hfn_list_av1 cap_labeled_response_hfnlist[] = {
 	{ "message_tag", cap_labeled_response_incoming },
 	{ "outbound_msgbuf", cap_labeled_response_process },
@@ -70,15 +54,11 @@ mapi_hfn_list_av1 cap_labeled_response_hfnlist[] = {
 	{ NULL, NULL }
 };
 
-static bool
-cap_receive_label_visible(struct Client *client)
-{
-	return false;
-}
-
 static void
 cap_labeled_response_incoming(void *data_)
 {
+	static struct ResponseInfo remote_response_info;
+	static char buf[BUFSIZE];
 	hook_data_message_tag *data = data_;
 
 	if (MyConnect(data->source)
@@ -87,12 +67,11 @@ cap_labeled_response_incoming(void *data_)
 		&& !EmptyString(data->value)
 		&& strlen(data->value) <= 64)
 	{
-		label_eligible = data->source;
 		SetClientCap(data->source, CLICAP_RECEIVE_LABEL);
 		outgoing_response_info = rb_malloc(sizeof(struct ResponseInfo));
 		outgoing_response_info->source_p = data->source;
 		outgoing_response_info->client_p = data->client;
-		rb_strlcpy(outgoing_response_info->label, data->value, sizeof(outgoing_response_info->label));
+		outgoing_response_info->label = rb_strdup(data->value);
 		/* don't propagate label further, but approve the tag so modules like m_batch can make use of it */
 		data->approved = MESSAGE_TAG_ALLOW;
 		data->capmask = NOCAPS;
@@ -100,45 +79,38 @@ cap_labeled_response_incoming(void *data_)
 	else if (IsServer(data->client) && !strcmp(serv_response_tag, data->key) && !EmptyString(data->value))
 	{
 		/* tag value should be UID,batch_id,mask */
-		char *buf = rb_strdup(data->value);
+		rb_strlcpy(buf, data->value, sizeof(buf));
 		char *p;
 		const char *uid = rb_strtok_r(buf, ",", &p);
-		const char *batch_id = rb_strtok_r(NULL, ",", &p);
-		const char *mask = rb_strtok_r(NULL, ",", &p);
+		char *batch_id = rb_strtok_r(NULL, ",", &p);
+		char *mask = rb_strtok_r(NULL, ",", &p);
 
 		if (uid == NULL || batch_id == NULL || mask == NULL)
-		{
-			rb_free(buf);
 			return;
-		}
 
 		struct Client *client = find_id(uid);
 		if (client == NULL)
-		{
-			rb_free(buf);
 			return;
-		}
 
 		if (MyConnect(client))
 		{
 			outgoing_response_info = get_remote_response_batch(batch_id);
 			if (outgoing_response_info != NULL && IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH))
 			{
-				label_eligible = outgoing_response_info->source_p;
 				SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
 			}
 		}
 		else if (data->client == client->from && match(mask, me.name))
 		{
-			outgoing_response_info = rb_malloc(sizeof(struct ResponseInfo));
-			outgoing_response_info->source_p = client;
-			outgoing_response_info->client_p = client->from;
-			rb_strlcpy(outgoing_response_info->batch, batch_id, sizeof(outgoing_response_info->batch));
-			rb_strlcpy(outgoing_response_info->mask, mask, sizeof(outgoing_response_info->mask));
-			outgoing_response_info->sent = true;
+			memset(&remote_response_info, 0, sizeof(remote_response_info));
+			remote_response_info.source_p = client;
+			remote_response_info.client_p = client->from;
+			remote_response_info.batch = batch_id;
+			remote_response_info.mask = mask;
+			remote_response_info.flags = RESPONSE_FLAG_STATIC | RESPONSE_FLAG_SENT;
+			outgoing_response_info = &remote_response_info;
 		}
 
-		rb_free(buf);
 		data->approved = MESSAGE_TAG_ALLOW;
 		data->capmask = CLICAP_SERVONLY;
 	}
@@ -161,14 +133,13 @@ cap_labeled_response_process(void *data_)
 			|| outgoing_response_info->source_p == data->target
 			|| (data->chptr != NULL && IsMeOrServer(data->source) && find_channel_membership(data->chptr, outgoing_response_info->source_p) != NULL);
 
-		if (!outgoing_response_info->sent && attach_tags && !outgoing_response_info->skip_tags)
+		if (!ResponseSent(outgoing_response_info) && attach_tags)
 		{
-			outgoing_response_info->sent = true;
+			outgoing_response_info->flags |= RESPONSE_FLAG_SENT;
 			msgbuf_append_tag(msgbuf, "label", outgoing_response_info->label, CLICAP_RECEIVE_LABEL);
 		}
 
 		if (attach_tags
-			&& !outgoing_response_info->skip_tags
 			&& !EmptyString(outgoing_response_info->batch)
 			&& msgbuf_get_tag(msgbuf, "batch") == NULL
 			&& strcmp(msgbuf->cmd, "BATCH") != 0)
@@ -201,7 +172,7 @@ cap_labeled_response_cleanup(void *unused)
 			if (MyConnect(outgoing_response_info->source_p))
 			{
 				/* send an ACK if the handlers didn't send anything */
-				if (!outgoing_response_info->sent)
+				if (!ResponseSent(outgoing_response_info))
 					sendto_one(outgoing_response_info->source_p, ":%s ACK", me.name);
 
 				if (!EmptyString(outgoing_response_info->batch) && outgoing_response_info->remote_response == 0)
@@ -219,15 +190,7 @@ cap_labeled_response_cleanup(void *unused)
 		}
 
 		if (outgoing_response_info->remote_response == 0)
-			free_response_batch(outgoing_response_info);
-
-		outgoing_response_info = NULL;
-	}
-
-	if (label_eligible != NULL)
-	{
-		ClearClientCap(label_eligible, CLICAP_RECEIVE_LABEL);
-		label_eligible = NULL;
+			free_response_batch(outgoing_response_info, NULL);
 	}
 }
 
@@ -241,4 +204,4 @@ me_ack(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	outgoing_response_info->remote_response--;
 }
 
-DECLARE_MODULE_AV2(cap_labeled_response, NULL, NULL, cap_labeled_response_clist, NULL, cap_labeled_response_hfnlist, cap_labeled_response_cap_list, NULL, cap_labeled_response_desc);
+DECLARE_MODULE_AV2(cap_labeled_response, NULL, NULL, cap_labeled_response_clist, NULL, cap_labeled_response_hfnlist, NULL, NULL, cap_labeled_response_desc);

--- a/modules/core/m_batch.c
+++ b/modules/core/m_batch.c
@@ -63,45 +63,35 @@ mapi_hfn_list_av1 batch_hfnlist[] = {
 
 DECLARE_MODULE_AV2(batch, batch_modinit, batch_moddeinit, batch_clist, NULL, batch_hfnlist, NULL, NULL, batch_desc);
 
+static struct
+{
+	const struct Client *incoming_client;
+	const struct MsgBuf *incoming_message;
+} saved_global_context;
+
 /* Restore global contextual pointers with the opening BATCH message */
 static void
 restore_global_context(struct Client *client_p, struct Batch *batch)
 {
-	uint64_t CLICAP_LABELED_RESPONSE = capability_get(cli_capindex, "labeled-response", NULL);
-	uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
-	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p) && CLICAP_RECEIVE_LABEL)
-		ClearClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
-
-	outgoing_response_info = batch->response_info;
+	saved_global_context.incoming_client = incoming_client;
+	saved_global_context.incoming_message = incoming_message;
 	incoming_client = client_p;
 	incoming_message = &batch->start->msg;
-
-	if (outgoing_response_info != NULL
-		&& MyConnect(outgoing_response_info->source_p)
-		&& IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH)
-		&& CLICAP_RECEIVE_LABEL)
-	{
-		SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
-	}
 }
 
 static void
-reset_global_context(const struct Client *orig_ic, const struct MsgBuf *orig_im, struct ResponseInfo *orig_ori, uint64_t set_cap)
+reset_global_context(void)
 {
-	outgoing_response_info = orig_ori;
-	incoming_client = orig_ic;
-	incoming_message = orig_im;
-	if (orig_ori != NULL && set_cap)
-		SetClientCap(orig_ori->source_p, set_cap);
+	incoming_client = saved_global_context.incoming_client;
+	incoming_message = saved_global_context.incoming_message;
 }
 
 static void
 batch_timeout(void *arg)
 {
-	/* non-NULL arg indicates this is being called during module unload so we need to "time out" all batches */
+	/* non-NULL arg indicates this is being called during module reload so we need to "time out" all batches */
 	rb_dlink_node *cptr, *ptr, *next_ptr;
 	struct Client *client;
-	struct Batch *batch;
 	time_t now = rb_current_time();
 
 	RB_DLINK_FOREACH(cptr, lclient_list.head)
@@ -109,14 +99,16 @@ batch_timeout(void *arg)
 		client = cptr->data;
 		RB_DLINK_FOREACH_SAFE(ptr, next_ptr, client->localClient->pending_batches.head)
 		{
-			batch = ptr->data;
+			struct Batch* batch = ptr->data;
 			if (arg != NULL || batch->expires <= now)
 			{
 				restore_global_context(client, batch);
+				struct ResponseInfo *info = resume_response_batch(batch->response_info);
 				sendto_one(client, ":%s FAIL BATCH TIMEOUT %s :Batch timed out",
 					me.name, batch->tag);
 				client->localClient->pending_batch_lines -= batch->len + 1;
-				batch_free(batch);
+				batch_free(batch, info);
+				reset_global_context();
 				rb_dlinkDestroy(ptr, &client->localClient->pending_batches);
 			}
 		}
@@ -124,22 +116,19 @@ batch_timeout(void *arg)
 
 	if (arg != NULL)
 	{
-		/* get rid of server batches only on module unload */
+		/* get rid of server batches only on module reload */
 		RB_DLINK_FOREACH(cptr, serv_list.head)
 		{
 			client = cptr->data;
 			RB_DLINK_FOREACH_SAFE(ptr, next_ptr, client->localClient->pending_batches.head)
 			{
-				batch_free(ptr->data);
+				batch_free(ptr->data, outgoing_response_info);
 				rb_dlinkDestroy(ptr, &client->localClient->pending_batches);
 			}
 
 			client->localClient->pending_batch_lines = 0;
 		}
 	}
-
-	/* reset context back to NULL since we're in an event handler */
-	reset_global_context(NULL, NULL, NULL, NOCAPS);
 }
 
 static void
@@ -153,7 +142,7 @@ handle_client_exit(void *data_)
 
 	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, data->target->localClient->pending_batches.head)
 	{
-		batch_free(ptr->data);
+		batch_free(ptr->data, outgoing_response_info);
 		rb_dlinkDestroy(ptr, &data->target->localClient->pending_batches);
 	}
 
@@ -166,6 +155,7 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 {
 	const struct BatchHandler *handler = get_batch_handler(batch->type);
 	rb_dlink_node *ptr, *next_ptr;
+	struct ResponseInfo *info;
 
 	/* abort unfinished nested batches under this one */
 	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, client_p->localClient->pending_batches.head)
@@ -174,18 +164,21 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 		if (other->parent == batch)
 		{
 			restore_global_context(client_p, other);
+			info = resume_response_batch(batch->response_info);
 			if (IsClient(source_p))
 				sendto_one(source_p, ":%s FAIL BATCH INCOMPLETE %s :Nested batch not finished before enclosing batch",
 					me.name, other->tag);
 
 			client_p->localClient->pending_batch_lines -= other->len + 1;
-			batch_free(other);
+			batch_free(other, info);
+			reset_global_context();
 			rb_dlinkDestroy(ptr, &client_p->localClient->pending_batches);
 		}
 	}
 
 	client_p->localClient->pending_batch_lines -= batch->len + 1;
 	restore_global_context(client_p, batch);
+	info = resume_response_batch(batch->response_info);
 
 	if (handler == NULL)
 	{
@@ -196,7 +189,8 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 			sendto_one(source_p, ":%s FAIL BATCH UNKNOWN_TYPE %s %s :Unrecognized batch type",
 				me.name, batch->tag, batch->type);
 
-		batch_free(batch);
+		batch_free(batch, info);
+		reset_global_context();
 		return;
 	}
 
@@ -209,11 +203,17 @@ finish_batch(struct Client *client_p, struct Client *source_p, struct Batch *bat
 		{
 			struct Batch *child = ptr->data;
 			rb_dlinkDestroy(ptr, &batch->children);
+			/* global context isn't a stack, so ensure we reset to base before recursing */
+			resume_response_batch(info);
+			reset_global_context();
 			finish_batch(client_p, source_p, child);
+			restore_global_context(client_p, batch);
+			info = resume_response_batch(batch->response_info);
 		}
 	}
 
-	batch_free(batch);
+	batch_free(batch, info);
+	reset_global_context();
 }
 
 static void
@@ -364,8 +364,7 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		client_p->localClient->pending_batch_lines++;
 
 		/* postpone any labeled-response to when the batch completes */
-		batch->response_info = outgoing_response_info;
-		outgoing_response_info = NULL;
+		batch->response_info = suspend_response_batch();
 	}
 	else
 	{
@@ -390,19 +389,7 @@ m_batch(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		}
 		else
 		{
-			/* save off global state since finish_batch() smashes it */
-			uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
-			const struct Client *orig_incoming_client = incoming_client;
-			const struct MsgBuf *orig_incoming_message = incoming_message;
-			struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-			bool has_receive_label = outgoing_response_info != NULL
-				&& CLICAP_RECEIVE_LABEL > 0
-				&& IsClientCapable(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
-
 			finish_batch(client_p, source_p, batch);
-
-			reset_global_context(orig_incoming_client, orig_incoming_message, orig_outgoing_response_info,
-				has_receive_label ? CLICAP_RECEIVE_LABEL : NOCAPS);
 		}
 	}
 }

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -1051,8 +1051,9 @@ msg_client(enum message_type msgtype,
 		}
 
 		/* suppress labeled-response on the primary message if they're messaging themselves */
-		if (outgoing_response_info != NULL && source_p == target_p)
-			outgoing_response_info->skip_tags++;
+		struct ResponseInfo *info = outgoing_response_info;
+		if (source_p == target_p)
+			suspend_response_batch();
 
 		if (msgtype == MESSAGE_TYPE_TAGMSG && IsClientCapable(target_p, CLICAP_MESSAGE_TAGS))
 		{
@@ -1067,9 +1068,7 @@ msg_client(enum message_type msgtype,
 				NOCAPS, NOCAPS, msgbuf_p->n_tags, msgbuf_p->tags, ":%s", text);
 		}
 
-		if (outgoing_response_info != NULL && source_p == target_p)
-			outgoing_response_info->skip_tags--;
-
+		resume_response_batch(info);
 		echo_msg(target_p, source_p, msgtype, text, msgbuf_p);
 	}
 	else
@@ -1140,8 +1139,7 @@ msg_mass(enum message_type msgtype, struct Client *client_p, struct Client *sour
 	}
 
 	/* suppress labeled-response on the message (it might be going to themselves) */
-	if (outgoing_response_info != NULL)
-		outgoing_response_info->skip_tags++;
+	struct ResponseInfo *info = suspend_response_batch();
 
 	sendto_match_butone_tags(IsServer(client_p) ? client_p : NULL, source_p,
 		mask + 1,
@@ -1153,8 +1151,7 @@ msg_mass(enum message_type msgtype, struct Client *client_p, struct Client *sour
 	if (msgtype == MESSAGE_TYPE_PRIVMSG && *text == '\001')
 		source_p->large_ctcp_sent = rb_current_time();
 
-	if (outgoing_response_info != NULL)
-		outgoing_response_info->skip_tags--;
+	resume_response_batch(info);
 
 	/* ECHO doesn't work with special syntax, so generate a local echo instead */
 	if (MyClient(source_p) && IsClientCapable(source_p, CLICAP_ECHO_MESSAGE))

--- a/modules/m_cap.c
+++ b/modules/m_cap.c
@@ -77,7 +77,7 @@ clicap_visible(struct Client *client_p, const struct CapabilityEntry *cap)
 
 	clicap = cap->ownerdata;
 	if (clicap->visible == NULL)
-		return 1;
+		return (clicap->flags & CLICAP_FLAGS_INVISIBLE) == 0;
 
 	return clicap->visible(client_p);
 }

--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -69,13 +69,10 @@ static void list_one_channel(struct Client *source_p, struct Channel *chptr, int
 static void safelist_one_channel(struct Client *source_p, struct Channel *chptr, struct ListClient *params);
 static void safelist_check_cliexit(void *);
 static void safelist_client_instantiate(struct Client *, struct ListClient *);
-static void safelist_client_release(struct Client *, struct ResponseInfo **);
+static void safelist_client_release(struct Client *, struct ResponseInfo *);
 static void safelist_iterate_client(struct Client *source_p);
 static void safelist_iterate_clients(void *unused);
 static void safelist_channel_named(struct Client *source_p, const char *name, int operspy);
-
-static uint64_t restore_global_context(struct Client *);
-static void reset_global_context(struct ResponseInfo *, uint64_t);
 
 struct Message list_msgtab = {
 	"LIST", 0, 0, 0, 0,
@@ -112,29 +109,18 @@ static int _modinit(void)
 static void _moddeinit(void)
 {
 	rb_dlink_node *n, *n2;
-	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-	uint64_t set_cap = NOCAPS;
-	bool first = true;
 
 	rb_event_delete(iterate_clients_ev);
 
 	RB_DLINK_FOREACH_SAFE(n, n2, safelisting_clients.head)
 	{
 		struct Client *source_p = n->data;
-		if (first)
-		{
-			set_cap = restore_global_context(source_p);
-			first = false;
-		}
-		else
-			restore_global_context(source_p);
-
+		struct ResponseInfo *orig_info = NULL;
+		if (MyClient(source_p))
+			orig_info = resume_response_batch(source_p->localClient->safelist_data->response_info);
 		sendto_one_notice(source_p, ":/LIST aborted");
-		safelist_client_release(source_p, &orig_outgoing_response_info);
+		safelist_client_release(source_p, orig_info);
 	}
-
-	if (!first)
-		reset_global_context(orig_outgoing_response_info, set_cap);
 
 	delete_isupport("SAFELIST");
 	delete_isupport("ELIST");
@@ -148,11 +134,9 @@ static void safelist_check_cliexit(void *data)
 	 */
 	if (MyClient(hdata->target) && hdata->target->localClient->safelist_data != NULL)
 	{
-		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-		uint64_t set_cap = restore_global_context(hdata->target);
+		struct ResponseInfo *orig_info = resume_response_batch(hdata->target->localClient->safelist_data->response_info);
 		sendto_one_notice(hdata->target, ":/LIST aborted");
-		safelist_client_release(hdata->target, &orig_outgoing_response_info);
-		reset_global_context(orig_outgoing_response_info, set_cap);
+		safelist_client_release(hdata->target, orig_info);
 	}
 }
 
@@ -169,11 +153,9 @@ m_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 
 	if (source_p->localClient->safelist_data != NULL)
 	{
-		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-		uint64_t set_cap = restore_global_context(source_p);
+		struct ResponseInfo *orig_info = resume_response_batch(source_p->localClient->safelist_data->response_info);
 		sendto_one_notice(source_p, ":/LIST aborted");
-		safelist_client_release(source_p, &orig_outgoing_response_info);
-		reset_global_context(orig_outgoing_response_info, set_cap);
+		safelist_client_release(source_p, orig_info);
 		return;
 	}
 
@@ -208,11 +190,9 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	if (source_p->localClient->safelist_data != NULL)
 	{
-		struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-		uint64_t set_cap = restore_global_context(source_p);
+		struct ResponseInfo *orig_info = resume_response_batch(source_p->localClient->safelist_data->response_info);
 		sendto_one_notice(source_p, ":/LIST aborted");
-		safelist_client_release(source_p, &orig_outgoing_response_info);
-		reset_global_context(orig_outgoing_response_info, set_cap);
+		safelist_client_release(source_p, orig_info);
 		return;
 	}
 
@@ -345,10 +325,7 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		}
 	}
 
-	/* mark it as a "remote" response that cannot expire so we don't terminate the batch at the end of the command handler */
-	begin_remote_response_batch(1, "");
-	if (outgoing_response_info != NULL)
-		outgoing_response_info->expires = 0;
+	begin_local_response_batch();
 	params->response_info = outgoing_response_info;
 
 	safelist_client_instantiate(source_p, params);
@@ -437,41 +414,6 @@ static void safelist_client_instantiate(struct Client *client_p, struct ListClie
 	safelist_iterate_client(client_p);
 }
 
-/* Restore global contextual pointers for SAFELIST */
-static uint64_t
-restore_global_context(struct Client *client_p)
-{
-	uint64_t CLICAP_LABELED_RESPONSE = capability_get(cli_capindex, "labeled-response", NULL);
-	uint64_t CLICAP_RECEIVE_LABEL = capability_get(cli_capindex, "?receive_label", NULL);
-	uint64_t set_cap = NOCAPS;
-
-	if (outgoing_response_info != NULL && MyConnect(outgoing_response_info->source_p) && CLICAP_RECEIVE_LABEL)
-	{
-		set_cap = IsClientCapable(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL) ? CLICAP_RECEIVE_LABEL : NOCAPS;
-		ClearClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
-	}
-
-	outgoing_response_info = client_p->localClient->safelist_data->response_info;
-
-	if (outgoing_response_info != NULL
-		&& MyConnect(outgoing_response_info->source_p)
-		&& IsClientCapable(outgoing_response_info->source_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH)
-		&& CLICAP_RECEIVE_LABEL)
-	{
-		SetClientCap(outgoing_response_info->source_p, CLICAP_RECEIVE_LABEL);
-	}
-
-	return set_cap;
-}
-
-static void
-reset_global_context(struct ResponseInfo *orig, uint64_t set_cap)
-{
-	outgoing_response_info = orig;
-	if (orig != NULL && set_cap)
-		SetClientCap(orig->source_p, set_cap);
-}
-
 /*
  * safelist_client_release()
  *
@@ -480,10 +422,12 @@ reset_global_context(struct ResponseInfo *orig, uint64_t set_cap)
  * side effects - the client is no longer being
  *                listed
  */
-static void safelist_client_release(struct Client *client_p, struct ResponseInfo **orig_response_info)
+static void safelist_client_release(struct Client *client_p, struct ResponseInfo *orig_response_info)
 {
 	if (!MyClient(client_p))
 		return;
+
+	struct ResponseInfo *info = client_p->localClient->safelist_data->response_info;
 
 	rb_dlinkFindDestroy(client_p, &safelisting_clients);
 
@@ -496,15 +440,10 @@ static void safelist_client_release(struct Client *client_p, struct ResponseInfo
 
 	sendto_one(client_p, form_str(RPL_LISTEND), me.name, client_p->name);
 
-	if (outgoing_response_info != NULL)
-		sendto_one(client_p, ":%s BATCH -%s", me.name, outgoing_response_info->batch);
+	if (info != NULL)
+		sendto_one(client_p, ":%s BATCH -%s", me.name, info->batch);
 
-	/* outgoing_response_info is about to be freed, so if orig is the same pointer, wipe it */
-	if (outgoing_response_info == *orig_response_info)
-		*orig_response_info = NULL;
-
-	free_response_batch(outgoing_response_info);
-	outgoing_response_info = NULL;
+	free_response_batch(info, orig_response_info);
 }
 
 /*
@@ -597,14 +536,12 @@ static void safelist_one_channel(struct Client *source_p, struct Channel *chptr,
  *
  * inputs       - client pointer
  * outputs      - none
- * side effects - the client's sendq is filled up again
+ * side effects - the client's sendq is filled up again, outgoing_response_info set to NULL
  */
 static void safelist_iterate_client(struct Client *source_p)
 {
 	struct Channel *chptr;
 	rb_radixtree_iteration_state iter;
-	struct ResponseInfo *orig_outgoing_response_info = outgoing_response_info;
-	uint64_t set_cap = restore_global_context(source_p);
 
 	RB_RADIXTREE_FOREACH_FROM(chptr, &iter, channel_tree, source_p->localClient->safelist_data->chname)
 	{
@@ -612,22 +549,27 @@ static void safelist_iterate_client(struct Client *source_p)
 		{
 			rb_free(source_p->localClient->safelist_data->chname);
 			source_p->localClient->safelist_data->chname = rb_strdup(chptr->chname);
-			outgoing_response_info = orig_outgoing_response_info;
-
+			suspend_response_batch();
 			return;
 		}
 
 		safelist_one_channel(source_p, chptr, source_p->localClient->safelist_data);
 	}
 
-	safelist_client_release(source_p, &orig_outgoing_response_info);
-	reset_global_context(orig_outgoing_response_info, set_cap);
+	safelist_client_release(source_p, NULL);
 }
 
 static void safelist_iterate_clients(void *unused)
 {
 	rb_dlink_node *n, *n2;
+	struct ResponseInfo *saved = outgoing_response_info;
 
 	RB_DLINK_FOREACH_SAFE(n, n2, safelisting_clients.head)
-		safelist_iterate_client((struct Client *)n->data);
+	{
+		struct Client *source_p = n->data;
+		resume_response_batch(source_p->localClient->safelist_data->response_info);
+		safelist_iterate_client(source_p);
+	}
+
+	resume_response_batch(saved);
 }

--- a/modules/meson.build
+++ b/modules/meson.build
@@ -1,6 +1,5 @@
 autoload_modules = [
   'cap_account_tag',
-  'cap_labeled_response',
   'cap_server_time',
   'chm_nocolour',
   'chm_noctcp',
@@ -10,7 +9,6 @@ autoload_modules = [
   'm_admin',
   'm_alias',
   'm_away',
-  'm_batch',
   'm_cap',
   'm_capab',
   'm_certfp',
@@ -86,7 +84,9 @@ foreach mod : autoload_modules
 endforeach
 
 core_modules = [
+  'cap_labeled_response',
   'm_ban',
+  'm_batch',
   'm_die',
   'm_error',
   'm_join',


### PR DESCRIPTION
The previous API was too error-prone, as evidenced by the large amount of crash bugs discovered with it. New functions were added to response.h to more easily manage labeled-response state, and some state tracking was moved into core (such as CLICAP_RECEIVE_LABEL, which must only ever be on one client at a time). Because this tracking is now in core, cap_labeled_response needs to be a core module as having that bit unloaded will cause issues. m_batch was also moved into being a core module as more and more core things have depended on batch support existing (and more will depend on it in the future).

m_list no longer re-uses remote response batches for SAFELIST, instead making use of new APIs to suspend a labeled-response batch and more easily resume it.

Batch resumption was made more focused as well, to ensure that we don't accidentally lose batches due to setting outgoing_response_info to NULL. The free_response_batch takes a resumption pointer to avoid cases where we could introduce use-after-free by combining
free+resume_response_batch.

struct ResponseInfo now takes strduped pointers instead of directly holding the buffers, and some fields were merged into a flags field or omitted entirely due to new suspension/resumption support. This will have a minor positive impact on memory usage as we no longer need to allocate buffers for maximum-sized strings for every labeled-response.