### PR TITLE
Fix tag_channel_context

### DIFF
--- a/extensions/tag_channel_context.c
+++ b/extensions/tag_channel_context.c
@@ -54,6 +54,9 @@ tag_ccon_allow(void *data_)
 {
 	hook_data_message_tag *data = data_;
 
+	if (strcmp(data->key, "+channel-context") != 0)
+		return;
+
 	if (MyClient(data->source))
 	{
 		if (NotClientCapable(data->source, CLICAP_MESSAGE_TAGS))


### PR DESCRIPTION
Only process incoming tags if they're +channel-context