### PR TITLE
Sort channel members in alphabetical order

### DIFF
--- a/include/channel.h
+++ b/include/channel.h
@@ -266,6 +266,7 @@ extern void add_user_to_channel(struct Channel *, struct Client *, int flags);
 extern void remove_user_from_channel(struct membership *);
 extern void remove_user_from_channels(struct Client *);
 extern void invalidate_bancache_user(struct Client *);
+extern void update_channel_member_pos(struct membership *msptr);
 
 extern void free_channel_list(rb_dlink_list *);
 

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -262,7 +262,16 @@ add_user_to_channel(struct Channel *chptr, struct Client *client_p, int flags)
 	else
 		rb_dlinkAddBefore(p, msptr, &msptr->usernode, &client_p->user->channel);
 
-	rb_dlinkAdd(msptr, &msptr->channode, &chptr->members);
+	RB_DLINK_FOREACH(p, chptr->members.head)
+	{
+		struct membership *ms2 = p->data;
+		if (irccmp(client_p->name, ms2->client_p->name) < 0)
+			break;
+	}
+	if (p == NULL)
+		rb_dlinkAddTail(msptr, &msptr->channode, &chptr->members);
+	else
+		rb_dlinkAddBefore(p, msptr, &msptr->channode, &chptr->members);
 
 	if(MyClient(client_p))
 		rb_dlinkAdd(msptr, &msptr->locchannode, &chptr->locmembers);
@@ -359,6 +368,31 @@ invalidate_bancache_user(struct Client *client_p)
 		msptr->bants = 0;
 		msptr->flags &= ~CHFL_BANNED;
 	}
+}
+
+/* update_channel_member_pos()
+ *
+ * input	- membership to update position for
+ * output	-
+ * side effects - keeps channel member list alphabetical
+ */
+void
+update_channel_member_pos(struct membership *msptr)
+{
+	rb_dlink_node *ptr;
+
+	RB_DLINK_FOREACH(ptr, msptr->chptr->members.head)
+	{
+		struct membership *m2 = ptr->data;
+		if (irccmp(msptr->client_p->name, m2->client_p->name) < 0)
+			break;
+	}
+
+	rb_dlinkDelete(&msptr->channode, &msptr->chptr->members);
+	if (ptr == NULL)
+		rb_dlinkAddTail(msptr, &msptr->channode, &msptr->chptr->members);
+	else
+		rb_dlinkAddBefore(ptr, msptr, &msptr->channode, &msptr->chptr->members);
 }
 
 /* check_channel_name()

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -826,12 +826,11 @@ resv_nick_fnc(const char *mask, const char *reason, int temp_time)
 			add_to_client_hash(nick, client_p);
 
 			monitor_signon(client_p);
+			del_all_accepts(client_p, false);
 
-			RB_DLINK_FOREACH_SAFE(ptr, next_ptr, client_p->on_allow_list.head)
+			RB_DLINK_FOREACH(ptr, client_p->user->channel.head)
 			{
-				target_p = ptr->data;
-				rb_dlinkFindDestroy(client_p, &target_p->localClient->allow_list);
-				rb_dlinkDestroy(ptr, &client_p->on_allow_list);
+				update_channel_member_pos(ptr->data);
 			}
 
 			snprintf(note, sizeof(note), "Nick: %s", nick);

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1707,6 +1707,12 @@ change_nick_user_host(struct Client *target_p,	const char *nick, const char *use
 	{
 		monitor_signon(target_p);
 		del_all_accepts(target_p, false);
+
+		/* Update channel positions */
+		RB_DLINK_FOREACH(ptr, target_p->user->channel.head)
+		{
+			update_channel_member_pos(ptr->data);
+		}
 	}
 }
 

--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -623,6 +623,7 @@ change_local_nick(struct Client *client_p, struct Client *source_p,
 	char note[NICKLEN + 10];
 	int samenick;
 	hook_cdata hook_info;
+	rb_dlink_node *ptr;
 
 	if (dosend)
 	{
@@ -704,10 +705,14 @@ change_local_nick(struct Client *client_p, struct Client *source_p,
 	 */
 	del_all_accepts(source_p, false);
 
+	/* Update channel positions */
+	RB_DLINK_FOREACH(ptr, source_p->user->channel.head)
+	{
+		update_channel_member_pos(ptr->data);
+	}
+
 	snprintf(note, sizeof(note), "Nick: %s", nick);
 	rb_note(client_p->localClient->F, note);
-
-	return;
 }
 
 /*
@@ -761,15 +766,12 @@ change_remote_nick(struct Client *client_p, struct Client *source_p,
 		monitor_signon(source_p);
 
 	/* remove all accepts pointing to the client */
-	RB_DLINK_FOREACH_SAFE(ptr, next_ptr, source_p->on_allow_list.head)
-	{
-		target_p = ptr->data;
+	del_all_accepts(source_p, false);
 
-		if (!has_common_channel(source_p, target_p))
-		{
-			rb_dlinkFindDestroy(source_p, &target_p->localClient->allow_list);
-			rb_dlinkDestroy(ptr, &source_p->on_allow_list);
-		}
+	/* Update channel positions */
+	RB_DLINK_FOREACH(ptr, source_p->user->channel.head)
+	{
+		update_channel_member_pos(ptr->data);
 	}
 }
 

--- a/modules/m_services.c
+++ b/modules/m_services.c
@@ -194,6 +194,7 @@ me_rsfnc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	time_t newts, curts;
 	struct nd_entry *nd;
 	char note[NAMELEN + 10];
+	rb_dlink_node *ptr;
 
 	if(!(source_p->flags & FLAGS_SERVICE))
 	{
@@ -299,6 +300,12 @@ doit:
 	 * loses that reference.
 	 */
 	del_all_accepts(target_p, false);
+
+	/* Update channel positions */
+	RB_DLINK_FOREACH(ptr, target_p->user->channel.head)
+	{
+		update_channel_member_pos(ptr->data);
+	}
 
 	snprintf(note, sizeof(note), "Nick: %s", target_p->name);
 	rb_note(target_p->localClient->F, note);


### PR DESCRIPTION
Previously, the ordering of members in a channel was based on the reverse ordering in which they joined (i.e. most recent first). While this worked just fine, the lack of a consistent ordering means that things like NAMES and WHO output are arbitrary and (more importantly) that it was impossible to implement asynchronous METADATA listings.

A user updating their nickname or a server forcing a nickchange will re-sort the user's position in the channel list to ensure the ordering remains alphabetical.

As part of this, a handful of cases that duplicated the code to clear a user's accept list were replaced by the helper function that did the same.