### PR TITLE
Make change_isupport useful

### DIFF
--- a/include/supported.h
+++ b/include/supported.h
@@ -33,8 +33,14 @@
 #ifndef INCLUDED_supported_h
 #define INCLUDED_supported_h
 
+struct isupport_data
+{
+	const char *(*func)(const void *);
+	const void *param;
+};
+
 extern void add_isupport(const char *, const char *(*)(const void *), const void *);
-extern const void *change_isupport(const char *, const char *(*)(const void *), const void *);
+extern int change_isupport(const char *, const char *(*)(const void *), const void *, struct isupport_data *);
 extern void delete_isupport(const char *);
 extern void show_isupport(struct Client *);
 extern void init_isupport(void);

--- a/ircd/supported.c
+++ b/ircd/supported.c
@@ -104,12 +104,16 @@ add_isupport(const char *name, const char *(*func)(const void *), const void *pa
 	rb_dlinkAddTail(item, &item->node, &isupportlist);
 }
 
-const void *
-change_isupport(const char *name, const char *(*func)(const void *), const void *param)
+int
+change_isupport(const char *name, const char *(*func)(const void *), const void *param, struct isupport_data *old)
 {
 	rb_dlink_node *ptr;
 	struct isupportitem *item;
-	const void *oldvalue = NULL;
+
+	if (old != NULL)
+	{
+		memset(old, 0, sizeof(struct isupport_data));
+	}
 
 	RB_DLINK_FOREACH(ptr, isupportlist.head)
 	{
@@ -117,17 +121,19 @@ change_isupport(const char *name, const char *(*func)(const void *), const void 
 
 		if (!strcmp(item->name, name))
 		{
-			oldvalue = item->param;
+			if (old != NULL)
+			{
+				old->func = item->func;
+				old->param = item->param;
+			}
 
-			// item->name = name;
 			item->func = func;
 			item->param = param;
-
 			break;
 		}
 	}
 
-	return oldvalue;
+	return ptr != NULL;
 }
 
 void


### PR DESCRIPTION
The function now accepts an optional pointer argument to a new struct that contains all of the data of the previous isupport function (both callback and data), rather than only returning the previous data pointer. This in turn allows modules to both call this function to overwrite an isupport handler in modinit as well as restore the previous handler in moddeinit (something that was impossible before).

The return value was changed to int, returning 0 if the named isupport method didn't previously exist and 1 if it did exist, so the caller can judge whether this function actually accomplished anything.

There were no callers of this function due to it previously being of questionable use, so no other code needed adjustment.