### PR TITLE
Hook updates

### DIFF
--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -495,25 +495,23 @@ channel is -k.
 
 ### channel_lowerts
 
-This hook is called after the server receives a join message for a remote user
-with a lower channel timestamp than what the server has for the channel. This
-hook is not called during netjoin bursts or when the remote side believes it
-has created a new channel; it is only called a join to an existing channel on
-the remote side.
+This hook is called after the server receives a `JOIN` or `SJOIN` message for
+a remote user with a lower channel timestamp than what the server has for the
+channel.
 
 Hook data: `hook_data_channel *`
 
 Fields:
 
-- client (`struct Client *`): The remote user joining the channel
+- client (`struct Client *`): For `JOIN`, the remote user joining the channel;
+  for `SJOIN`, the server issuing the `SJOIN` message
 - chptr (`struct Channel *`): The channel being joined
 - approved (`int`): Unused (always 0)
 
-At the time the hook is called, client has not yet been added to chptr as a
-member, but we have cleared all modes from the local channel. Because this
-hook is only called when we receive a JOIN from a remote server and not an
-SJOIN, it is not a reliable method of knowing that a local channel has had its
-timestamp lowered.
+At the time the hook is called, `client` has not yet been added to chptr as a
+member (for `JOIN`) or the clients specified in the user list have not yet
+been joined to the channel (for `SJOIN`), but we have cleared all modes from
+the local channel.
 
 ### client_exit
 

--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -36,6 +36,7 @@ module or define a new hook in a module, see `extensions/example_module.c`.
 | Core       | server_introduced              | A server has been introduced to the network (pre-burst)   |
 | Core       | server_eob                     | A server has finished processing a netjoin burst from us  |
 | Core       | umode_changed                  | The modes for a user have changed                         |
+| Core       | user_welcome                   | Called during the registration burst for a new local user |
 | m_info     | doing_info_conf                | Conf entries have been sent to an oper using INFO         |
 | m_invite   | can_invite                     | A local user is about to invite another user to a channel |
 | m_invite   | invite                         | A local user is about to be invited to a channel          |
@@ -1314,3 +1315,14 @@ Fields:
 
 Because any mode changes have already been applied, hook functions can check
 the current user modes or snomask for the user to determine what has changed.
+
+### user_welcome
+
+This hook is called while the registration burst for a new local user is being
+sent. It happens after sending ISUPPORT but before sending LUSERS. Some IRCv3
+specifications require sending additional registration data during precisely
+this timing.
+
+Hook data: `struct Client *`
+
+The hook data is the client that is being introduced to the network.

--- a/doc/technical/hooks.md
+++ b/doc/technical/hooks.md
@@ -781,15 +781,17 @@ target of the WHOIS will always be a local client. The hook is called after
 all regular WHOIS lines have been sent to the user, but before the
 `RPL_ENDOFWHOIS` numeric is sent to the user.
 
-Hook data: `hook_data_client *`
+Hook data: `hook_data_client_approval *`
 
 Fields:
 
 - client (`struct Client *`): The user executing WHOIS
 - target (`struct Client *`): The target of the WHOIS command
+- approved (`int`): Set to 1 if this is an operspy WHOIS, 0 otherwise
 
 Hook functions can use this hook to send additional lines to the client as a
-part of the WHOIS response.
+part of the WHOIS response. The approved field is not an output field; it is
+an indicator as to whether or not an operspy was performed.
 
 ### doing_whois_channel_visibility
 
@@ -823,15 +825,17 @@ target of the WHOIS in such a case will always be a local client. The hook is
 called after all regular WHOIS lines have been sent to the user, but before
 the `RPL_ENDOFWHOIS` numeric is sent to the user.
 
-Hook data: `hook_data_client *`
+Hook data: `hook_data_client_approval *`
 
 Fields:
 
 - client (`struct Client *`): The user executing WHOIS
 - target (`struct Client *`): The target of the WHOIS command
+- approved (`int`): Set to 1 if this is an operspy WHOIS, 0 otherwise
 
 Hook functions can use this hook to send additional lines to the client as a
-part of the WHOIS response.
+part of the WHOIS response. The approved field is not an output field; it is
+an indicator as to whether or not an operspy was performed.
 
 ### doing_whois_show_idle
 

--- a/include/hook.h
+++ b/include/hook.h
@@ -65,6 +65,7 @@ extern int h_cap_change;
 extern int h_message_tag;
 extern int h_message_handler;
 extern int h_parse_end;
+extern int h_user_welcome;
 
 void init_hook(void);
 int register_hook(const char *name);

--- a/ircd/hook.c
+++ b/ircd/hook.c
@@ -76,6 +76,7 @@ int h_cap_change;
 int h_message_tag;
 int h_message_handler;
 int h_parse_end;
+int h_user_welcome;
 
 void
 init_hook(void)
@@ -105,6 +106,7 @@ init_hook(void)
 	h_message_tag = register_hook("message_tag");
 	h_message_handler = register_hook("message_handler");
 	h_parse_end = register_hook("parse_end");
+	h_user_welcome = register_hook("user_welcome");
 }
 
 /* grow_hooktable()

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1431,7 +1431,7 @@ user_welcome(struct Client *source_p)
 	sendto_one_numeric(source_p, RPL_MYINFO, form_str(RPL_MYINFO), me.name, ircd_version, umodebuf, cflagsmyinfo);
 
 	show_isupport(source_p);
-
+	call_hook(h_user_welcome, source_p);
 	show_lusers(source_p);
 
 	if(ConfigFileEntry.short_motd)

--- a/modules/core/m_join.c
+++ b/modules/core/m_join.c
@@ -750,6 +750,12 @@ ms_sjoin(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 		/* since we're dropping our modes, we want to clear the mlock as well. --nenolod */
 		set_channel_mlock(client_p, source_p, chptr, NULL, false);
+
+		hook_data_channel hookdata;
+		hookdata.client = source_p;
+		hookdata.chptr = chptr;
+
+		call_hook(h_channel_lowerts, &hookdata);
 	}
 
 	if(*modebuf != '\0')

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -229,7 +229,7 @@ static void
 single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 {
 	char buf[BUFSIZE];
-	hook_data_client hdata;
+	hook_data_client_approval hdata;
 	struct sockaddr_in ip4;
 
 	if(target_p->user == NULL)
@@ -255,6 +255,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 
 	hdata.client = source_p;
 	hdata.target = target_p;
+	hdata.approved = operspy;
 
 	if (!IsService(target_p))
 	{


### PR DESCRIPTION
- Pass whether operspy is being performed to the doing_whois and doing_whois_global hooks.
- Add user_welcome hook to send data to the client after sending ISUPPORT but before sending LUSERS.
- Call channel_lowerts if TS is lowered from SJOIN too. There are no in-tree consumers of this hook so the functionality change is safe.