### PR TITLE
Prevent users from running CAPAB pre-registration

### DIFF
--- a/modules/m_capab.c
+++ b/modules/m_capab.c
@@ -64,8 +64,17 @@ mr_capab(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	if(client_p->localClient == NULL)
 		return;
 
-	if(client_p->user)
+	if (client_p->user)
+	{
+		exit_client(client_p, client_p, client_p, "Mixing client and server protocol");
 		return;
+	}
+
+	if (!IsServerCapable(client_p, CAP_TS6))
+	{
+		exit_client(client_p, client_p, client_p, "Incompatible TS version");
+		return;
+	}
 
 	/* CAP_TS6 is set in PASS, so is valid.. */
 	if((client_p->localClient->server_caps & ~CAP_TS6) != 0)


### PR DESCRIPTION
We now disconnect the client if they attempt to run CAPAB before running PASS (introducing themselves as a TS6 server with an SID) or if they've already sent USER/NICK info. USER/NICK already has the other half of the requisite checks by disconnecting the user if they have an SID. As such, the logic flow of requiring an SID before CAPAB means users can never have server caps set on them.

This prevents various issues such as a client sending CAPAB STAG receiving all message tags, including those designed to be s2s-only.