### PR TITLE
Fix authd crash with dnsbl

### DIFF
--- a/authd/providers/dnsbl.c
+++ b/authd/providers/dnsbl.c
@@ -434,7 +434,10 @@ dnsbls_generic_cancel(struct auth_client *auth, const char *message)
 	rb_free(bluser);
 	set_provider_data(auth, SELF_PID, NULL);
 	set_provider_timeout_absolute(auth, SELF_PID, 0);
-	provider_done(auth, SELF_PID);
+
+	/* this may have already happened via e.g. reject_client() */
+	if (is_provider_running(auth, SELF_PID))
+		provider_done(auth, SELF_PID);
 
 	auth_client_unref(auth);
 }

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -892,14 +892,14 @@ serverhide {
 	disable_hidden = no;
 };
 
-/* These are the blacklist settings.
+/* These are the DNSBL settings.
  * You can have multiple combinations of host and rejection reasons.
  * They are used in pairs of one host/rejection reason.
  *
- * These settings should be adequate for most networks.
+ * The default settings should be adequate for most networks.
  *
- * Word to the wise: Do not use blacklists like SPEWS for blocking IRC
- * connections.
+ * It is not recommended to use DNSBL services designed for e-mail spam
+ * prevention, such as SPEWS for blocking IRC connections.
  *
  * As of charybdis 2.2, you can do some keyword substitution on the rejection
  * reason. The available keyword substitutions are:
@@ -919,21 +919,21 @@ serverhide {
  * is considered a match. If included, a comma-separated list of *quoted*
  * strings is allowed to match queries. They may be of the format "0" to "255"
  * to match the final octet (e.g. 127.0.0.1) or "127.x.y.z" to explicitly match
- * an A record. The blacklist is only applied if it matches anything in the
+ * an A record. The DNSBL match is only applied if it matches anything in the
  * list. You may freely mix full IP's and final octets.
  *
- * Consult your blacklist provider for the meaning of these parameters; they
- * are usually used to denote different ban types.
+ * Consult your DNSBL provider for the meaning of these parameters; they
+ * are usually used to denote different block reasons.
  */
-blacklist {
+dnsbl {
 	host = "rbl.efnetrbl.org";
 	type = ipv4;
 	reject_reason = "${nick}, your IP (${ip}) is listed in EFnet's RBL. For assistance, see http://efnetrbl.org/?i=${ip}";
 
 	/* Example of a blacklist that supports both IPv4 and IPv6 and using matches */
 #	host = "foobl.blacklist.invalid";
-#	matches = "4", "6", "127.0.0.10";
 #	type = ipv4, ipv6;
+#	matches = "4", "6", "127.0.0.10";
 #	reject_reason = "${nick}, your IP (${ip}) is listed in ${dnsbl-host} for some reason. In order to protect ${network-name} from abuse, we are not allowing connections listed in ${dnsbl-host} to connect";
 };
 

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -30,8 +30,6 @@
  * Do not mess with these values unless you know what you are doing!
  */
 
-#include "setup.h"
-
 /* Below are the elements for default paths. */
 typedef enum {
 	IRCD_PATH_PREFIX,

--- a/include/stdinc.h
+++ b/include/stdinc.h
@@ -24,6 +24,7 @@
 #ifndef INCLUDED_stdinc_h
 #define INCLUDED_stdinc_h 1
 
+#include "setup.h"
 #include "rb_lib.h"
 #include "ircd_defs.h"  /* Needed for some reasons here -- dwr */
 

--- a/meson.build
+++ b/meson.build
@@ -205,6 +205,13 @@ endif
 # We only support Linux, though
 conf_data.set_quoted('LT_MODULE_EXT', '.so')
 
+if get_option('b_ndebug') == 'true'
+  assertions_enabled = false
+elif get_option('b_ndebug') == 'if-release' and get_option('buildtype') == 'release'
+  assertions_enabled = false
+else
+  assertions_enabled = true
+endif
 
 c_args = []
 link_args = []
@@ -256,7 +263,7 @@ summary({
 }, section: 'Features')
 
 summary({
-  'Assertions': get_option('b_ndebug'),
+  'Assertions': assertions_enabled,
   'Profile': get_option('profile'),
   'Warnings': get_option('warning_level'),
 }, section: 'Debug Options')


### PR DESCRIPTION
If a dnsbl returned a hit, authd would reliably crash. While this still results in the client being properly rejected, it is very noisy in server notices/logs.

Also update reference.conf as it was still using the old (deprecated) block name for DNSBLs. Copy over the updated wording from ircd.conf.example.

Fixes #541 