### PR TITLE
Fix meson test and labeled-response

### DIFF
--- a/help/make_index.SH
+++ b/help/make_index.SH
@@ -21,7 +21,7 @@ for help in "$SOURCE/users/"*; do
 done
 
 # Add symlinks to users index
-for link in topic accept cmode admin names links away whowas version kick who invite quit join list nick oper part time credits motd userhost users whois ison lusers user help pass error challenge knock ping pong map trace chantrace extban monitor batch; do
+for link in topic accept admin names links away whowas version kick who invite quit join list nick oper part time credits motd userhost users whois ison lusers user help pass error challenge knock ping pong map trace chantrace extban monitor batch; do
   echo "$link" >> "$USERS_INDEX.tmp"
 done
 

--- a/help/meson.build
+++ b/help/meson.build
@@ -3,7 +3,7 @@ meson.add_install_script(files('make_index.SH'), meson.current_source_dir(), hel
 
 # Symlinks from users -> opers for shared help topics
 user_symlinks = [
-  'topic', 'accept', 'cmode', 'admin', 'names', 'links', 'away', 'whowas',
+  'topic', 'accept', 'admin', 'names', 'links', 'away', 'whowas',
   'version', 'kick', 'who', 'invite', 'quit', 'join', 'list', 'nick',
   'oper', 'part', 'time', 'credits', 'motd', 'userhost', 'users', 'whois',
   'ison', 'lusers', 'user', 'help', 'pass', 'error', 'challenge', 'knock',

--- a/ircd/response.c
+++ b/ircd/response.c
@@ -173,7 +173,8 @@ free_response_batch(struct ResponseInfo *response, struct ResponseInfo *resume)
 			rb_dlinkDestroy(response->remote_node, &response->source_p->localClient->pending_remote_responses);
 	}
 
-	rb_dictionary_delete(pending_responses, response->batch);
+	if (!EmptyString(response->batch))
+		rb_dictionary_delete(pending_responses, response->batch);
 
 	if (!(response->flags & RESPONSE_FLAG_STATIC))
 	{

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -252,7 +252,7 @@ hunt_server(struct Client *client_p, struct Client *source_p,
 		old = parv[server];
 		parv[server] = get_id(target_p, target_p);
 
-		begin_remote_response_batch(1, target_p->servptr->name);
+		begin_remote_response_batch(1, IsServer(target_p) ? target_p->name : target_p->servptr->name);
 		sendto_one(target_p, command, get_id(source_p, target_p),
 			   parv[1], parv[2], parv[3], parv[4], parv[5], parv[6], parv[7], parv[8]);
 		parv[server] = old;

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -883,6 +883,10 @@ sendto_channel_local_internal(struct Client *one, int type, struct Client *sourc
 
 	rb_fsnprint(buf, sizeof(buf), &strings);
 
+	/* source_p == NULL in some tests; in real code this would indicate a server-sent message, so use &me if NULL */
+	if (source_p == NULL)
+		source_p = &me;
+
 	bool receives_message = false;
 	if (MyClient(source_p) && (msptr = find_channel_membership(chptr, source_p)) != NULL)
 	{

--- a/librb/include/rb_dictionary.h
+++ b/librb/include/rb_dictionary.h
@@ -60,6 +60,11 @@ struct rb_dictionary_iter
 extern rb_dictionary *rb_dictionary_create(const char *name, DCF compare_cb);
 
 /*
+ * rb_dictionary_get_for_tests() gets a dictionary by name, for use in tests/ ONLY.
+ */
+extern rb_dictionary *rb_dictionary_get_for_tests(const char *name);
+
+/*
  * rb_dictionary_set_comparator_func() resets the comparator used for lookups and
  * insertions in the DTree structure.
  */

--- a/librb/include/rb_event.h
+++ b/librb/include/rb_event.h
@@ -44,6 +44,7 @@ void rb_event_update(struct ev_entry *, time_t freq);
 void rb_set_back_events(time_t);
 void rb_dump_events(void (*func) (char *, void *), void *ptr);
 void rb_run_one_event(struct ev_entry *);
+void rb_run_one_event_for_tests(const char *name);
 time_t rb_event_next(void);
 
 #endif /* INCLUDED_event_h */

--- a/librb/include/rb_tools.h
+++ b/librb/include/rb_tools.h
@@ -30,6 +30,7 @@
 #ifndef __TOOLS_H__
 #define __TOOLS_H__
 
+int rb_strcmp(const void *s1, const void *s2);
 int rb_strcasecmp(const void *s1, const void *s2);
 int rb_strncasecmp(const void *s1, const void *s2, size_t n);
 char *rb_strcasestr(const char *s, const char *find);

--- a/librb/src/dictionary.c
+++ b/librb/src/dictionary.c
@@ -68,6 +68,21 @@ rb_dictionary *rb_dictionary_create(const char *name,
 	return dtree;
 }
 
+rb_dictionary *rb_dictionary_get_for_tests(const char *name)
+{
+	rb_dlink_node *ptr;
+	rb_dictionary *dtree;
+
+	RB_DLINK_FOREACH(ptr, dictionary_list.head)
+	{
+		dtree = ptr->data;
+		if (!strcmp(dtree->id, name))
+			return dtree;
+	}
+
+	return NULL;
+}
+
 /*
  * rb_dictionary_set_comparator_func(rb_dictionary *dict,
  *     DCF compare_cb)

--- a/librb/src/event.c
+++ b/librb/src/event.c
@@ -208,6 +208,23 @@ rb_run_one_event(struct ev_entry *ev)
 		event_time_min = ev->when;
 }
 
+void
+rb_run_one_event_for_tests(const char *name)
+{
+	rb_dlink_node *ptr;
+	struct ev_entry *ev;
+
+	RB_DLINK_FOREACH(ptr, event_list.head)
+	{
+		ev = ptr->data;
+		if (!strcmp(ev->name, name))
+		{
+			rb_run_one_event(ev);
+			return;
+		}
+	}
+}
+
 /*
  * void rb_event_run(void)
  *

--- a/librb/src/export-syms.txt
+++ b/librb/src/export-syms.txt
@@ -42,6 +42,7 @@ rb_dictionary_retrieve
 rb_dictionary_size
 rb_dictionary_stats
 rb_dictionary_stats_walk
+rb_dictionary_get_for_tests
 rb_dirname
 rb_dump_events
 rb_dump_fd
@@ -153,6 +154,7 @@ rb_rawbuf_length
 rb_read
 rb_recv_fd_buf
 rb_run_one_event
+rb_run_one_event_for_tests
 rb_sctp_bindx
 rb_select
 rb_send_fd_buf
@@ -180,6 +182,7 @@ rb_ssl_start_accepted
 rb_ssl_start_connected
 rb_strcasecmp
 rb_strcasestr
+rb_strcmp
 rb_strerror
 rb_string_to_array
 rb_strlcat

--- a/librb/src/tools.c
+++ b/librb/src/tools.c
@@ -134,6 +134,12 @@ rb_string_to_array(char *string, char **parv, int maxpara)
 }
 
 int
+rb_strcmp(const void *s1, const void *s2)
+{
+	return strcmp(s1, s2);
+}
+
+int
 rb_strcasecmp(const void *s1, const void *s2)
 {
 	return strcasecmp(s1, s2);

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -440,7 +440,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
 				}
 			}
 
-			/* non existant channel */
+			/* non-existent channel */
 			else if(msgtype == MESSAGE_TYPE_PRIVMSG)
 				sendto_one_numeric(source_p, ERR_NOSUCHNICK,
 						   form_str(ERR_NOSUCHNICK), nick);
@@ -683,8 +683,8 @@ msg_channel(enum message_type msgtype,
 {
 	int result;
 	hook_data_privmsg_channel hdata;
-	int cli_cap = 0;
-	int serv_cap = 0;
+	uint64_t cli_cap = NOCAPS;
+	uint64_t serv_cap = NOCAPS;
 	const char *fmt = "%s %s :%s";
 
 	if (msgtype == MESSAGE_TYPE_TAGMSG)
@@ -788,8 +788,8 @@ msg_channel_opmod(enum message_type msgtype,
 		  struct Channel *chptr, const char *text, struct MsgBuf *msgbuf_p)
 {
 	hook_data_privmsg_channel hdata;
-	int cli_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CLICAP_MESSAGE_TAGS : 0;
-	int serv_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : 0;
+	uint64_t cli_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CLICAP_MESSAGE_TAGS : NOCAPS;
+	uint64_t serv_cap = msgtype == MESSAGE_TYPE_TAGMSG ? CAP_STAG : NOCAPS;
 
 	hdata.msgtype = msgtype;
 	hdata.source_p = source_p;
@@ -855,8 +855,8 @@ msg_channel_flags(enum message_type msgtype, struct Client *client_p,
 	int type;
 	char c;
 	hook_data_privmsg_channel hdata;
-	int cli_cap = 0;
-	int serv_cap = 0;
+	uint64_t cli_cap = NOCAPS;
+	uint64_t serv_cap = NOCAPS;
 	const char *fmt = "%s %c%s :%s";
 
 	if (msgtype == MESSAGE_TYPE_TAGMSG)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,6 +5,7 @@ check_PROGRAMS = runtests \
 	msgbuf_parse1 \
 	msgbuf_unparse1 \
 	hostmask1 \
+	labeled_response1 \
 	privilege1 \
 	rb_dictionary1 \
 	rb_snprintf_append1 \

--- a/tests/client_util.c
+++ b/tests/client_util.c
@@ -44,7 +44,7 @@ static struct Listener fake_listener = {
 		{ .ss_family = AF_INET6 },
 		{ .ss_family = AF_INET6 },
 	},
-	.vhost = { 'f', 'a', 'k', 'e' },
+	.vhost = { "fake" },
 };
 
 struct Client *make_local_unknown(void)

--- a/tests/client_util.c
+++ b/tests/client_util.c
@@ -35,7 +35,7 @@
 static struct Listener fake_listener = {
 	.name = "fake",
 	.F = NULL,
-	.ref_count = 0,
+	.ref_count = 1,
 	.active = 1,
 	.ssl = 1,
 	.defer_accept = 0,
@@ -44,7 +44,7 @@ static struct Listener fake_listener = {
 		{ .ss_family = AF_INET6 },
 		{ .ss_family = AF_INET6 },
 	},
-	.vhost = { "fake" },
+	.vhost = { 'f', 'a', 'k', 'e' },
 };
 
 struct Client *make_local_unknown(void)
@@ -56,6 +56,7 @@ struct Client *make_local_unknown(void)
 	client->servptr = &me;
 	rb_dlinkAdd(client, &client->lnode, &client->servptr->serv->users);
 	client->localClient->listener = &fake_listener;
+	fake_listener.ref_count++;
 	client->preClient->auth.accepted = true;
 	client->localClient->localflags |= LFLAGS_FAKE;
 
@@ -69,10 +70,20 @@ struct Client *make_local_person(void)
 
 struct Client *make_local_person_nick(const char *nick)
 {
-	return make_local_person_full(nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME);
+	return make_local_person_full_id(nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME, "");
+}
+
+struct Client *make_local_person_id(const char *nick, const char *id)
+{
+	return make_local_person_full_id(nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME, id);
 }
 
 struct Client *make_local_person_full(const char *nick, const char *username, const char *hostname, const char *ip, const char *realname)
+{
+	return make_local_person_full_id(nick, username, hostname, ip, realname, "");
+}
+
+struct Client *make_local_person_full_id(const char *nick, const char *username, const char *hostname, const char *ip, const char *realname, const char *id)
 {
 	struct Client *client;
 
@@ -81,6 +92,7 @@ struct Client *make_local_person_full(const char *nick, const char *username, co
 	SetClient(client);
 
 	rb_inet_pton_sock(ip, &client->localClient->ip);
+	rb_strlcpy(client->id, id, sizeof(client->id));
 	rb_strlcpy(client->name, nick, sizeof(client->name));
 	rb_strlcpy(client->username, username, sizeof(client->username));
 	rb_strlcpy(client->host, hostname, sizeof(client->host));
@@ -88,6 +100,9 @@ struct Client *make_local_person_full(const char *nick, const char *username, co
 	rb_strlcpy(client->info, realname, sizeof(client->info));
 
 	add_to_client_hash(client->name, client);
+	add_to_hostname_hash(client->host, client);
+	if (strlen(id))
+		add_to_id_hash(client->id, client);
 
 	return client;
 }
@@ -150,10 +165,20 @@ struct Client *make_remote_person(struct Client *server)
 
 struct Client *make_remote_person_nick(struct Client *server, const char *nick)
 {
-	return make_remote_person_full(server, nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME);
+	return make_remote_person_full_id(server, nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME, "");
+}
+
+struct Client *make_remote_person_id(struct Client *server, const char *nick, const char *id)
+{
+	return make_remote_person_full_id(server, nick, TEST_USERNAME, TEST_HOSTNAME, TEST_IP, TEST_REALNAME, id);
 }
 
 struct Client *make_remote_person_full(struct Client *server, const char *nick, const char *username, const char *hostname, const char *ip, const char *realname)
+{
+	return make_remote_person_full_id(server, nick, username, hostname, ip, realname, "");
+}
+
+struct Client *make_remote_person_full_id(struct Client *server, const char *nick, const char *username, const char *hostname, const char *ip, const char *realname, const char *id)
 {
 	struct Client *client;
 	struct sockaddr_storage addr;
@@ -166,6 +191,7 @@ struct Client *make_remote_person_full(struct Client *server, const char *nick, 
 	rb_dlinkAdd(server, &server->lnode, &server->servptr->serv->users);
 
 	rb_inet_pton_sock(ip, &addr);
+	rb_strlcpy(client->id, id, sizeof(client->id));
 	rb_strlcpy(client->name, nick, sizeof(client->name));
 	rb_strlcpy(client->username, username, sizeof(client->username));
 	rb_strlcpy(client->host, hostname, sizeof(client->host));
@@ -174,6 +200,8 @@ struct Client *make_remote_person_full(struct Client *server, const char *nick, 
 
 	add_to_client_hash(nick, client);
 	add_to_hostname_hash(client->host, client);
+	if (strlen(id))
+		add_to_id_hash(client->id, client);
 
 	return client;
 }
@@ -186,22 +214,23 @@ void make_remote_person_oper(struct Client *client)
 
 void remove_remote_person(struct Client *client)
 {
-	exit_client(client, client->servptr, client->servptr, "Test client removed");
+	exit_client(NULL, client, &me, "Test client removed");
 }
 
 void remove_remote_server(struct Client *server)
 {
-	exit_client(server, server, server->servptr, "Test server removed");
+	exit_client(NULL, server, &me, "Test server removed");
 }
 
 struct Channel *make_channel(void)
 {
-	return allocate_channel(TEST_CHANNEL);
+	return get_or_create_channel(&me, TEST_CHANNEL, NULL);
 }
 
 char *get_client_sendq(const struct Client *client)
 {
 	static char buf[EXT_BUFSIZE + sizeof(CRLF)];
+	*buf = '\0';
 
 	if (rb_linebuf_len(&client->localClient->buf_sendq)) {
 		int ret;
@@ -209,14 +238,23 @@ char *get_client_sendq(const struct Client *client)
 		memset(buf, 0, sizeof(buf));
 		ret = rb_linebuf_get(&client->localClient->buf_sendq, buf, sizeof(buf), 0, 1);
 
-		if (ok(ret > 0, MSG)) {
-			return buf;
-		} else {
-			return "<get_client_sendq error>";
+		if (!ok(ret > 0, MSG)) {
+			strcpy(buf, "<get_client_sendq error>");
 		}
 	}
 
-	return "";
+	return buf;
+}
+
+void drain_client_sendq(const struct Client *client)
+{
+	static char buf[EXT_BUFSIZE + sizeof(CRLF)];
+
+	while (rb_linebuf_len(&client->localClient->buf_sendq) > 0)
+	{
+		if (!rb_linebuf_get(&client->localClient->buf_sendq, buf, sizeof(buf), 0, 1))
+			return;
+	}
 }
 
 void client_util_parse(struct Client *client, const char *message)

--- a/tests/client_util.h
+++ b/tests/client_util.h
@@ -66,7 +66,9 @@ void client_util_free(void);
 struct Client *make_local_unknown(void);
 struct Client *make_local_person(void);
 struct Client *make_local_person_nick(const char *nick);
+struct Client *make_local_person_id(const char *nick, const char *id);
 struct Client *make_local_person_full(const char *nick, const char *username, const char *hostname, const char *ip, const char *realname);
+struct Client *make_local_person_full_id(const char *nick, const char *username, const char *hostname, const char *ip, const char *realname, const char *id);
 void make_local_person_oper(struct Client *client);
 void remove_local_person(struct Client *client);
 
@@ -75,7 +77,9 @@ struct Client *make_remote_server_name(struct Client *uplink, const char *name);
 struct Client *make_remote_server_full(struct Client *uplink, const char *name, const char *id);
 struct Client *make_remote_person(struct Client *server);
 struct Client *make_remote_person_nick(struct Client *server, const char *nick);
+struct Client *make_remote_person_id(struct Client *server, const char *nick, const char *id);
 struct Client *make_remote_person_full(struct Client *server, const char *nick, const char *username, const char *hostname, const char *ip, const char *realname);
+struct Client *make_remote_person_full_id(struct Client *server, const char *nick, const char *username, const char *hostname, const char *ip, const char *realname, const char *id);
 void make_remote_person_oper(struct Client *client);
 void remove_remote_person(struct Client *client);
 void remove_remote_server(struct Client *server);
@@ -83,6 +87,7 @@ void remove_remote_server(struct Client *server);
 struct Channel *make_channel(void);
 
 char *get_client_sendq(const struct Client *client);
+void drain_client_sendq(const struct Client *client);
 
 void client_util_parse(struct Client *client, const char *message);
 

--- a/tests/labeled_response1.c
+++ b/tests/labeled_response1.c
@@ -1,0 +1,726 @@
+/*
+ * Copyright (c) 2026 Ryan Schmidt <skizzerz@skizzerz.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <math.h>
+
+#include "stdinc.h"
+#include "tap/basic.h"
+#include "ircd_util.h"
+#include "client_util.h"
+
+#include "batch.h"
+#include "hash.h"
+#include "hostmask.h"
+#include "send.h"
+#include "s_serv.h"
+#include "newconf.h"
+#include "response.h"
+#include "s_conf.h"
+#include "s_newconf.h"
+#include "s_user.h"
+
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+#define LONG_VALUE_50 "12345678901234567890123456789012345678901234567890"
+#define LONG_VALUE_100 LONG_VALUE_50 LONG_VALUE_50
+#define LONG_VALUE_200 LONG_VALUE_100 LONG_VALUE_100
+
+// What time is it?
+#define ADVENTURE_TIME "2017-07-14T02:40:00.000Z"
+
+int rb_gettimeofday(struct timeval *tv, void *tz)
+{
+	if (tv == NULL) {
+		errno = EFAULT;
+		return -1;
+	}
+	tv->tv_sec = 1500000000;
+	tv->tv_usec = 0;
+	return 0;
+}
+
+static struct Client *user;
+static struct Client *server;
+static struct Client *remote;
+static struct Client *server2;
+static struct Client *remote2;
+static struct Client *server3;
+static struct Client *remote3;
+static struct Channel *channel;
+static struct Channel *lchannel;
+
+static struct Client *local_chan_o;
+static struct Client *local_chan_ov;
+static struct Client *local_chan_v;
+static struct Client *local_chan_p;
+static struct Client *local_no_chan;
+
+static struct Client *remote_chan_o;
+static struct Client *remote_chan_ov;
+static struct Client *remote_chan_v;
+static struct Client *remote_chan_p;
+
+static struct Client *remote2_chan_p;
+static struct Client *remote2_no_chan;
+
+static char batch1[BATCH_ID_LEN];
+static char batch2[BATCH_ID_LEN];
+static char batch3[BATCH_ID_LEN];
+static char batch4[BATCH_ID_LEN];
+static char batch5[BATCH_ID_LEN];
+static char batch6[BATCH_ID_LEN];
+static char batch7[BATCH_ID_LEN];
+static char batch8[BATCH_ID_LEN];
+
+static void standard_init(void)
+{
+	user = make_local_person_id(TEST_NICK, TEST_ID);
+	server = make_remote_server_full(&me, TEST_SERVER_NAME, TEST_SERVER_ID);
+	remote = make_remote_person_id(server, TEST_REMOTE_NICK, TEST_REMOTE_ID);
+	server2 = make_remote_server_full(&me, TEST_SERVER2_NAME, TEST_SERVER2_ID);
+	remote2 = make_remote_person_id(server2, TEST_REMOTE2_NICK, TEST_REMOTE2_ID);
+	server3 = make_remote_server_full(&me, TEST_SERVER3_NAME, TEST_SERVER3_ID);
+	remote3 = make_remote_person_id(server3, TEST_REMOTE3_NICK, TEST_REMOTE3_ID);
+
+	SetServerCap(server, CAP_STAG | CAP_ENCAP);
+	SetServerCap(server2, CAP_STAG | CAP_ENCAP);
+	SetServerCap(server3, CAP_STAG | CAP_ENCAP);
+
+	local_chan_o = make_local_person_id("LChanOp", TEST_ME_ID "90001");
+	local_chan_ov = make_local_person_id("LChanOpVoice", TEST_ME_ID "90002");
+	local_chan_v = make_local_person_id("LChanVoice", TEST_ME_ID "90003");
+	local_chan_p = make_local_person_id("LChanPeon", TEST_ME_ID "90004");
+	local_no_chan = make_local_person_id("LNoChan", TEST_ME_ID "90005");
+
+	remote_chan_o = make_remote_person_id(server, "RChanOp", TEST_SERVER_ID "90101");
+	remote_chan_ov = make_remote_person_id(server, "RChanOpVoice", TEST_SERVER_ID "90102");
+	remote_chan_v = make_remote_person_id(server, "RChanVoice", TEST_SERVER_ID "90103");
+	remote_chan_p = make_remote_person_id(server, "RChanPeon", TEST_SERVER_ID "90104");
+
+	remote2_chan_p = make_remote_person_id(server2, "R2ChanPeon", TEST_SERVER2_ID "90204");
+	remote2_no_chan = make_remote_person_id(server2, "R2NoChan", TEST_SERVER2_ID "90205");
+
+	channel = make_channel();
+
+	add_user_to_channel(channel, local_chan_o, CHFL_CHANOP);
+	add_user_to_channel(channel, local_chan_ov, CHFL_CHANOP | CHFL_VOICE);
+	add_user_to_channel(channel, local_chan_v, CHFL_VOICE);
+	add_user_to_channel(channel, local_chan_p, CHFL_PEON);
+
+	add_user_to_channel(channel, remote_chan_o, CHFL_CHANOP);
+	add_user_to_channel(channel, remote_chan_ov, CHFL_CHANOP | CHFL_VOICE);
+	add_user_to_channel(channel, remote_chan_v, CHFL_VOICE);
+	add_user_to_channel(channel, remote_chan_p, CHFL_PEON);
+
+	add_user_to_channel(channel, remote2_chan_p, CHFL_PEON);
+
+	lchannel = get_or_create_channel(&me, "&test", NULL);
+
+	add_user_to_channel(lchannel, user, CHFL_PEON);
+	add_user_to_channel(lchannel, remote, CHFL_PEON);
+	add_user_to_channel(lchannel, remote2, CHFL_PEON);
+	add_user_to_channel(lchannel, remote3, CHFL_PEON);
+
+	/* for consistent batch IDs */
+	srand(0);
+}
+
+static void init_large_list(void)
+{
+	char chname[CHANNELLEN];
+
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+	attach_conf(user, find_conf_by_address(user->host, user->sockhost, NULL,
+		(struct sockaddr *)&user->localClient->ip, CONF_CLIENT, GET_SS_FAMILY(&user->localClient->ip),
+		user->username, user->localClient->auth_user));
+
+	for (int i = 0; i < 100; i++)
+	{
+		snprintf(chname, sizeof(chname), "#safelist%02d", i);
+		struct Channel *c = get_or_create_channel(user, chname, NULL);
+		add_user_to_channel(c, user, CHFL_PEON);
+		set_channel_topic(c, LONG_VALUE_200, "test!test@test", 0);
+	}
+}
+
+static void make_local_person_admin(struct Client *client_p)
+{
+	struct oper_conf *oper_p = find_oper_conf(client_p->username, client_p->orighost, client_p->sockhost, "admin");
+	oper_up(client_p, oper_p);
+	drain_client_sendq(client_p);
+	drain_client_sendq(server);
+	drain_client_sendq(server2);
+	drain_client_sendq(server3);
+}
+
+static void standard_free(void)
+{
+	remove_remote_person(remote2_chan_p);
+	remove_remote_person(remote2_no_chan);
+
+	remove_remote_person(remote_chan_o);
+	remove_remote_person(remote_chan_ov);
+	remove_remote_person(remote_chan_v);
+	remove_remote_person(remote_chan_p);
+
+	remove_local_person(local_chan_o);
+	remove_local_person(local_chan_ov);
+	remove_local_person(local_chan_v);
+	remove_local_person(local_chan_p);
+	remove_local_person(local_no_chan);
+
+	remove_remote_person(remote3);
+	remove_remote_server(server3);
+	remove_remote_person(remote2);
+	remove_remote_server(server2);
+	remove_remote_person(remote);
+	remove_remote_server(server);
+
+	if (user != NULL)
+		remove_local_person(user);
+}
+
+static void single_response(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH | CLICAP_ECHO_MESSAGE);
+
+	client_util_parse(user, "@label=foo PRIVMSG &test :hello");
+	snprintf(expected, sizeof(expected), "@label=foo :%s!%s@%s PRIVMSG &test :hello" CRLF, user->name, user->username, user->host);
+	is_client_sendq(expected, user, MSG);
+
+	/* echo-message self-PMs generate the unlabeled delivery first and the labeled echo second */
+	client_util_parse(user, "@label=foo PRIVMSG " TEST_NICK " :hello");
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :hello" CRLF, user->name, user->username, user->host, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@label=foo :%s!%s@%s PRIVMSG %s :hello" CRLF, user->name, user->username, user->host, user->name);
+	is_client_sendq(expected, user, MSG);
+
+	ClearClientCap(user, CLICAP_ECHO_MESSAGE);
+
+	/* without echo-message we expect a labeled ACK instead, still after the delivered message */
+	client_util_parse(user, "@label=foo PRIVMSG " TEST_NICK " :hello");
+	snprintf(expected, sizeof(expected), ":%s!%s@%s PRIVMSG %s :hello" CRLF, user->name, user->username, user->host, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@label=foo :%s ACK" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+
+	client_util_parse(user, "@label=foo PRIVMSG #notachannel :hello");
+	snprintf(expected, sizeof(expected), "@label=foo :%s 401 %s #notachannel :No such nick/channel" CRLF, me.name, user->name);
+	is_client_sendq(expected, user, MSG);
+
+	/* other (non-PRIVMSG) commands that return single-line responses */
+	client_util_parse(user, "@label=foo USERHOST " TEST_NICK);
+	snprintf(expected, sizeof(expected), "@label=foo :%s 302 %s :%s=+%s@%s " CRLF, me.name, user->name, user->name, user->username, user->sockhost);
+	is_client_sendq(expected, user, MSG);
+
+	client_util_parse(user, "@label=foo TOPIC " TEST_CHANNEL);
+	snprintf(expected, sizeof(expected), "@label=foo :%s 331 %s %s :No topic is set." CRLF, me.name, user->name, channel->chname);
+	is_client_sendq(expected, user, MSG);
+
+	standard_free();
+}
+
+static void single_response__multi_client(void)
+{
+	char expected[BUFSIZE];
+	rb_dictionary *dict = rb_dictionary_get_for_tests("remote labeled responses");
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+	SetClientCap(local_chan_p, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+	SetClientCap(local_chan_v, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+	/* remote WHOIS has a server-wide rate limit; ensure we don't trip it */
+	make_local_person_admin(local_chan_p);
+	make_local_person_admin(local_chan_v);
+
+	client_util_parse(local_chan_p, "@label=foo WHOIS RChanOp RChanOp");
+	client_util_parse(local_chan_v, "@label=foo WHOIS RChanOp RChanOp");
+	is_int(1, rb_dlink_list_length(&local_chan_p->localClient->pending_remote_responses), MSG);
+	is_int(1, rb_dlink_list_length(&local_chan_v->localClient->pending_remote_responses), MSG);
+	is_int(2, rb_dictionary_size(dict), MSG);
+
+	client_util_parse(user, "@label=foo PRIVMSG #notachannel :hello");
+	snprintf(expected, sizeof(expected), "@label=foo :%s 401 %s #notachannel :No such nick/channel" CRLF, me.name, user->name);
+	is_client_sendq(expected, user, MSG);
+
+	is_int(1, rb_dlink_list_length(&local_chan_p->localClient->pending_remote_responses), MSG);
+	is_int(1, rb_dlink_list_length(&local_chan_v->localClient->pending_remote_responses), MSG);
+	is_int(2, rb_dictionary_size(dict), MSG);
+
+	standard_free();
+}
+
+static void multi_response(void)
+{
+	char expected[BUFSIZE];
+	char *line;
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+
+	client_util_parse(user, "@label=foo CAP LIST");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s CAP %s LIST :batch labeled-response" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+
+	client_util_parse(user, "@label=foo LIST >0");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch2);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 321 %s Channel :Users  Name" CRLF, batch2, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 322 %s #test 9 :" CRLF, batch2, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 322 %s &test 4 :" CRLF, batch2, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 323 %s :End of /LIST" CRLF, batch2, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch2);
+	is_client_sendq(expected, user, MSG);
+
+	client_util_parse(user, "@label=foo WHOIS " TEST_REMOTE_NICK);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch3);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s ", batch3);
+	while (*(line = get_client_sendq(user)) != '\0')
+	{
+		if (*line == '@')
+		{
+			*(line + strlen(expected)) = '\0';
+			is_string(expected, line, MSG);
+		}
+		else
+			break;
+	}
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch3);
+	is_string(expected, line, MSG);
+	is_client_sendq_empty(user, MSG);
+
+	client_util_parse(user, "@label=foo JOIN " TEST_CHANNEL);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch4);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s ", batch4);
+	while (*(line = get_client_sendq(user)) != '\0')
+	{
+		if (*line == '@')
+		{
+			*(line + strlen(expected)) = '\0';
+			is_string(expected, line, MSG);
+		}
+		else
+			break;
+	}
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch4);
+	is_string(expected, line, MSG);
+	is_client_sendq_empty(user, MSG);
+
+	client_util_parse(user, "@label=foo WHO " TEST_CHANNEL);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch5);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s ", batch5);
+	while (*(line = get_client_sendq(user)) != '\0')
+	{
+		if (*line == '@')
+		{
+			*(line + strlen(expected)) = '\0';
+			is_string(expected, line, MSG);
+		}
+		else
+			break;
+	}
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch5);
+	is_string(expected, line, MSG);
+	is_client_sendq_empty(user, MSG);
+
+	standard_free();
+}
+
+static void remote_response__hunted_server(void)
+{
+	char expected[BUFSIZE];
+	rb_dictionary *dict = rb_dictionary_get_for_tests("remote labeled responses");
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+
+	client_util_parse(user, "@label=foo TIME " TEST_SERVER_NAME);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,%s,%s :%s TIME :" TEST_SERVER_ID CRLF,
+		user->id, batch1, server->name, user->id);
+	is_client_sendq(expected, server, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	snprintf(expected, sizeof(expected),
+		"@solanum.chat/response=%s,%s,%s :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		user->id, batch1, server->name, server->id, user->id, server->name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected),
+		"@batch=%s :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		batch1, server->name, user->name, server->name);
+	is_client_sendq(expected, user, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	snprintf(expected, sizeof(expected), "@solanum.chat/response=%s,%s,%s :%s ENCAP %s ACK", user->id, batch1, server->name, server->id, me.name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	is_int(0, rb_dictionary_size(dict), MSG);
+	is_int(0, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	standard_free();
+}
+
+static void remote_response__hunted_client(void)
+{
+	char expected[BUFSIZE];
+	rb_dictionary *dict = rb_dictionary_get_for_tests("remote labeled responses");
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+
+	client_util_parse(user, "@label=foo TIME " TEST_REMOTE_NICK);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,%s,%s :%s TIME :" TEST_REMOTE_ID CRLF,
+		user->id, batch1, server->name, user->id);
+	is_client_sendq(expected, server, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+	is_int(1, ((struct ResponseInfo *)user->localClient->pending_remote_responses.head->data)->remote_response, MSG);
+
+	snprintf(expected, sizeof(expected),
+		"@solanum.chat/response=%s,%s,%s :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		user->id, batch1, server->name, server->id, user->id, server->name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected),
+		"@batch=%s :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		batch1, server->name, user->name, server->name);
+	is_client_sendq(expected, user, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	snprintf(expected, sizeof(expected), "@solanum.chat/response=%s,%s,%s :%s ENCAP %s ACK", user->id, batch1, server->name, server->id, me.name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	is_int(0, rb_dictionary_size(dict), MSG);
+	is_int(0, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	standard_free();
+}
+
+static void remote_response__mask(void)
+{
+	char expected[BUFSIZE];
+	rb_dictionary *dict = rb_dictionary_get_for_tests("remote labeled responses");
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+	make_local_person_admin(user);
+
+	client_util_parse(user, "@label=foo MODLIST foo remote*");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,%s,remote* :%s ENCAP remote* MODLIST foo" CRLF,
+		user->id, batch1, user->id);
+	is_client_sendq(expected, server, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+	is_int(3, ((struct ResponseInfo *)user->localClient->pending_remote_responses.head->data)->remote_response, MSG);
+
+	snprintf(expected, sizeof(expected), "@solanum.chat/response=%s,%s,remote* :%s ENCAP %s ACK", user->id, batch1, server->id, me.name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected), "@solanum.chat/response=%s,%s,remote* :%s ENCAP %s ACK", user->id, batch1, server2->id, me.name);
+	client_util_parse(server2, expected);
+	snprintf(expected, sizeof(expected), "@solanum.chat/response=%s,%s,remote* :%s ENCAP %s ACK", user->id, batch1, server3->id, me.name);
+	client_util_parse(server3, expected);
+
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	is_int(0, rb_dictionary_size(dict), MSG);
+	is_int(0, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	standard_free();
+}
+
+static void remote_response__timeout(void)
+{
+	char expected[BUFSIZE];
+	rb_dictionary *dict = rb_dictionary_get_for_tests("remote labeled responses");
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+
+	client_util_parse(user, "@label=foo WHOIS " TEST_REMOTE_NICK " " TEST_REMOTE_NICK);
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	is_int(1, rb_dictionary_size(dict), MSG);
+	is_int(1, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	/* backdate the expiration so the event cleans it up */
+	struct ResponseInfo *info = user->localClient->pending_remote_responses.head->data;
+	info->expires = 1;
+	rb_run_one_event_for_tests("cleanup_pending_responses");
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	is_int(0, rb_dictionary_size(dict), MSG);
+	is_int(0, rb_dlink_list_length(&user->localClient->pending_remote_responses), MSG);
+
+	/* late response doesn't carry batch tag and late ACK does nothing */
+	snprintf(expected, sizeof(expected),
+		"@solanum.chat/response=%s,%s,%s :%s 318 %s %s :End of /WHOIS list.",
+		user->id, batch1, server->name, server->id, user->name, remote->name);
+	client_util_parse(server, expected);
+	snprintf(expected, sizeof(expected), ":%s 318 %s %s :End of /WHOIS list." CRLF, server->name, user->name, remote->name);
+	is_client_sendq(expected, user, MSG);
+	snprintf(expected, sizeof(expected),
+		"@solanum.chat/response=%s,%s,%s :%s ENCAP %s ACK",
+		user->id, batch1, server->name, server->id, me.name);
+	client_util_parse(server, expected);
+	is_client_sendq_empty(user, MSG);
+
+	standard_free();
+}
+
+static void response_tag(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+
+	/* if we match the mask (3rd part of the tag), we need to send back ENCAP ACK */
+	client_util_parse(server, "@solanum.chat/response=" TEST_REMOTE_ID ",foo,* :" TEST_REMOTE_ID " TIME :" TEST_ME_ID);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,foo,* :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		remote->id, me.id, remote->id, me.name);
+	is_client_sendq_one(expected, server, MSG);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,foo,* :%s ENCAP %s ACK" CRLF,
+		remote->id, me.id, server->name);
+	is_client_sendq(expected, server, MSG);
+
+	/* no ACK if we don't match the mask */
+	client_util_parse(server, "@solanum.chat/response=" TEST_REMOTE_ID ",foo,badmask :" TEST_REMOTE_ID " TIME :" TEST_ME_ID);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,foo,badmask :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		remote->id, me.id, remote->id, me.name);
+	is_client_sendq(expected, server, MSG);
+
+	/* invalid tags don't get passed (and also have no ACK) */
+	client_util_parse(server, "@solanum.chat/response=invalid,value :" TEST_REMOTE_ID " TIME :" TEST_ME_ID);
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME " :%s 391 %s %s :Friday July 14 2017 -- 02:40:00 +00:00" CRLF,
+		me.id, remote->id, me.name);
+	is_client_sendq(expected, server, MSG);
+
+	/* we still do an ACK if we get an ENCAP not destined for us */
+	client_util_parse(server, "@solanum.chat/response=" TEST_REMOTE_ID ",foo,* :" TEST_REMOTE_ID " ENCAP badmask FOO");
+	snprintf(expected, sizeof(expected),
+		"@time=" ADVENTURE_TIME ";solanum.chat/response=%s,foo,* :%s ENCAP %s ACK" CRLF,
+		remote->id, me.id, server->name);
+	is_client_sendq(expected, server, MSG);
+
+	standard_free();
+}
+
+static void safelist_response(void)
+{
+	char expected[BUFSIZE];
+	int refills = 0;
+
+	standard_init();
+	init_large_list();
+
+	client_util_parse(user, "@label=foo LIST #safelist*,>0");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 321 %s Channel :Users  Name" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+
+	for (int i = 0; i < 100; i++)
+	{
+		snprintf(expected, sizeof(expected), "@batch=%s :%s 322 %s #safelist%02d 1 :" LONG_VALUE_200 CRLF, batch1, me.name, user->name, i);
+		is_client_sendq_one(expected, user, MSG);
+
+		if (rb_linebuf_len(&user->localClient->buf_sendq) == 0 && user->localClient->safelist_data != NULL)
+		{
+			rb_run_one_event_for_tests("safelist_iterate_clients");
+			if (rb_linebuf_len(&user->localClient->buf_sendq) == 0)
+			{
+				ok(0, "safelist_iterate_clients failed; " MSG);
+				return;
+			}
+
+			refills++;
+		}
+	}
+
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 323 %s :End of /LIST" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	ok(user->localClient->safelist_data == NULL, MSG);
+	ok(refills > 0, MSG);
+
+	standard_free();
+}
+
+static void safelist_response__exit(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	init_large_list();
+
+	client_util_parse(user, "@label=foo LIST #safelist*,>0");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+
+	/* empty the sendq to make room for more messages.
+	 * we're already testing the contents in a different test, so for this one just clear it */
+	drain_client_sendq(user);
+
+	/* verify the user still has LIST in progress */
+	ok(user->localClient->safelist_data != NULL, MSG);
+
+	/* this should trip ASAN (and probably cause a crash even on non-ASAN builds)
+	 * if the client wasn't fully cleaned up */
+	remove_local_person(user);
+	rb_run_one_event_for_tests("free_exited_clients");
+	rb_run_one_event_for_tests("safelist_iterate_clients");
+
+	user = NULL;
+	standard_free();
+}
+
+static void safelist_response__part(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	init_large_list();
+
+	client_util_parse(user, "@label=foo LIST #safelist*,>0");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+
+	/* empty the sendq to make room for more messages.
+	 * we're already testing the contents in a different test, so for this one just clear it */
+	drain_client_sendq(user);
+
+	/* verify the user still has LIST in progress */
+	ok(user->localClient->safelist_data != NULL, MSG);
+
+	/* this will destroy every #safelist* channel since user is the only member,
+	 * meaning there should be no more channels left to iterate after next event execution */
+	remove_user_from_channels(user);
+	rb_run_one_event_for_tests("safelist_iterate_clients");
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 323 %s :End of /LIST" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+
+	is_hex(0, (uintptr_t)user->localClient->safelist_data, MSG);
+
+	standard_free();
+}
+
+static void safelist_response__abort(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	init_large_list();
+
+	client_util_parse(user, "@label=foo LIST #safelist*,>0");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+
+	/* empty the sendq to make room for more messages.
+	 * we're already testing the contents in a different test, so for this one just clear it */
+	drain_client_sendq(user);
+
+	/* verify the user still has LIST in progress */
+	ok(user->localClient->safelist_data != NULL, MSG);
+
+	/* sending another list aborts the first and returns no response for the second */
+	client_util_parse(user, "@label=bar LIST >0");
+	snprintf(expected, sizeof(expected), "@batch=%s :%s NOTICE %s :/LIST aborted" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@batch=%s :%s 323 %s :End of /LIST" CRLF, batch1, me.name, user->name);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), ":%s BATCH -%s" CRLF, me.name, batch1);
+	is_client_sendq_one(expected, user, MSG);
+	snprintf(expected, sizeof(expected), "@label=bar :%s ACK" CRLF, me.name);
+	is_client_sendq(expected, user, MSG);
+
+	is_hex(0, (uintptr_t)user->localClient->safelist_data, MSG);
+
+	standard_free();
+}
+
+int main(int argc, char *argv[])
+{
+	/* we call TIME which uses localtime(), so ensure we're in UTC */
+	rb_setenv("TZ", "UTC", 1);
+	tzset();
+
+	plan_lazy();
+
+	ircd_util_init(__FILE__);
+	client_util_init();
+
+	srand(0);
+	generate_batch_id(batch1, sizeof(batch1));
+	generate_batch_id(batch2, sizeof(batch2));
+	generate_batch_id(batch3, sizeof(batch3));
+	generate_batch_id(batch4, sizeof(batch4));
+	generate_batch_id(batch5, sizeof(batch5));
+	generate_batch_id(batch6, sizeof(batch6));
+	generate_batch_id(batch7, sizeof(batch7));
+	generate_batch_id(batch8, sizeof(batch8));
+
+	single_response();
+	single_response__multi_client();
+	multi_response();
+	remote_response__hunted_server();
+	remote_response__hunted_client();
+	remote_response__mask();
+	remote_response__timeout();
+
+	response_tag();
+
+	safelist_response();
+	safelist_response__exit();
+	safelist_response__part();
+	safelist_response__abort();
+
+	client_util_free();
+	ircd_util_free();
+	return 0;
+}

--- a/tests/labeled_response1.conf
+++ b/tests/labeled_response1.conf
@@ -1,0 +1,46 @@
+serverinfo {
+	sid = "0AA";
+	name = "me.test";
+	description = "Test server";
+	network_name = "Test network";
+};
+
+connect "remote.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote2.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+connect "remote3.test" {
+	host = "::1";
+	fingerprint = "test";
+	class = "default";
+};
+
+privset "admin" {
+	privs = oper:general, oper:admin;
+};
+
+operator "admin" {
+    user = "*@*";
+    password = "test";
+    flags = ~encrypted;
+    privset = "admin";
+};
+
+class "lowq" {
+    sendq = 8 kbytes;
+};
+
+/* not used by default, fake clients normally have no attached iline
+ * needed to test async production via SAFELIST */
+auth {
+    user = "*@*";
+    class = "lowq";
+};

--- a/tests/make_test_runtime.sh
+++ b/tests/make_test_runtime.sh
@@ -20,18 +20,18 @@ ln -s $BUILDROOT/ssld/ssld $OUTPUT/bin/ssld
 cp -r $SOURCEROOT/help/opers $OUTPUT/help
 cp -r $SOURCEROOT/help/users $OUTPUT/help
 $SOURCEROOT/help/make_index.SH $SOURCEROOT/help $OUTPUT/help
-links=($(grep -Pazo '(?s)user_symlinks = \[.*?\]' $SOURCEROOT/help/meson.build | grep -Pao "(?<=')[a-z]+"))
-for link in "${links[@]}"; do
+links=$(grep -Pazo '(?s)user_symlinks = \[.*?\]' $SOURCEROOT/help/meson.build | grep -Pao "(?<=')[a-z]+")
+echo $links | tr ' ' '\n' |  while read link; do
   ln -s "$OUTPUT/help/opers/$link" "$OUTPUT/help/users/$link"
 done
 
-coremods=($(grep -Pazo '(?s)core_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')"))
-for link in "${coremods[@]}"; do
+coremods=$(grep -Pazo '(?s)core_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')")
+echo $coremods | tr ' ' '\n' | while read link; do
   ln -s "$BUILDROOT/modules/$link.so" "$OUTPUT/modules/$link.so"
 done
 
-modules=($(grep -Pazo '(?s)autoload_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')"))
-for link in "${modules[@]}"; do
+modules=$(grep -Pazo '(?s)autoload_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')")
+echo $modules | tr ' ' '\n' | while read link; do
   ln -s "$BUILDROOT/modules/$link.so" "$OUTPUT/modules/autoload/$link.so"
 done
 

--- a/tests/make_test_runtime.sh
+++ b/tests/make_test_runtime.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Generates the runtime/ dir to execute tests for meson
+# Not to be run manually!
+
+set -eu
+
+SOURCEROOT=$(realpath -s $1)
+BUILDROOT=$(realpath -s $2)
+OUTPUT=$(realpath -s $3)/runtime
+
+rm -rf $OUTPUT
+mkdir -p $OUTPUT/modules/autoload
+mkdir $OUTPUT/bin
+mkdir $OUTPUT/help
+
+ln -s $BUILDROOT/authd/authd $OUTPUT/bin/authd
+ln -s $BUILDROOT/bandb/bandb $OUTPUT/bin/bandb
+ln -s $BUILDROOT/ssld/ssld $OUTPUT/bin/ssld
+
+cp -r $SOURCEROOT/help/opers $OUTPUT/help
+cp -r $SOURCEROOT/help/users $OUTPUT/help
+$SOURCEROOT/help/make_index.SH $SOURCEROOT/help $OUTPUT/help
+links=($(grep -Pazo '(?s)user_symlinks = \[.*?\]' $SOURCEROOT/help/meson.build | grep -Pao "(?<=')[a-z]+"))
+for link in "${links[@]}"; do
+  ln -s "$OUTPUT/help/opers/$link" "$OUTPUT/help/users/$link"
+done
+
+coremods=($(grep -Pazo '(?s)core_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')"))
+for link in "${coremods[@]}"; do
+  ln -s "$BUILDROOT/modules/$link.so" "$OUTPUT/modules/$link.so"
+done
+
+modules=($(grep -Pazo '(?s)autoload_modules = \[.*?\]' $SOURCEROOT/modules/meson.build | grep -Pao "(?<=')[^']+(?=')"))
+for link in "${modules[@]}"; do
+  ln -s "$BUILDROOT/modules/$link.so" "$OUTPUT/modules/autoload/$link.so"
+done
+
+cp $SOURCEROOT/tests/*.conf $3
+echo "Hello World!" > $OUTPUT/motd

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,6 +34,7 @@ test_programs = {
   'msgbuf_parse1': 'msgbuf_parse1.c',
   'msgbuf_unparse1': 'msgbuf_unparse1.c',
   'hostmask1': 'hostmask1.c',
+  'labeled_response1': 'labeled_response1.c',
   'privilege1': 'privilege1.c',
   'rb_dictionary1': 'rb_dictionary1.c',
   'rb_snprintf_append1': 'rb_snprintf_append1.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,6 +19,14 @@ test_utils = static_library('test_utils',
   include_directories: [include_directories('..')]
 )
 
+test_runtime = custom_target('test_runtime',
+  output: ['test_runtime'],
+  install: false,
+  build_by_default: true,
+  build_always_stale: true,
+  command: [files('make_test_runtime.sh'), '@SOURCE_ROOT@', '@BUILD_ROOT@', '@OUTDIR@']
+)
+
 test_programs = {
   'chmode1': 'chmode1.c',
   'match1': 'match1.c',
@@ -46,7 +54,10 @@ foreach test_name, test_source : test_programs
     build_by_default: true
   )
 
-  test(test_name, test_exe)
+  test(test_name, test_exe,
+    protocol: 'tap',
+    depends: [test_runtime],
+    workdir: meson.current_build_dir())
 endforeach
 
 runtests = executable('runtests',

--- a/tests/sasl_abort1.c
+++ b/tests/sasl_abort1.c
@@ -56,10 +56,7 @@ static void common_sasl_test(bool aborted)
 	remote->umodes |= UMODE_SERVICE;
 
 	client_util_parse(user, "CAP LS 302" CRLF);
-	const char *line;
-	while ((line = get_client_sendq(user)) && strcmp(line, "")) {
-		printf("%s", line);
-	}
+	drain_client_sendq(user);
 
 	client_util_parse(user, "NICK " TEST_NICK CRLF);
 	client_util_parse(user, "USER " TEST_USERNAME " 0 0 :" TEST_REALNAME CRLF);
@@ -99,9 +96,7 @@ static void common_sasl_test(bool aborted)
 	}
 
 	is_client_sendq_one(":" TEST_ME_NAME " 001 " TEST_NICK " :Welcome to the Test Internet Relay Chat Network " TEST_NICK CRLF, user, MSG);
-	while ((line = get_client_sendq(user)) && strcmp(line, "")) {
-		printf("%s", line);
-	}
+	drain_client_sendq(user);
 
 	if (aborted) {
 		// Return a successful auth after auth was aborted


### PR DESCRIPTION
A new custom build target sets up the runtime dir the way the testsuite expects it so that it can run properly. Also fix the help script as it was trying to treat a file as a symlink when it wasn't which broke the new build target. Tests now also properly use the TAP protocol in the meson build file, and fix a segfault in the send1 tests that passes NULL to a function that previously assumed that NULL would not be passed.

Some additional enhancements were made to the test utility code, some of which are not currently in use by existing tests (although to fix a TAP issue in sasl_abort1 the drain function was used), but these enable better and more comprehensive tests in the future.

This PR also fixes two issues (including a crash bug) with labeled-response and adds tests for labeled-response functionality.