### PR TITLE
Expand monitor

### DIFF
--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -43,6 +43,7 @@ module or define a new hook in a module, see `extensions/example_module.c`.
 | m_join     | channel_join                   | A user has finished joining a channel                     |
 | m_join     | channel_lowerts                | A remote server gave us a lower TS for a channel          |
 | m_kill     | can_kill                       | A local oper is about to kill a user                      |
+| m_monitor  | new_monitor                    | A user has added a new entry to their MONITOR list        |
 | m_nick     | local_nick_change              | A local user has changed nicknames                        |
 | m_nick     | remote_nick_change             | A remote user has changed nicknames                       |
 | m_quit     | client_quit                    | A user has quit from the network                          |
@@ -1069,6 +1070,24 @@ Hook data: `struct Client *`
 
 The hook data is the user being introduced. Hook functions can safely kill
 this client should the connection attempt not be allowed to proceed.
+
+### new_monitor
+
+This hook is called after a local user has added a new nickname to their
+MONITOR list.
+
+Hook data: `hook_data *`
+
+Fields:
+
+- client (`struct Client *`): The client adding the monitor entry
+- arg1 (`struct monitor *`): The monitor entry that was added
+- arg2 (`struct Client *`): The client corresponding to the new entry, or
+  `NULL` if no client matching the nickname is online
+
+The `client` has already been added to the `arg1->users` list at the time this
+hook is called. All relevant `RPL_MONONLINE` and `RPL_MONOFFLINE` messages
+have already been sent to the client for the added nickname.
 
 ### new_remote_user
 

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -26,6 +26,7 @@ void free_monitor(struct monitor *);
 void init_monitor(void);
 struct monitor *find_monitor(const char *name, int add);
 void clear_monitor(struct Client *);
+bool is_monitoring(struct Client *client_p, const char *name);
 
 void monitor_signon(struct Client *);
 void monitor_signoff(struct Client *);

--- a/include/send.h
+++ b/include/send.h
@@ -103,7 +103,15 @@ extern void sendto_match_servs(struct Client *source_p, const char *mask,
 extern void sendto_match_servs_tags(struct Client *source_p, const char *mask,
 				uint64_t cap, uint64_t negcap, size_t n_tags, const struct MsgTag tags[], const char *, ...) AFP(7, 8);
 
-extern void sendto_monitor(struct Client *, struct monitor *monptr, const char *, ...) AFP(3, 4);
+extern void sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *pattern, ...) AFP(3, 4);
+extern void sendto_monitor_with_capability(struct Client *source_p, struct monitor *monptr,
+	uint64_t caps, uint64_t negcaps, const char *pattern, ...) AFP(5, 6);
+extern void sendto_list_local_butone(struct Client *one, struct Client *source_p, rb_dlink_list *list,
+	uint64_t caps, uint64_t negcaps, bool (*filter)(struct Client *, void *), void *filter_data,
+	const char *pattern, ...) AFP(8, 9);
+extern void sendto_list_local_tags_butone(struct Client *one, struct Client *source_p, rb_dlink_list *list,
+	uint64_t caps, uint64_t negcaps, bool (*filter)(struct Client *, void *), void *filter_data,
+	size_t n_tags, const struct MsgTag tags[], const char *pattern, ...) AFP(10, 11);
 
 extern void sendto_anywhere(struct Client *, struct Client *, const char *,
 			    const char *, ...) AFP(4, 5);

--- a/ircd/monitor.c
+++ b/ircd/monitor.c
@@ -76,6 +76,16 @@ free_monitor(struct monitor *monptr)
 	rb_free(monptr);
 }
 
