### PR TITLE
Fix null dereference in LIST

### DIFF
--- a/modules/m_list.c
+++ b/modules/m_list.c
@@ -347,7 +347,8 @@ mo_list(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	/* mark it as a "remote" response that cannot expire so we don't terminate the batch at the end of the command handler */
 	begin_remote_response_batch(1, "");
-	outgoing_response_info->expires = 0;
+	if (outgoing_response_info != NULL)
+		outgoing_response_info->expires = 0;
 	params->response_info = outgoing_response_info;
 
 	safelist_client_instantiate(source_p, params);


### PR DESCRIPTION
Introduced in 66a8049e700c5c55ddd32cf211c1ceef06992ff3

When a client with no capability sends a `LIST` command:

```
1779619131.862 valgrind ==988041== Invalid write of size 8
1779619131.862 valgrind ==988041==    at 0x58A038D: mo_list (m_list.c:350)
1779619131.862 valgrind ==988041==    by 0x589FCE5: m_list (m_list.c:194)
1779619131.862 valgrind ==988041==    by 0x48A12D1: handle_command (parse.c:318)
1779619131.862 valgrind ==988041==    by 0x48A0D2A: parse (parse.c:225)
1779619131.862 valgrind ==988041==    by 0x48A038C: client_dopacket (packet.c:377)
1779619131.862 valgrind ==988041==    by 0x489F85B: parse_client_queued (packet.c:150)
1779619131.862 valgrind ==988041==    by 0x489FE45: read_packet (packet.c:306)
1779619131.862 valgrind ==988041==    by 0x4B576E7: rb_select_epoll (epoll.c:199)
1779619131.862 valgrind ==988041==    by 0x4B50E24: rb_select (commio.c:2052)
1779619131.862 valgrind ==988041==    by 0x4B542D3: rb_lib_loop (rb_lib.c:237)
1779619131.862 valgrind ==988041==    by 0x48904E5: solanum_main (ircd.c:769)
1779619131.862 valgrind ==988041==    by 0x109158: main (main.c:8)
1779619131.862 valgrind ==988041==  Address 0x70 is not stack'd, malloc'd or (recently) free'd
1779619131.862 valgrind ==988041== 
1779619131.862 valgrind ==988041== 
1779619131.862 valgrind ==988041== Process terminating with default action of signal 11 (SIGSEGV): dumping core
1779619131.862 valgrind ==988041==  Access not within mapped region at address 0x70
1779619131.862 valgrind ==988041==    at 0x58A038D: mo_list (m_list.c:350)
1779619131.862 valgrind ==988041==    by 0x589FCE5: m_list (m_list.c:194)
1779619131.862 valgrind ==988041==    by 0x48A12D1: handle_command (parse.c:318)
1779619131.862 valgrind ==988041==    by 0x48A0D2A: parse (parse.c:225)
1779619131.862 valgrind ==988041==    by 0x48A038C: client_dopacket (packet.c:377)
1779619131.862 valgrind ==988041==    by 0x489F85B: parse_client_queued (packet.c:150)
1779619131.862 valgrind ==988041==    by 0x489FE45: read_packet (packet.c:306)
1779619131.862 valgrind ==988041==    by 0x4B576E7: rb_select_epoll (epoll.c:199)
1779619131.862 valgrind ==988041==    by 0x4B50E24: rb_select (commio.c:2052)
1779619131.862 valgrind ==988041==    by 0x4B542D3: rb_lib_loop (rb_lib.c:237)
1779619131.862 valgrind ==988041==    by 0x48904E5: solanum_main (ircd.c:769)
1779619131.862 valgrind ==988041==    by 0x109158: main (main.c:8)
1779619131.862 valgrind ==988041==  If you believe this happened as a result of a stack
1779619131.862 valgrind ==988041==  overflow in your program's main thread (unlikely but
1779619131.862 valgrind ==988041==  possible), you can try to increase the size of the
1779619131.862 valgrind ==988041==  main thread stack using the --main-stacksize= flag.
1779619131.862 valgrind ==988041==  The main thread stack size used in this run was 8388608.
```