### PR TITLE
Clean up outgoing_response_info on parse end

### DIFF
--- a/modules/core/cap_labeled_response.c
+++ b/modules/core/cap_labeled_response.c
@@ -164,34 +164,36 @@ cap_labeled_response_process(void *data_)
 static void
 cap_labeled_response_cleanup(void *unused)
 {
-	if (outgoing_response_info != NULL)
-	{
-		/* don't try to send anything if they disconnected */
-		if (!IsAnyDead(outgoing_response_info->source_p))
-		{
-			if (MyConnect(outgoing_response_info->source_p))
-			{
-				/* send an ACK if the handlers didn't send anything */
-				if (!ResponseSent(outgoing_response_info))
-					sendto_one(outgoing_response_info->source_p, ":%s ACK", me.name);
+	if (outgoing_response_info == NULL)
+		return;
 
-				if (!EmptyString(outgoing_response_info->batch) && outgoing_response_info->remote_response == 0)
-				{
-					sendto_one(outgoing_response_info->source_p, ":%s BATCH -%s",
-						me.name, outgoing_response_info->batch);
-				}
-			}
-			else
+	/* don't try to send anything if they disconnected */
+	if (!IsAnyDead(outgoing_response_info->source_p))
+	{
+		if (MyConnect(outgoing_response_info->source_p))
+		{
+			/* send an ACK if the handlers didn't send anything */
+			if (!ResponseSent(outgoing_response_info))
+				sendto_one(outgoing_response_info->source_p, ":%s ACK", me.name);
+
+			if (!EmptyString(outgoing_response_info->batch) && outgoing_response_info->remote_response == 0)
 			{
-				/* notify remote that we're done sending responses to this command */
-				sendto_one(outgoing_response_info->source_p, ":%s ENCAP %s ACK",
-					me.id, outgoing_response_info->source_p->servptr->name);
+				sendto_one(outgoing_response_info->source_p, ":%s BATCH -%s",
+					me.name, outgoing_response_info->batch);
 			}
 		}
-
-		if (outgoing_response_info->remote_response == 0)
-			free_response_batch(outgoing_response_info, NULL);
+		else
+		{
+			/* notify remote that we're done sending responses to this command */
+			sendto_one(outgoing_response_info->source_p, ":%s ENCAP %s ACK",
+				me.id, outgoing_response_info->source_p->servptr->name);
+		}
 	}
+
+	if (outgoing_response_info->remote_response == 0)
+		free_response_batch(outgoing_response_info, NULL);
+
+	outgoing_response_info = NULL;
 }
 
 static void

--- a/tests/labeled_response1.c
+++ b/tests/labeled_response1.c
@@ -548,6 +548,23 @@ static void response_tag(void)
 	standard_free();
 }
 
+static void response_cleanup(void)
+{
+	char expected[BUFSIZE];
+
+	standard_init();
+	SetClientCap(user, CLICAP_LABELED_RESPONSE | CLICAP_BATCH);
+
+	client_util_parse(user, "@label=foo PRIVMSG " TEST_REMOTE_NICK " :hi");
+	snprintf(expected, sizeof(expected), "@label=foo :%s BATCH +%s labeled-response" CRLF, me.name, batch1);
+	is_client_sendq(expected, user, MSG);
+	/* ensure outgoing_response_info is NULL after parsing a command;
+	 * otherwise, future commands will inherit incorrect context (and possibly crash) */
+	is_hex(0, (uintptr_t)outgoing_response_info, "outgoing_response_info not cleaned up: " MSG);
+
+	standard_free();
+}
+
 static void safelist_response(void)
 {
 	char expected[BUFSIZE];
@@ -714,6 +731,7 @@ int main(int argc, char *argv[])
 	remote_response__timeout();
 
 	response_tag();
+	response_cleanup();
 
 	safelist_response();
 	safelist_response__exit();


### PR DESCRIPTION
Failing to set outgoing_response_info to NULL after finishing parsing a command means any future commands that do *not* have a label tag will incorrectly inherit that labeled response context. This can cause, among other things, crashes when sending an unlabeled remote command after a labeled remote command.

Also add a regression test for this behaviour.