+bool
+is_monitoring(struct Client *client_p, const char *name)
+{
+	struct monitor *monptr = find_monitor(name, 0);
+	if (monptr == NULL)
+		return false;
+
+	return rb_dlinkFind(client_p, &monptr->users) != NULL;
+}
+
 /* monitor_signon()
  *
  * inputs	- client who has just connected

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -1456,42 +1456,91 @@ sendto_local_clients_with_capability(uint64_t cap, const char *pattern, ...)
 	msgbuf_cache_free(&msgbuf_cache);
 }
 
-/* sendto_monitor()
- *
- * inputs	- monitor nick to send to, format, va_args
- * outputs	- message to local users monitoring the given nick
- * side effects -
- */
-void
-sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *pattern, ...)
+static void
+sendto_list_internal(struct Client *one, struct Client *source_p, rb_dlink_list *list,
+	uint64_t caps, uint64_t negcaps, bool (*filter)(struct Client *, void *), void *filter_data,
+	const char *pattern, va_list *args,
+	size_t n_tags, const struct MsgTag tags[])
 {
-	va_list args;
 	struct Client *target_p;
 	rb_dlink_node *ptr;
-	rb_dlink_node *next_ptr;
 	struct MsgBuf msgbuf;
 	struct MsgBuf_cache msgbuf_cache;
 	char buf[DATALEN + 1];
-	rb_strf_t strings = { .format = pattern, .format_args = &args, .next = NULL };
+	rb_strf_t strings = { .format = pattern, .format_args = args, .next = NULL };
 
-	va_start(args, pattern);
 	rb_fsnprint(buf, sizeof(buf), &strings);
-	va_end(args);
 
-	build_msgbuf(&msgbuf, source_p, NULL, NULL, false, buf, 0, NULL);
+	build_msgbuf(&msgbuf, source_p, NULL, NULL, false, buf, n_tags, tags);
 	msgbuf_cache_init(&msgbuf_cache, &msgbuf, NULL, NULL);
 
-	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, monptr->users.head)
+	RB_DLINK_FOREACH(ptr, list->head)
 	{
 		target_p = ptr->data;
+		if (target_p == one)
+			continue;
 
-		if (IsIOError(target_p))
+		if (caps != NOCAPS && !IsClientCapable(target_p, caps))
+			continue;
+
+		if (negcaps != NOCAPS && !NotClientCapable(target_p, negcaps))
+			continue;
+
+		if (filter != NULL && !filter(target_p, filter_data))
 			continue;
 
 		send_linebuf(target_p, msgbuf_cache_get(&msgbuf_cache, CLIENT_CAP_MASK(target_p), false));
 	}
 
 	msgbuf_cache_free(&msgbuf_cache);
