### PR TITLE
Add optional fallback for +reply tag

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -1543,6 +1543,17 @@ general {
 	 * Requires extensions/filter to be loaded.
 	 */
 	#filter_exit_message = "Connection closed";
+
+	/* reply_enable_fallback: Whether we accept incoming +draft/reply tags and synthesize outgoing +draft/reply tags.
+	 * Requires extensions/tag_reply to be loaded.
+	 */
+	#reply_enable_fallback = no;
+
+	/* reply_advertise_fallback: Advertise draft/reply being allowed in CLIENTTAGDENY.
+	 * Has no effect if reply_enable_fallback = no.
+	 * Requires extensions/tag_reply to be loaded.
+	 */
+	#reply_advertise_fallback = no;
 };
 
 /* The quarantine block is only used if you have the m_quarantine extension loaded;

--- a/extensions/tag_reply.c
+++ b/extensions/tag_reply.c
@@ -32,6 +32,7 @@
 #include "numeric.h"
 #include "chmode.h"
 #include "hash.h"
+#include "newconf.h"
 #include "parse.h"
 #include "inline/stringops.h"
 
@@ -46,10 +47,24 @@
 #define MSGID_LEN_MIN (19 + IDLEN)
 
 static const char tag_reply_desc[] = "Provides support for the +reply client tag.";
+static void conf_set_reply_advertise_fallback(void *);
+static void conf_set_reply_enable_fallback(void *);
 static void tag_reply_allow(void *);
+static void tag_reply_apply_conf(void *);
+static void tag_reply_conf_info(void *);
+static void tag_reply_fallback(void *);
+static void tag_reply_reset_conf(void *);
+
+/* Require network opt-in for all fallback behaviour */
+int enable_fallback = 0;
+int advertise_fallback = 0;
 
 mapi_hfn_list_av1 tag_reply_hfnlist[] = {
+	{ "conf_read_end", tag_reply_apply_conf },
+	{ "conf_read_start", tag_reply_reset_conf },
+	{ "doing_info_conf", tag_reply_conf_info },
 	{ "message_tag", tag_reply_allow },
+	{ "outbound_msgbuf", tag_reply_fallback },
 	{ NULL, NULL }
 };
 
@@ -57,6 +72,8 @@ static int
 modinit(void)
 {
 	add_client_tag("reply");
+	add_conf_item("general", "reply_enable_fallback", CF_YESNO, conf_set_reply_enable_fallback);
+	add_conf_item("general", "reply_advertise_fallback", CF_YESNO, conf_set_reply_advertise_fallback);
 	return 0;
 }
 
@@ -64,6 +81,21 @@ static void
 moddeinit(void)
 {
 	remove_client_tag("reply");
+	remove_client_tag("draft/reply");
+	remove_conf_item("general", "reply_enable_fallback");
+	remove_conf_item("general", "reply_advertise_fallback");
+}
+
+static void
+conf_set_reply_advertise_fallback(void *data)
+{
+	advertise_fallback = *(int *)data;
+}
+
+static void
+conf_set_reply_enable_fallback(void *data)
+{
+	enable_fallback = *(int *)data;
 }
 
 static void
@@ -71,6 +103,10 @@ tag_reply_allow(void *data_)
 {
 	hook_data_message_tag *data = data_;
 	const char *target = data->message->para[1];
+
+	/* fallback: rewrite +draft/reply into +reply as long as both don't exist */
+	if (enable_fallback && !strcmp("+draft/reply", data->key) && msgbuf_get_tag(data->message, "+reply") == NULL)
+		data->key = "+reply";
 
 	if (strcmp("+reply", data->key) != 0 || EmptyString(data->value))
 		return;
@@ -138,6 +174,55 @@ tag_reply_allow(void *data_)
 
 	data->capmask = CLICAP_MESSAGE_TAGS;
 	data->approved = MESSAGE_TAG_ALLOW;
+}
+
+static void
+tag_reply_apply_conf(void *unused)
+{
+	if (enable_fallback && advertise_fallback)
+		add_client_tag("draft/reply");
+	else
+		remove_client_tag("draft/reply");
+}
+
+static void
+tag_reply_reset_conf(void *unused)
+{
+	enable_fallback = 0;
+	advertise_fallback = 0;
+}
+
+static void
+tag_reply_conf_info(void *data_)
+{
+	hook_data *data = data_;
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"reply_enable_fallback",
+		enable_fallback ? "YES" : "NO",
+		"Enable +draft/reply fallback support for +reply");
+
+	/* Everything after this point requires that fallback is enabled */
+	if (!enable_fallback)
+		return;
+
+	sendto_one(data->client, ":%s %d %s :%-30s %-16s [%s]",
+		get_id(&me, data->client), RPL_INFO,
+		get_id(data->client, data->client),
+		"reply_advertise_fallback",
+		advertise_fallback ? "YES" : "NO",
+		"Advertise +draft/reply in CLIENTTAGDENY");
+}
+
+static void
+tag_reply_fallback(void *data_)
+{
+	hook_data_outbound_msgbuf *data = data_;
+	const char *reply = msgbuf_get_tag(data->msgbuf, "+reply");
+
+	if (enable_fallback && reply != NULL && msgbuf_get_tag(data->msgbuf, "+draft/reply") == NULL)
+		msgbuf_append_tag(data->msgbuf, "+draft/reply", reply, CLICAP_MESSAGE_TAGS);
 }
 
 DECLARE_MODULE_AV2(tag_reply, modinit, moddeinit, NULL, NULL, tag_reply_hfnlist, NULL, NULL, tag_reply_desc);


### PR DESCRIPTION
If enabled, we accept incoming +draft/reply tags in addition to +reply (if both are specified, then we read +reply and ignore +draft/reply). Additionally, if either +reply or +draft/reply were given to us, we will provide both +reply and +draft/reply in the outgoing message, with the same value. This fallback is disabled by default but can be enabled via a new ircd.conf option.

A second configuration option (also disabled by default) advertises draft/reply as allowed in CLIENTTAGDENY. The tag's presence in CLIENTTAGDENY bears no impact on whether it is accepted by the software, and networks may wish to keep it off the list in case it is already very long or if they want to encourage clients to upgrade to the non-draft spec.