+}
+
+/* sendto_list_local_butone()
+ *
+ * inputs	- target to exclude, list of targets to send to, filters, format, va_args
+ * outputs	- message to local users on the list who match the filters
+ * side effects -
+ */
+void
+sendto_list_local_butone(struct Client *one, struct Client *source_p, rb_dlink_list *list,
+	uint64_t caps, uint64_t negcaps, bool (*filter)(struct Client *, void *), void *filter_data,
+	const char *pattern, ...)
+{
+	va_list args;
+	va_start(args, pattern);
+	sendto_list_internal(one, source_p, list, caps, negcaps, filter, filter_data, pattern, &args, 0, NULL);
+	va_end(args);
+}
+
+void
+sendto_list_local_tags_butone(struct Client *one, struct Client *source_p, rb_dlink_list *list,
+	uint64_t caps, uint64_t negcaps, bool (*filter)(struct Client *, void *), void *filter_data,
+	size_t n_tags, const struct MsgTag tags[],
+	const char *pattern, ...)
+{
+	va_list args;
+	va_start(args, pattern);
+	sendto_list_internal(one, source_p, list, caps, negcaps, filter, filter_data, pattern, &args, n_tags, tags);
+	va_end(args);
+}
+
+void
+sendto_monitor(struct Client *source_p, struct monitor *monptr, const char *pattern, ...)
+{
+	va_list args;
+	va_start(args, pattern);
+	sendto_list_internal(NULL, source_p, &monptr->users, NOCAPS, NOCAPS, NULL, NULL, pattern, &args, 0, NULL);
+	va_end(args);
+}
+
+void
+sendto_monitor_with_capability(struct Client *source_p, struct monitor *monptr,
+	uint64_t caps, uint64_t negcaps, const char *pattern, ...)
+{
+	va_list args;
+	va_start(args, pattern);
+	sendto_list_internal(NULL, source_p, &monptr->users, caps, negcaps, NULL, NULL, pattern, &args, 0, NULL);
+	va_end(args);
 }
 
 /* _sendto_anywhere()

--- a/modules/m_monitor.c
+++ b/modules/m_monitor.c
@@ -42,6 +42,8 @@
 
 static const char monitor_desc[] = "Provides the MONITOR facility for tracking user signon and signoff";
 
+static int h_new_monitor;
+
 static int monitor_init(void);
 static void monitor_deinit(void);
 static void m_monitor(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
@@ -52,8 +54,12 @@ struct Message monitor_msgtab = {
 };
 
 mapi_clist_av1 monitor_clist[] = { &monitor_msgtab, NULL };
+mapi_hlist_av1 monitor_hlist[] = {
+	{ "new_monitor", &h_new_monitor },
+	{ NULL, NULL }
+};
 
-DECLARE_MODULE_AV2(monitor, monitor_init, monitor_deinit, monitor_clist, NULL, NULL, NULL, NULL, monitor_desc);
+DECLARE_MODULE_AV2(monitor, monitor_init, monitor_deinit, monitor_clist, monitor_hlist, NULL, NULL, NULL, monitor_desc);
 
 static int monitor_init(void)
 {
@@ -75,6 +81,7 @@ add_monitor(struct Client *client_p, const char *nicks)
 	const char *name;
 	char *tmp;
 	char *p;
+	hook_data hdata = { client_p };
 
 	prev_head = client_p->localClient->monitor_list.head;
 	tmp = LOCAL_COPY(nicks);
@@ -160,6 +167,14 @@ add_monitor(struct Client *client_p, const char *nicks)
 				client_p->name,
 				ConfigFileEntry.max_monitor,
 				buf);
+	}
+
+	RB_DLINK_FOREACH_PREV(ptr, prev_head)
+	{
+		monptr = ptr->data;
+		hdata.arg1 = monptr;
+		hdata.arg2 = find_named_person(monptr->name);
+		call_hook(h_new_monitor, &hdata);
 	}
 }
 

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -3434,6 +3434,356 @@ static void sendto_monitor1__tags(void)
 	standard_free();
 }
 
+static void sendto_monitor_with_capability1(void)
+{
+	struct monitor *monptr;
+
+	standard_init();
+
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+
+	monptr = find_monitor(TEST_NICK, 1);
+	rb_dlinkAddAlloc(local_chan_o, &monptr->users);
+	rb_dlinkAddAlloc(monptr, &local_chan_o->localClient->monitor_list);
+	rb_dlinkAddAlloc(local_chan_v, &monptr->users);
+	rb_dlinkAddAlloc(monptr, &local_chan_v->localClient->monitor_list);
+
+	sendto_monitor_with_capability(user, monptr, CAP_MULTI_PREFIX, NOCAPS, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_o, "Monitoring, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_v, "Monitoring, no cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_monitor_with_capability(user, monptr, NOCAPS, CAP_MULTI_PREFIX, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_o, "Monitoring, has negcap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "Monitoring, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_monitor_with_capability(user, monptr, NOCAPS, NOCAPS, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_o, "Monitoring; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "Monitoring; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
+static void sendto_monitor_with_capability1__tags(void)
+{
+	struct monitor *monptr;
+
+	standard_init();
+
+	strcpy(user->user->suser, "test");
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX | CAP_ACCOUNT_TAG | CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_ACCOUNT_TAG);
+
+	monptr = find_monitor(TEST_NICK, 1);
+	rb_dlinkAddAlloc(local_chan_o, &monptr->users);
+	rb_dlinkAddAlloc(monptr, &local_chan_o->localClient->monitor_list);
+	rb_dlinkAddAlloc(local_chan_v, &monptr->users);
+	rb_dlinkAddAlloc(monptr, &local_chan_v->localClient->monitor_list);
+
+	sendto_monitor_with_capability(user, monptr, CAP_MULTI_PREFIX, NOCAPS, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "Monitoring, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_v, "Monitoring, no cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_monitor_with_capability(user, monptr, NOCAPS, CAP_MULTI_PREFIX, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_o, "Monitoring, has negcap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq("@account=test Hello World!" CRLF, local_chan_v, "Monitoring, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_monitor_with_capability(user, monptr, NOCAPS, NOCAPS, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not monitoring; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "Monitoring; " MSG);
+	is_client_sendq_empty(local_chan_ov, "Not monitoring; " MSG);
+	is_client_sendq("@account=test Hello World!" CRLF, local_chan_v, "Monitoring; " MSG);
+	is_client_sendq_empty(local_chan_p, "Not monitoring; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not monitoring; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
+static bool filter_voice(struct Client *client_p, void *chptr)
+{
+	struct membership *msptr = find_channel_membership(chptr, client_p);
+	return msptr != NULL && msptr->flags & CHFL_VOICE;
+}
+
+static void sendto_list_local_butone1(void)
+{
+	rb_dlink_list list = { NULL, NULL, 0 };
+	rb_dlink_node n1, n2, n3, n4;
+
+	standard_init();
+
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
+
+	rb_dlinkAdd(local_chan_o, &n1, &list);
+	rb_dlinkAdd(local_chan_ov, &n2, &list);
+	rb_dlinkAdd(local_chan_v, &n3, &list);
+	rb_dlinkAdd(local_chan_p, &n4, &list);
+
+	sendto_list_local_butone(NULL, user, &list, NOCAPS, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_o, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, NOCAPS, NOCAPS, filter_voice, channel, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "In list, no filter match; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list, filter match; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list, filter match; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no filter match; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(local_chan_o, user, &list, NOCAPS, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, CAP_MULTI_PREFIX, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_o, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, CAP_MULTI_PREFIX, NOCAPS, filter_voice, channel, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "In list, has cap, no filter match; " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap, filter match; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list, has cap, filter match; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap, no filter match; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, NOCAPS, CAP_MULTI_PREFIX, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "In list, has negcap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_v, "In list, has negcap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(local_chan_o, user, &list, CAP_MULTI_PREFIX, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
+static void sendto_list_local_butone1__tags(void)
+{
+	rb_dlink_list list = { NULL, NULL, 0 };
+	rb_dlink_node n1, n2, n3, n4;
+
+	standard_init();
+
+	strcpy(user->user->suser, "test");
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX | CAP_ACCOUNT_TAG | CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+
+	rb_dlinkAdd(local_chan_o, &n1, &list);
+	rb_dlinkAdd(local_chan_ov, &n2, &list);
+	rb_dlinkAdd(local_chan_v, &n3, &list);
+	rb_dlinkAdd(local_chan_p, &n4, &list);
+
+	sendto_list_local_butone(NULL, user, &list, NOCAPS, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "In list; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(local_chan_o, user, &list, NOCAPS, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, CAP_MULTI_PREFIX, NOCAPS, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_v, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_butone(NULL, user, &list, NOCAPS, CAP_MULTI_PREFIX, NULL, NULL, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "In list, has negcap; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "In list, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_v, "In list, has negcap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list, no negcap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
+static void sendto_list_local_tags_butone1(void)
+{
+	rb_dlink_list list = { NULL, NULL, 0 };
+	rb_dlink_node n1, n2, n3, n4;
+	struct MsgTag tag = { "test", "123abc", CAP_MULTI_PREFIX };
+
+	standard_init();
+
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
+
+	rb_dlinkAdd(local_chan_o, &n1, &list);
+	rb_dlinkAdd(local_chan_ov, &n2, &list);
+	rb_dlinkAdd(local_chan_v, &n3, &list);
+	rb_dlinkAdd(local_chan_p, &n4, &list);
+
+	sendto_list_local_tags_butone(NULL, user, &list, NOCAPS, NOCAPS, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_o, "In list, has cap for tag; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list, no cap for tag; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_v, "In list, has cap for tag; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list, no cap for tag; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_tags_butone(local_chan_o, user, &list, NOCAPS, NOCAPS, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list, no cap for tag; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_v, "In list, has cap for tag; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list, no cap for tag; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_tags_butone(NULL, user, &list, CAP_MULTI_PREFIX, NOCAPS, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_o, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_v, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_tags_butone(NULL, user, &list, NOCAPS, CAP_MULTI_PREFIX, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq_empty(local_chan_o, "In list, has negcap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_ov, "In list, no negcap (no cap for tag); " MSG);
+	is_client_sendq_empty(local_chan_v, "In list, has negcap; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list, no negcap (no cap for tag); " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
+static void sendto_list_local_tags_butone1__tags(void)
+{
+	rb_dlink_list list = { NULL, NULL, 0 };
+	rb_dlink_node n1, n2, n3, n4;
+	struct MsgTag tag = { "test", "123abc", CAP_MULTI_PREFIX };
+
+	standard_init();
+
+	strcpy(user->user->suser, "test");
+	SetClientCap(local_chan_o, CAP_MULTI_PREFIX | CAP_ACCOUNT_TAG | CAP_SERVER_TIME);
+	SetClientCap(local_chan_v, CAP_MULTI_PREFIX);
+	SetClientCap(local_chan_ov, CAP_SERVER_TIME);
+
+	rb_dlinkAdd(local_chan_o, &n1, &list);
+	rb_dlinkAdd(local_chan_ov, &n2, &list);
+	rb_dlinkAdd(local_chan_v, &n3, &list);
+	rb_dlinkAdd(local_chan_p, &n4, &list);
+
+	sendto_list_local_tags_butone(NULL, user, &list, NOCAPS, NOCAPS, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@test=123abc;time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "In list; " MSG);
+	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "In list; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_v, "In list; " MSG);
+	is_client_sendq("Hello World!" CRLF, local_chan_p, "In list; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	sendto_list_local_tags_butone(NULL, user, &list, CAP_MULTI_PREFIX, NOCAPS, NULL, NULL, 1, &tag, "Hello %s!", "World");
+	is_client_sendq_empty(user, "Not in list; " MSG);
+	is_client_sendq("@test=123abc;time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_ov, "In list, no cap; " MSG);
+	is_client_sendq("@test=123abc Hello World!" CRLF, local_chan_v, "In list, has cap; " MSG);
+	is_client_sendq_empty(local_chan_p, "In list, no cap; " MSG);
+	is_client_sendq_empty(local_chan_d, "Not in list; " MSG);
+	is_client_sendq_empty(server, MSG);
+	is_client_sendq_empty(server2, MSG);
+
+	standard_free();
+}
+
 static void sendto_anywhere1(void)
 {
 	standard_init();
@@ -5081,8 +5431,16 @@ int main(int argc, char *argv[])
 	sendto_match_servs1__tags();
 	sendto_local_clients_with_capability1();
 	sendto_local_clients_with_capability1__tags();
+
 	sendto_monitor1();
 	sendto_monitor1__tags();
+	sendto_monitor_with_capability1();
+	sendto_monitor_with_capability1__tags();
+	sendto_list_local_butone1();
+	sendto_list_local_butone1__tags();
+	sendto_list_local_tags_butone1();
+	sendto_list_local_tags_butone1__tags();
+
 	sendto_anywhere1();
 	sendto_anywhere1__tags();
 	sendto_anywhere_echo1();


### PR DESCRIPTION
This set of changes allows other modules to better interact with a user's MONITOR list via a new hook and is_monitoring function. Some new sendto functions were added to send to an rb_dlink_list of local clients, and sendto_monitor was refactored to use that same underlying machinery. There are no current callers of the new functions, but it will be needed for METADATA support in the future.